### PR TITLE
Add headless components for additional domains

### DIFF
--- a/src/ui/headless/registration/MultiStepRegistration.tsx
+++ b/src/ui/headless/registration/MultiStepRegistration.tsx
@@ -1,0 +1,40 @@
+/**
+ * Headless Multi Step Registration Component
+ *
+ * Provides basic multi step flow logic without rendering UI.
+ */
+import { useState } from 'react';
+
+export interface MultiStepRegistrationProps {
+  steps: string[];
+  onComplete?: (data: Record<string, any>) => Promise<void>;
+  render: (props: {
+    currentStep: number;
+    next: () => void;
+    back: () => void;
+    setValue: (key: string, value: any) => void;
+    values: Record<string, any>;
+    handleSubmit: (e: React.FormEvent) => void;
+  }) => React.ReactNode;
+}
+
+export function MultiStepRegistration({ steps, onComplete, render }: MultiStepRegistrationProps) {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [values, setValues] = useState<Record<string, any>>({});
+
+  const setValue = (key: string, value: any) => setValues(v => ({ ...v, [key]: value }));
+
+  const next = () => setCurrentStep(s => Math.min(s + 1, steps.length - 1));
+  const back = () => setCurrentStep(s => Math.max(s - 1, 0));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (currentStep < steps.length - 1) {
+      next();
+    } else {
+      await onComplete?.(values);
+    }
+  };
+
+  return <>{render({ currentStep, next, back, setValue, values, handleSubmit })}</>;
+}

--- a/src/ui/headless/registration/ProfileCompletion.tsx
+++ b/src/ui/headless/registration/ProfileCompletion.tsx
@@ -1,0 +1,28 @@
+/**
+ * Headless Profile Completion Component
+ *
+ * Manages profile details state and completion submission.
+ */
+import { useState } from 'react';
+
+export interface ProfileCompletionProps {
+  onSubmit?: (data: Record<string, any>) => Promise<void>;
+  render: (props: {
+    values: Record<string, any>;
+    setValue: (field: string, value: any) => void;
+    handleSubmit: (e: React.FormEvent) => void;
+  }) => React.ReactNode;
+}
+
+export function ProfileCompletion({ onSubmit, render }: ProfileCompletionProps) {
+  const [values, setValues] = useState<Record<string, any>>({});
+
+  const setValue = (field: string, value: any) => setValues(v => ({ ...v, [field]: value }));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await onSubmit?.(values);
+  };
+
+  return <>{render({ values, setValue, handleSubmit })}</>;
+}

