### PR TITLE
Add headless versions of new auth components

### DIFF
--- a/src/ui/headless/auth/AccountLockout.tsx
+++ b/src/ui/headless/auth/AccountLockout.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+export interface AccountLockoutProps {
+  message?: string;
+  render: (props: { message: string }) => React.ReactNode;
+}
+
+export function AccountLockout({ message = 'Your account has been temporarily locked due to too many failed login attempts. Please try again later or contact support.', render }: AccountLockoutProps) {
+  return <>{render({ message })}</>;
+}

--- a/src/ui/headless/auth/EmailVerification.tsx
+++ b/src/ui/headless/auth/EmailVerification.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState } from 'react';
+import { useAuthStore } from '@/lib/stores/auth.store';
+
+export interface EmailVerificationProps {
+  render: (props: {
+    token: string;
+    setToken: (value: string) => void;
+    email: string;
+    setEmail: (value: string) => void;
+    isLoading: boolean;
+    error: string | null;
+    successMessage: string | null;
+    handleVerify: (e: React.FormEvent) => void;
+    handleResend: (e: React.FormEvent) => void;
+  }) => React.ReactNode;
+}
+
+export function EmailVerification({ render }: EmailVerificationProps) {
+  const verifyEmail = useAuthStore(state => state.verifyEmail);
+  const sendVerificationEmail = useAuthStore(state => state.sendVerificationEmail);
+  const isLoading = useAuthStore(state => state.isLoading);
+  const error = useAuthStore(state => state.error);
+  const successMessage = useAuthStore(state => state.successMessage);
+  const clearError = useAuthStore(state => state.clearError);
+  const clearSuccess = useAuthStore(state => state.clearSuccessMessage);
+
+  const [token, setToken] = useState('');
+  const [email, setEmail] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleVerify = async (e: React.FormEvent) => {
+    e.preventDefault();
+    clearError();
+    clearSuccess();
+    setSubmitted(false);
+    try {
+      await verifyEmail(token);
+      setSubmitted(true);
+    } catch {
+      setSubmitted(true);
+    }
+  };
+
+  const handleResend = async (e: React.FormEvent) => {
+    e.preventDefault();
+    clearError();
+    clearSuccess();
+    setSubmitted(false);
+    try {
+      await sendVerificationEmail(email);
+      setSubmitted(true);
+    } catch {
+      setSubmitted(true);
+    }
+  };
+
+  return (
+    <>{render({ token, setToken, email, setEmail, isLoading: isLoading || false, error: submitted ? error : null, successMessage: submitted ? successMessage : null, handleVerify, handleResend })}</>
+  );
+}

--- a/src/ui/headless/auth/PasswordlessLogin.tsx
+++ b/src/ui/headless/auth/PasswordlessLogin.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useState } from 'react';
+import { api } from '@/lib/api/axios';
+
+export interface PasswordlessLoginProps {
+  render: (props: {
+    email: string;
+    setEmail: (value: string) => void;
+    status: 'idle' | 'success' | 'error';
+    error: string | null;
+    isLoading: boolean;
+    handleSendLink: (e: React.FormEvent) => void;
+  }) => React.ReactNode;
+}
+
+export function PasswordlessLogin({ render }: PasswordlessLoginProps) {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSendLink = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError(null);
+    setStatus('idle');
+    try {
+      await api.post('/api/auth/passwordless', { email });
+      setStatus('success');
+    } catch (err: any) {
+      setError(err.response?.data?.error || 'Failed to send magic link');
+      setStatus('error');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>{render({ email, setEmail, status, error, isLoading, handleSendLink })}</>
+  );
+}

--- a/src/ui/headless/auth/RememberMeToggle.tsx
+++ b/src/ui/headless/auth/RememberMeToggle.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useState } from 'react';
+
+export interface RememberMeToggleProps {
+  initialChecked?: boolean;
+  render: (props: { checked: boolean; setChecked: (val: boolean) => void }) => React.ReactNode;
+}
+
+export function RememberMeToggle({ initialChecked = false, render }: RememberMeToggleProps) {
+  const [checked, setChecked] = useState(initialChecked);
+  return <>{render({ checked, setChecked })}</>;
+}

--- a/src/ui/headless/auth/SocialLoginCallbacks.tsx
+++ b/src/ui/headless/auth/SocialLoginCallbacks.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+export interface SocialLoginCallbacksProps {
+  render: () => React.ReactNode;
+}
+
+export function SocialLoginCallbacks({ render }: SocialLoginCallbacksProps) {
+  return <>{render()}</>;
+}

