### PR TITLE
Add headless payment components

### DIFF
--- a/src/ui/headless/payment/InvoiceGenerator.tsx
+++ b/src/ui/headless/payment/InvoiceGenerator.tsx
@@ -1,0 +1,64 @@
+import { ReactNode, useState } from 'react';
+import { api } from '@/lib/api/axios';
+
+export interface Invoice {
+  id: string;
+  number: string;
+  date: string;
+  amount: number;
+  status: 'paid' | 'pending' | 'overdue';
+}
+
+export interface InvoiceGeneratorProps {
+  /**
+   * Render prop with invoice data and actions
+   */
+  render: (props: {
+    invoices: Invoice[];
+    isLoading: boolean;
+    error: string | null;
+    generateInvoice: () => Promise<void>;
+    downloadInvoice: (id: string) => Promise<void>;
+  }) => ReactNode;
+}
+
+/**
+ * Headless InvoiceGenerator component
+ */
+export function InvoiceGenerator({ render }: InvoiceGeneratorProps) {
+  const [invoices, setInvoices] = useState<Invoice[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const generateInvoice = async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const response = await api.post('/invoices/generate');
+      setInvoices((prev) => [...prev, response.data]);
+    } catch (err) {
+      setError('Failed to generate invoice');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const downloadInvoice = async (id: string) => {
+    try {
+      const response = await api.get(`/invoices/${id}/download`, { responseType: 'blob' });
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', `invoice-${id}.pdf`);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } catch (err) {
+      setError('Failed to download invoice');
+    }
+  };
+
+  return (
+    <>{render({ invoices, isLoading, error, generateInvoice, downloadInvoice })}</>
+  );
+}

--- a/src/ui/headless/payment/PaymentForm.tsx
+++ b/src/ui/headless/payment/PaymentForm.tsx
@@ -1,0 +1,71 @@
+import { ReactNode, useState } from 'react';
+import { useForm, FieldErrors } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+
+/**
+ * Schema for payment form validation
+ */
+const paymentSchema = z.object({
+  cardNumber: z.string().min(16).max(16),
+  expiryDate: z.string().regex(/^(0[1-9]|1[0-2])\/([0-9]{2})$/),
+  cvv: z.string().min(3).max(4),
+});
+
+export type PaymentFormData = z.infer<typeof paymentSchema>;
+
+export interface PaymentFormProps {
+  /**
+   * Optional submit handler. If not provided, the form simply resolves.
+   */
+  onSubmit?: (data: PaymentFormData) => Promise<void>;
+
+  /**
+   * Optional external loading state
+   */
+  isLoading?: boolean;
+
+  /**
+   * Optional external error message
+   */
+  error?: string | null;
+
+  /**
+   * Render prop that receives form state and handlers
+   */
+  render: (props: {
+    register: ReturnType<typeof useForm<PaymentFormData>>['register'];
+    handleSubmit: (e: React.FormEvent) => void;
+    errors: FieldErrors<PaymentFormData>;
+    isSubmitting: boolean;
+    error?: string | null;
+  }) => ReactNode;
+}
+
+/**
+ * Headless Payment Form component providing form state via render props
+ */
+export function PaymentForm({ onSubmit, isLoading: externalIsLoading, error: externalError, render }: PaymentFormProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const {
+    register,
+    handleSubmit: rhfHandleSubmit,
+    formState: { errors },
+  } = useForm<PaymentFormData>({ resolver: zodResolver(paymentSchema) });
+
+  const isLoading = externalIsLoading !== undefined ? externalIsLoading : isSubmitting;
+  const formError = externalError ?? null;
+
+  const handleSubmit = rhfHandleSubmit(async (data) => {
+    setIsSubmitting(true);
+    try {
+      if (onSubmit) {
+        await onSubmit(data);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  });
+
+  return <>{render({ register, handleSubmit, errors, isSubmitting: isLoading, error: formError })}</>;
+}

--- a/src/ui/headless/payment/PaymentHistory.tsx
+++ b/src/ui/headless/payment/PaymentHistory.tsx
@@ -1,0 +1,41 @@
+import { ReactNode, useEffect } from 'react';
+import { usePayment } from '@/hooks/usePayment';
+
+export interface PaymentHistoryItem {
+  id: string;
+  amount: number;
+  status: 'succeeded' | 'failed' | 'pending';
+  date: string;
+  description: string;
+}
+
+export interface PaymentHistoryProps {
+  /**
+   * Render prop with payment history data
+   */
+  render: (props: {
+    paymentHistory: PaymentHistoryItem[];
+    isLoading: boolean;
+    error: string | null;
+    refresh: () => Promise<void>;
+  }) => ReactNode;
+}
+
+/**
+ * Headless PaymentHistory component
+ */
+export function PaymentHistory({ render }: PaymentHistoryProps) {
+  const { paymentHistory, isLoading, error, fetchPaymentHistory } = usePayment();
+
+  useEffect(() => {
+    fetchPaymentHistory();
+  }, [fetchPaymentHistory]);
+
+  const refresh = async () => {
+    await fetchPaymentHistory();
+  };
+
+  return (
+    <>{render({ paymentHistory, isLoading, error, refresh })}</>
+  );
+}

--- a/src/ui/headless/payment/PaymentMethodList.tsx
+++ b/src/ui/headless/payment/PaymentMethodList.tsx
@@ -1,0 +1,43 @@
+import { ReactNode, useEffect } from 'react';
+import { usePayment } from '@/hooks/usePayment';
+
+interface PaymentMethod {
+  id: string;
+  type: 'card' | 'paypal';
+  last4?: string;
+  brand?: string;
+  expiryMonth?: string;
+  expiryYear?: string;
+}
+
+export interface PaymentMethodListProps {
+  /**
+   * Render prop that receives payment methods and handlers
+   */
+  render: (props: {
+    paymentMethods: PaymentMethod[];
+    isLoading: boolean;
+    error: string | null;
+    removePaymentMethod: (id: string) => Promise<void>;
+    refresh: () => Promise<void>;
+  }) => ReactNode;
+}
+
+/**
+ * Headless PaymentMethodList component
+ */
+export function PaymentMethodList({ render }: PaymentMethodListProps) {
+  const { paymentMethods, isLoading, error, fetchPaymentMethods, removePaymentMethod } = usePayment();
+
+  useEffect(() => {
+    fetchPaymentMethods();
+  }, [fetchPaymentMethods]);
+
+  const refresh = async () => {
+    await fetchPaymentMethods();
+  };
+
+  return (
+    <>{render({ paymentMethods, isLoading, error, removePaymentMethod, refresh })}</>
+  );
+}

--- a/src/ui/headless/payment/SubscriptionManager.tsx
+++ b/src/ui/headless/payment/SubscriptionManager.tsx
@@ -1,0 +1,46 @@
+import { ReactNode, useEffect } from 'react';
+import { usePayment } from '@/hooks/usePayment';
+
+interface Subscription {
+  id: string;
+  status: 'active' | 'canceled' | 'past_due';
+  currentPeriodEnd: string;
+  plan: {
+    id: string;
+    name: string;
+    price: number;
+    interval: 'month' | 'year';
+  };
+}
+
+export interface SubscriptionManagerProps {
+  /**
+   * Render prop with subscription data
+   */
+  render: (props: {
+    activeSubscription: Subscription | null;
+    isLoading: boolean;
+    error: string | null;
+    cancelSubscription: () => Promise<void>;
+    refresh: () => Promise<void>;
+  }) => ReactNode;
+}
+
+/**
+ * Headless SubscriptionManager component
+ */
+export function SubscriptionManager({ render }: SubscriptionManagerProps) {
+  const { activeSubscription, isLoading, error, fetchSubscription, cancelSubscription } = usePayment();
+
+  useEffect(() => {
+    fetchSubscription();
+  }, [fetchSubscription]);
+
+  const refresh = async () => {
+    await fetchSubscription();
+  };
+
+  return (
+    <>{render({ activeSubscription, isLoading, error, cancelSubscription, refresh })}</>
+  );
+}


### PR DESCRIPTION
## Summary
- implement PaymentForm headless component
- implement PaymentMethodList headless component
- implement PaymentHistory headless component
- implement SubscriptionManager headless component
- implement InvoiceGenerator headless component

## Testing
- `npm test` *(fails: vitest not found)*