--- a/src/ui/headless/search/SearchPage.tsx
+++ b/src/ui/headless/search/SearchPage.tsx
@@ -1,0 +1,42 @@
+/**
+ * Headless Search Page Component
+ *
+ * Exposes search state and callbacks without UI rendering.
+ */
+import { useEffect, useState } from 'react';
+
+export interface SearchPageProps {
+  onSearch?: (query: string) => Promise<any[]>;
+  render: (props: {
+    searchTerm: string;
+    setSearchTerm: (v: string) => void;
+    results: any[];
+    isLoading: boolean;
+    error: string | null;
+  }) => React.ReactNode;
+}
+
+export function SearchPage({ onSearch, render }: SearchPageProps) {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [results, setResults] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetch = async () => {
+      if (!onSearch) return;
+      setIsLoading(true);
+      setError(null);
+      try {
+        setResults(await onSearch(searchTerm));
+      } catch (err: any) {
+        setError(err.message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    if (searchTerm) fetch();
+  }, [searchTerm, onSearch]);
+
+  return <>{render({ searchTerm, setSearchTerm, results, isLoading, error })}</>;
+}

--- a/src/ui/headless/session/SessionPolicyEnforcer.tsx
+++ b/src/ui/headless/session/SessionPolicyEnforcer.tsx
@@ -1,0 +1,46 @@
+/**
+ * Headless Session Policy Enforcer
+ *
+ * Periodically enforces session policies without rendering UI.
+ */
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import { api } from '@/lib/api/axios';
+import { useAuthStore } from '@/lib/stores/auth.store';
+
+export interface SessionPolicyEnforcerProps {
+  intervalMs?: number;
+  children?: React.ReactNode;
+}
+
+export function SessionPolicyEnforcer({ intervalMs = 5 * 60 * 1000, children }: SessionPolicyEnforcerProps) {
+  const enforceIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const router = useRouter();
+  const { isAuthenticated, logout } = useAuthStore();
+
+  const enforceSessionPolicies = async () => {
+    if (!isAuthenticated) return;
+    try {
+      await api.post('/api/session/enforce-policies');
+    } catch (error: any) {
+      if (error.response?.status === 401) {
+        logout();
+        router.push('/login?reason=session_expired');
+      }
+    }
+  };
+
+  useEffect(() => {
+    enforceSessionPolicies();
+    enforceIntervalRef.current = setInterval(enforceSessionPolicies, intervalMs);
+    const activityEvents = ['mousedown', 'keydown', 'touchstart', 'scroll'];
+    const handleActivity = () => enforceSessionPolicies();
+    activityEvents.forEach(e => window.addEventListener(e, handleActivity, { passive: true }));
+    return () => {
+      if (enforceIntervalRef.current) clearInterval(enforceIntervalRef.current);
+      activityEvents.forEach(e => window.removeEventListener(e, handleActivity));
+    };
+  }, [isAuthenticated, intervalMs]);
+
+  return <>{children}</>;
+}

--- a/src/ui/headless/settings/AccountDeletion.tsx
+++ b/src/ui/headless/settings/AccountDeletion.tsx
@@ -1,0 +1,4 @@
+/**
+ * Headless AccountDeletion re-export for Settings domain.
+ */
+export { AccountDeletion as default } from '../account/AccountDeletion';

--- a/src/ui/headless/settings/DataExport.tsx
+++ b/src/ui/headless/settings/DataExport.tsx
@@ -1,0 +1,53 @@
+/**
+ * Headless Data Export Component
+ *
+ * Exposes export options state and export trigger without UI.
+ */
+import { useState } from 'react';
+import { ExportFormat, ExportCategory, downloadDataExport } from '@/lib/utils/data-export';
+
+export interface DataExportProps {
+  onComplete?: () => void;
+  render: (props: {
+    selectedFormat: ExportFormat;
+    setSelectedFormat: (f: ExportFormat) => void;
+    selectedCategories: ExportCategory[];
+    setSelectedCategories: (c: ExportCategory[]) => void;
+    includeTimestamp: boolean;
+    setIncludeTimestamp: (v: boolean) => void;
+    anonymize: boolean;
+    setAnonymize: (v: boolean) => void;
+    prettify: boolean;
+    setPrettify: (v: boolean) => void;
+    isLoading: boolean;
+    error: string | null;
+    handleExport: () => Promise<void>;
+  }) => React.ReactNode;
+}
+
+export function DataExport({ onComplete, render }: DataExportProps) {
+  const [selectedFormat, setSelectedFormat] = useState<ExportFormat>(ExportFormat.JSON);
+  const [selectedCategories, setSelectedCategories] = useState<ExportCategory[]>([ExportCategory.ALL]);
+  const [includeTimestamp, setIncludeTimestamp] = useState(true);
+  const [anonymize, setAnonymize] = useState(false);
+  const [prettify, setPrettify] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleExport = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await downloadDataExport({ selectedFormat, selectedCategories, includeTimestamp, anonymize, prettify });
+      onComplete?.();
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>{render({ selectedFormat, setSelectedFormat, selectedCategories, setSelectedCategories, includeTimestamp, setIncludeTimestamp, anonymize, setAnonymize, prettify, setPrettify, isLoading, error, handleExport })}</>
+  );
+}