--- a/src/ui/headless/gdpr/ConsentManagement.tsx
+++ b/src/ui/headless/gdpr/ConsentManagement.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { usePreferencesStore } from '@/lib/stores/preferences.store';
+
+export interface ConsentManagementProps {
+  render: (props: {
+    marketing: boolean;
+    setMarketing: (val: boolean) => void;
+    isLoading: boolean;
+    error: string | null;
+    submitted: boolean;
+    handleSave: () => Promise<void>;
+  }) => React.ReactNode;
+}
+
+export function ConsentManagement({ render }: ConsentManagementProps) {
+  const { preferences, fetchPreferences, updatePreferences, isLoading, error } = usePreferencesStore();
+  const [marketing, setMarketing] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    if (!preferences) fetchPreferences();
+  }, [preferences, fetchPreferences]);
+
+  useEffect(() => {
+    if (preferences) {
+      setMarketing(!!preferences.notifications?.marketing);
+    }
+  }, [preferences]);
+
+  const handleSave = async () => {
+    setSubmitted(false);
+    await updatePreferences({
+      notifications: {
+        ...preferences?.notifications,
+        marketing,
+      },
+    });
+    setSubmitted(true);
+  };
+
+  return (
+    <>{render({ marketing, setMarketing, isLoading, error, submitted, handleSave })}</>
+  );
+}

--- a/src/ui/headless/session/SessionTimeout.tsx
+++ b/src/ui/headless/session/SessionTimeout.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useAuthStore } from '@/lib/stores/auth.store';
+
+export interface SessionTimeoutProps {
+  isOpen: boolean;
+  onClose: () => void;
+  render: (props: { handleLogout: () => void; isOpen: boolean; onClose: () => void }) => React.ReactNode;
+}
+
+export function SessionTimeout({ isOpen, onClose, render }: SessionTimeoutProps) {
+  const logout = useAuthStore(state => state.logout);
+
+  const handleLogout = () => {
+    logout();
+    onClose();
+  };
+
+  return <>{render({ handleLogout, isOpen, onClose })}</>;
+}