--- a/src/ui/headless/settings/DataImport.tsx
+++ b/src/ui/headless/settings/DataImport.tsx
@@ -1,0 +1,50 @@
+/**
+ * Headless Data Import Component
+ *
+ * Handles file parsing and optional upload logic without UI.
+ */
+import { useState } from 'react';
+import { supabase } from '@/lib/database/supabase';
+
+export interface DataImportProps {
+  onSuccess?: (summary: any) => void;
+  onError?: (error: string) => void;
+  render: (props: {
+    file: File | null;
+    setFile: (f: File | null) => void;
+    isLoading: boolean;
+    error: string | null;
+    handleImport: () => Promise<void>;
+  }) => React.ReactNode;
+}
+
+async function parseFile(file: File): Promise<any> {
+  const text = await file.text();
+  if (file.name.endsWith('.json')) return JSON.parse(text);
+  if (file.name.endsWith('.csv')) return text.split('\n').map(r => r.split(','));
+  throw new Error('Unsupported format');
+}
+
+export function DataImport({ onSuccess, onError, render }: DataImportProps) {
+  const [file, setFile] = useState<File | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleImport = async () => {
+    if (!file) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await parseFile(file);
+      await supabase.from('imports').insert({ data });
+      onSuccess?.(data);
+    } catch (err: any) {
+      setError(err.message);
+      onError?.(err.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return <>{render({ file, setFile, isLoading, error, handleImport })}</>;
+}

--- a/src/ui/headless/settings/LanguageSelector.tsx
+++ b/src/ui/headless/settings/LanguageSelector.tsx
@@ -1,0 +1,23 @@
+/**
+ * Headless Language Selector Component
+ *
+ * Manages language state without rendering UI.
+ */
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export interface LanguageSelectorProps {
+  render: (props: { language: string; setLanguage: (lang: string) => void }) => React.ReactNode;
+}
+
+export function LanguageSelector({ render }: LanguageSelectorProps) {
+  const { i18n } = useTranslation();
+  const [language, setLanguageState] = useState(i18n.language);
+
+  const setLanguage = (lang: string) => {
+    i18n.changeLanguage(lang);
+    setLanguageState(lang);
+  };
+
+  return <>{render({ language, setLanguage })}</>;
+}

--- a/src/ui/headless/settings/SettingsPanel.tsx
+++ b/src/ui/headless/settings/SettingsPanel.tsx
@@ -1,0 +1,24 @@
+/**
+ * Headless Settings Panel
+ *
+ * Provides settings data and update handlers via render props.
+ */
+import { useEffect } from 'react';
+import { useSettingsStore } from '@/lib/stores/settings.store';
+
+export interface SettingsPanelProps {
+  render: (props: {
+    settings: any;
+    isLoading: boolean;
+    error: string | null;
+    updateSettings: (s: any) => Promise<void>;
+  }) => React.ReactNode;
+}
+
+export function SettingsPanel({ render }: SettingsPanelProps) {
+  const { settings, isLoading, error, fetchSettings, updateSettings } = useSettingsStore();
+
+  useEffect(() => { fetchSettings(); }, [fetchSettings]);
+
+  return <>{render({ settings, isLoading, error, updateSettings })}</>;
+}

--- a/src/ui/headless/shared/ConnectedAccounts.tsx
+++ b/src/ui/headless/shared/ConnectedAccounts.tsx
@@ -1,0 +1,35 @@
+/**
+ * Headless Connected Accounts Component
+ *
+ * Provides account linking state and actions without UI.
+ */
+import { useEffect } from 'react';
+import { useConnectedAccountsStore } from '@/lib/stores/connected-accounts.store';
+import type { ConnectedAccount, OAuthProvider } from '@/types/connected-accounts';
+
+export interface ConnectedAccountsProps {
+  render: (props: {
+    accounts: ConnectedAccount[];
+    isLoading: boolean;
+    error: string | null;
+    link: (provider: OAuthProvider) => Promise<void>;
+    unlink: (id: string) => Promise<void>;
+  }) => React.ReactNode;
+}
+
+export function ConnectedAccounts({ render }: ConnectedAccountsProps) {
+  const {
+    accounts,
+    fetchConnectedAccounts,
+    linkAccount,
+    unlinkAccount,
+    isLoading,
+    error,
+  } = useConnectedAccountsStore();
+
+  useEffect(() => { fetchConnectedAccounts(); }, [fetchConnectedAccounts]);
+
+  return (
+    <>{render({ accounts, isLoading, error, link: linkAccount, unlink: unlinkAccount })}</>
+  );
+}

--- a/src/ui/headless/shared/NotificationPreferences.tsx
+++ b/src/ui/headless/shared/NotificationPreferences.tsx
@@ -1,0 +1,25 @@
+/**
+ * Headless Notification Preferences Component
+ *
+ * Provides user notification preferences without UI.
+ */
+import { useEffect } from 'react';
+import { usePreferencesStore } from '@/lib/stores/preferences.store';
+import type { UserPreferences } from '@/types/database';
+
+export interface NotificationPreferencesProps {
+  render: (props: {
+    preferences: UserPreferences | null;
+    isLoading: boolean;
+    error: string | null;
+    update: (prefs: Partial<UserPreferences>) => Promise<void>;
+  }) => React.ReactNode;
+}
+
+export function NotificationPreferences({ render }: NotificationPreferencesProps) {
+  const { preferences, isLoading, error, fetchPreferences, updatePreferences } = usePreferencesStore();
+
+  useEffect(() => { fetchPreferences(); }, [fetchPreferences]);
+
+  return <>{render({ preferences, isLoading, error, update: updatePreferences })}</>;
+}

--- a/src/ui/headless/sharing/SocialSharingComponent.tsx
+++ b/src/ui/headless/sharing/SocialSharingComponent.tsx
@@ -1,0 +1,40 @@
+/**
+ * Headless Social Sharing Component
+ *
+ * Generates share URLs and exposes copy/share handlers.
+ */
+import { useEffect, useState } from 'react';
+
+export interface SharedItemData {
+  id: string;
+  title: string;
+  slug: string;
+}
+
+export interface SocialSharingComponentProps {
+  itemData: SharedItemData;
+  basePath?: string;
+  render: (props: {
+    shareUrl: string;
+    isCopied: boolean;
+    copy: () => void;
+    open: boolean;
+    setOpen: (v: boolean) => void;
+  }) => React.ReactNode;
+}
+
+export function SocialSharingComponent({ itemData, basePath = '', render }: SocialSharingComponentProps) {
+  const [shareUrl, setShareUrl] = useState('');
+  const [isCopied, setIsCopied] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    setShareUrl(`${basePath}/${itemData.slug}`);
+  }, [basePath, itemData.slug]);
+
+  const copy = () => {
+    navigator.clipboard.writeText(shareUrl).then(() => setIsCopied(true));
+  };
+
+  return <>{render({ shareUrl, isCopied, copy, open, setOpen })}</>;
+}