--- a/src/ui/styled/auth/AccountLockout.tsx
+++ b/src/ui/styled/auth/AccountLockout.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
+
+export function AccountLockout() {
+  return (
+    <Alert variant="destructive" role="alert">
+      <AlertTitle>Account Locked</AlertTitle>
+      <AlertDescription>
+        Your account has been temporarily locked due to too many failed login attempts. Please try again later or contact support.
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/src/ui/styled/auth/EmailVerification.tsx
+++ b/src/ui/styled/auth/EmailVerification.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useAuthStore } from '@/lib/stores/auth.store';
+
+export function EmailVerification() {
+  const verifyEmail = useAuthStore(state => state.verifyEmail);
+  const sendVerificationEmail = useAuthStore(state => state.sendVerificationEmail);
+  const isLoading = useAuthStore(state => state.isLoading);
+  const error = useAuthStore(state => state.error);
+  const successMessage = useAuthStore(state => state.successMessage);
+  const clearError = useAuthStore(state => state.clearError);
+  const clearSuccess = useAuthStore(state => state.clearSuccessMessage);
+
+  const [token, setToken] = useState('');
+  const [email, setEmail] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleVerify = async (e: React.FormEvent) => {
+    e.preventDefault();
+    clearError();
+    clearSuccess();
+    setSubmitted(false);
+    try {
+      await verifyEmail(token);
+      setSubmitted(true);
+    } catch (err) {
+      setSubmitted(true);
+    }
+  };
+
+  const handleResend = async (e: React.FormEvent) => {
+    e.preventDefault();
+    clearError();
+    clearSuccess();
+    setSubmitted(false);
+    try {
+      await sendVerificationEmail(email);
+      setSubmitted(true);
+    } catch (err) {
+      setSubmitted(true);
+    }
+  };
+
+  return (
+    <div className="space-y-6 w-full max-w-md mx-auto">
+      {submitted && error && (
+        <Alert variant="destructive" role="alert">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      {submitted && successMessage && !error && (
+        <Alert>
+          <AlertDescription>{successMessage}</AlertDescription>
+        </Alert>
+      )}
+
+      <form onSubmit={handleVerify} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="token">Verification Token</Label>
+          <Input
+            id="token"
+            value={token}
+            onChange={e => setToken(e.target.value)}
+            disabled={isLoading}
+          />
+        </div>
+        <Button type="submit" disabled={isLoading} className="w-full">
+          Verify Email
+        </Button>
+      </form>
+
+      <form onSubmit={handleResend} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            disabled={isLoading}
+          />
+        </div>
+        <Button type="submit" variant="outline" disabled={isLoading} className="w-full">
+          Resend Verification Email
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/src/ui/styled/auth/PasswordlessLogin.tsx
+++ b/src/ui/styled/auth/PasswordlessLogin.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { api } from '@/lib/api/axios';
+
+export function PasswordlessLogin() {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSendLink = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError(null);
+    setStatus('idle');
+    try {
+      await api.post('/api/auth/passwordless', { email });
+      setStatus('success');
+    } catch (err: any) {
+      setError(err.response?.data?.error || 'Failed to send magic link');
+      setStatus('error');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4 w-full max-w-md mx-auto">
+      {status === 'success' && (
+        <Alert>
+          <AlertDescription>
+            A login link has been sent to your email if an account exists.
+          </AlertDescription>
+        </Alert>
+      )}
+      {status === 'error' && error && (
+        <Alert variant="destructive" role="alert">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      <form onSubmit={handleSendLink} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="email-ml">Email</Label>
+          <Input
+            id="email-ml"
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            disabled={isLoading}
+          />
+        </div>
+        <Button type="submit" disabled={isLoading} className="w-full">
+          {isLoading ? 'Sending...' : 'Send Magic Link'}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/src/ui/styled/auth/RememberMeToggle.tsx
+++ b/src/ui/styled/auth/RememberMeToggle.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+
+interface RememberMeToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export function RememberMeToggle({ checked, onChange }: RememberMeToggleProps) {
+  return (
+    <div className="flex items-center space-x-2">
+      <Checkbox
+        id="remember-me"
+        checked={checked}
+        onCheckedChange={value => onChange(value === true)}
+      />
+      <Label htmlFor="remember-me">Remember me</Label>
+    </div>
+  );
+}

--- a/src/ui/styled/auth/SocialLoginCallbacks.tsx
+++ b/src/ui/styled/auth/SocialLoginCallbacks.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { OAuthCallback } from './OAuthCallback';
+
+export function SocialLoginCallbacks() {
+  return <OAuthCallback />;
+}

--- a/src/ui/styled/gdpr/ConsentManagement.tsx
+++ b/src/ui/styled/gdpr/ConsentManagement.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { usePreferencesStore } from '@/lib/stores/preferences.store';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+export function ConsentManagement() {
+  const { preferences, fetchPreferences, updatePreferences, isLoading, error } = usePreferencesStore();
+  const [marketing, setMarketing] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    if (!preferences) fetchPreferences();
+  }, [preferences, fetchPreferences]);
+
+  useEffect(() => {
+    if (preferences) {
+      setMarketing(!!preferences.notifications?.marketing);
+    }
+  }, [preferences]);
+
+  const handleSave = async () => {
+    setSubmitted(false);
+    await updatePreferences({
+      notifications: {
+        ...preferences?.notifications,
+        marketing,
+      },
+    });
+    setSubmitted(true);
+  };
+
+  return (
+    <div className="space-y-4 w-full max-w-md mx-auto">
+      {submitted && error && (
+        <Alert variant="destructive" role="alert">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      {submitted && !error && (
+        <Alert>
+          <AlertDescription>Preferences updated</AlertDescription>
+        </Alert>
+      )}
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="marketing-consent"
+          checked={marketing}
+          onCheckedChange={val => setMarketing(val === true)}
+        />
+        <Label htmlFor="marketing-consent">Allow marketing emails</Label>
+      </div>
+      <Button onClick={handleSave} disabled={isLoading}>Save</Button>
+    </div>
+  );
+}

--- a/src/ui/styled/session/SessionTimeout.tsx
+++ b/src/ui/styled/session/SessionTimeout.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useAuthStore } from '@/lib/stores/auth.store';
+
+interface SessionTimeoutProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function SessionTimeout({ isOpen, onClose }: SessionTimeoutProps) {
+  const logout = useAuthStore(state => state.logout);
+
+  const handleLogout = () => {
+    logout();
+    onClose();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Session Expired</DialogTitle>
+        </DialogHeader>
+        <p className="py-4">Your session has expired due to inactivity. Please log in again.</p>
+        <DialogFooter>
+          <Button onClick={handleLogout}>Log In Again</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- move recently added auth/session/GDPR components to `src/ui/styled`
- implement headless counterparts under `src/ui/headless`
- keep styled implementations referencing the auth store

## Testing
- `npm test` *(fails: vitest not found)*