--- a/src/ui/headless/subscription/SubscriptionBadge.tsx
+++ b/src/ui/headless/subscription/SubscriptionBadge.tsx
@@ -1,0 +1,18 @@
+/**
+ * Headless Subscription Badge
+ *
+ * Exposes subscription tier information with no UI.
+ */
+import { useSubscriptionStore } from '@/lib/stores/subscription.store';
+import { SubscriptionTier } from '@/lib/types/subscription';
+
+export interface SubscriptionBadgeProps {
+  children: (props: { tier: SubscriptionTier; trialDays: number | null; isSubscribed: boolean }) => React.ReactNode;
+}
+
+export function SubscriptionBadge({ children }: SubscriptionBadgeProps) {
+  const { getTier, isSubscribed, getRemainingTrialDays } = useSubscriptionStore();
+  const tier = getTier();
+  const trialDays = getRemainingTrialDays();
+  return <>{children({ tier, trialDays, isSubscribed })}</>;
+}

--- a/src/ui/headless/subscription/SubscriptionPlans.tsx
+++ b/src/ui/headless/subscription/SubscriptionPlans.tsx
@@ -1,0 +1,35 @@
+/**
+ * Headless Subscription Plans
+ *
+ * Provides subscription plans data and selection callbacks via render props.
+ */
+import { useEffect, useState } from 'react';
+import { useSubscriptionStore } from '@/lib/stores/subscription.store';
+import { SubscriptionPeriod } from '@/lib/types/subscription';
+
+export interface SubscriptionPlansProps {
+  periods?: SubscriptionPeriod[];
+  defaultPeriod?: SubscriptionPeriod;
+  onSelect?: (planId: string) => void;
+  render: (props: {
+    plans: any[];
+    selectedPeriod: SubscriptionPeriod;
+    setSelectedPeriod: (p: SubscriptionPeriod) => void;
+    isLoading: boolean;
+    error: string | null;
+    select: (id: string) => void;
+  }) => React.ReactNode;
+}
+
+export function SubscriptionPlans({ periods = [SubscriptionPeriod.MONTHLY], defaultPeriod = periods[0], onSelect, render }: SubscriptionPlansProps) {
+  const { fetchPlans, plans, isLoading, error } = useSubscriptionStore();
+  const [selectedPeriod, setSelectedPeriod] = useState<SubscriptionPeriod>(defaultPeriod);
+
+  useEffect(() => { fetchPlans(); }, [fetchPlans]);
+
+  const select = (id: string) => onSelect?.(id);
+
+  const filtered = plans.filter(p => p.period === selectedPeriod);
+
+  return <>{render({ plans: filtered, selectedPeriod, setSelectedPeriod, isLoading, error, select })}</>;
+}

--- a/src/ui/headless/subscription/withSubscription.tsx
+++ b/src/ui/headless/subscription/withSubscription.tsx
@@ -1,0 +1,40 @@
+/**
+ * Headless subscription gating HOC
+ */
+import React from 'react';
+import { useSubscriptionStore } from '@/lib/stores/subscription.store';
+import { SubscriptionTier } from '@/lib/types/subscription';
+import { useUserManagement } from '@/lib/auth/UserManagementProvider';
+
+export interface WithSubscriptionProps {
+  featureName?: string;
+  requiredTier?: SubscriptionTier;
+  fallback?: React.ReactNode;
+}
+
+export function withSubscription<P extends object>(
+  WrappedComponent: React.ComponentType<P>,
+  options: WithSubscriptionProps = {}
+) {
+  return function WithSubscriptionComponent(props: P) {
+    const { hasFeature, getTier } = useSubscriptionStore();
+    const { subscription } = useUserManagement();
+    if (!subscription.enabled) {
+      return <WrappedComponent {...props} />;
+    }
+    const hasAccess = options.featureName
+      ? hasFeature(options.featureName)
+      : options.requiredTier
+        ? getTier() >= options.requiredTier
+        : true;
+    return hasAccess ? <WrappedComponent {...props} /> : options.fallback || null;
+  };
+}
+
+export function SubscriptionGate({ children, featureName, requiredTier, fallback }: React.PropsWithChildren<WithSubscriptionProps>) {
+  const { hasFeature, getTier } = useSubscriptionStore();
+  const { subscription } = useUserManagement();
+  if (!subscription.enabled) return <>{children}</>;
+  const hasAccess = featureName ? hasFeature(featureName) : requiredTier ? getTier() >= requiredTier : true;
+  return hasAccess ? <>{children}</> : fallback ? <>{fallback}</> : null;
+}

--- a/src/ui/headless/theme/theme-provider.tsx
+++ b/src/ui/headless/theme/theme-provider.tsx
@@ -1,0 +1,4 @@
+/**
+ * Headless Theme Provider re-export.
+ */
+export { ThemeProvider, useTheme } from '@/components/ui/theme-provider';


### PR DESCRIPTION
## Summary
- add headless versions for registration components
- implement search headless module
- add session policy enforcer headless component
- implement settings headless components
- add shared, sharing, subscription, and theme headless modules

## Testing
- `npm test` *(fails: vitest not found)*