### PR TITLE
Wrap styled components with headless versions

### DIFF
--- a/src/ui/styled/__tests__/headless-wrappers.test.tsx
+++ b/src/ui/styled/__tests__/headless-wrappers.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, fireEvent } from '@/tests/test-utils';
+import '@/tests/i18nTestSetup';
+import { vi } from 'vitest';
+
+const dashboardState: any = {
+  items: [{ id: '1', title: 'Item1', description: 'Desc' }],
+  isEditing: false,
+  currentItem: null,
+  error: null,
+  setIsEditing: vi.fn(),
+  setCurrentItem: vi.fn(),
+  handleCreate: vi.fn(),
+  handleUpdate: vi.fn(),
+  handleDelete: vi.fn(),
+};
+vi.mock('../dashboard/../../headless/dashboard/Dashboard', () => ({
+  Dashboard: ({ children }: any) => children(dashboardState),
+}));
+import { Dashboard } from '../dashboard/Dashboard';
+
+const consentState: any = {
+  marketing: true,
+  setMarketing: vi.fn(),
+  isLoading: false,
+  error: null,
+  submitted: false,
+  handleSave: vi.fn(),
+};
+vi.mock('../gdpr/../../headless/gdpr/ConsentManagement', () => ({
+  ConsentManagement: ({ render }: any) => render(consentState),
+}));
+import { ConsentManagement } from '../gdpr/ConsentManagement';
+
+const searchState: any = {
+  searchTerm: '',
+  setSearchTerm: vi.fn(),
+  results: [{ id: '1', title: 'Foo', category: 'report', date: '2020-01-01' }],
+  isLoading: false,
+  error: null,
+};
+vi.mock('../search/../../headless/search/SearchPage', () => ({
+  SearchPage: ({ onSearch, render }: any) => {
+    onSearch && onSearch('');
+    return render(searchState);
+  },
+}));
+import SearchPage from '../search/SearchPage';
+
+const featuresState: any = {
+  title: 'Title',
+  description: 'Desc',
+  features: [{ name: 'A', description: 'B', icon: () => null }],
+};
+vi.mock('../layout/../../headless/layout/Features', () => ({
+  Features: ({ children }: any) => children(featuresState),
+}));
+import { Features } from '../layout/Features';
+
+const footerState: any = {
+  footerClasses: 'footer',
+  platform: 'web',
+  isNative: false,
+  year: 2024,
+  position: 'static',
+};
+vi.mock('../layout/../../headless/layout/Footer', () => ({
+  Footer: ({ children }: any) => children(footerState),
+}));
+import { Footer } from '../layout/Footer';
+
+describe('Styled wrappers', () => {
+  it('renders Dashboard list', () => {
+    render(<Dashboard />);
+    expect(screen.getByText('Item1')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Create New'));
+    expect(dashboardState.setIsEditing).toHaveBeenCalled();
+  });
+
+  it('renders ConsentManagement', () => {
+    render(<ConsentManagement />);
+    expect(screen.getByLabelText('Allow marketing emails')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Save'));
+    expect(consentState.handleSave).toHaveBeenCalled();
+  });
+
+  it('renders SearchPage results', () => {
+    render(<SearchPage />);
+    expect(screen.getByRole('searchbox')).toBeInTheDocument();
+    expect(screen.getByText('Foo')).toBeInTheDocument();
+  });
+
+  it('renders Features list', () => {
+    render(<Features />);
+    expect(screen.getByText('Title')).toBeInTheDocument();
+    expect(screen.getByText('A')).toBeInTheDocument();
+  });
+
+  it('renders Footer', () => {
+    render(<Footer />);
+    expect(screen.getByText(/User Management/)).toBeInTheDocument();
+  });
+});

--- a/src/ui/styled/dashboard/Dashboard.tsx
+++ b/src/ui/styled/dashboard/Dashboard.tsx
@@ -1,140 +1,81 @@
-import React, { useEffect, useState } from 'react';
-import { supabase } from '@/lib/database/supabase';
+import React from 'react';
+import { Dashboard as HeadlessDashboard } from '../../headless/dashboard/Dashboard';
 
-interface Item {
-  id: string;
-  title: string;
-  description: string;
-}
+export const Dashboard: React.FC = () => (
+  <HeadlessDashboard>
+    {({
+      items,
+      isEditing,
+      currentItem,
+      error,
+      setIsEditing,
+      setCurrentItem,
+      handleCreate,
+      handleUpdate,
+      handleDelete,
+    }) => (
+      <div>
+        {error && <div role="alert">{error}</div>}
 
-export const Dashboard: React.FC = () => {
-  const [items, setItems] = useState<Item[]>([]);
-  const [isEditing, setIsEditing] = useState(false);
-  const [currentItem, setCurrentItem] = useState<Item | null>(null);
-  const [error, setError] = useState<string | null>(null);
+        <button onClick={() => setIsEditing(true)}>Create New</button>
 
-  const fetchItems = async () => {
-    const { data, error } = await supabase.from('items').select('*');
-    if (error) {
-      setError(error.message);
-    } else {
-      setItems(data || []);
-    }
-  };
+        {isEditing && (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              const form = e.target as HTMLFormElement;
+              const title = (form.elements.namedItem('title') as HTMLInputElement).value;
+              const description = (form.elements.namedItem('description') as HTMLInputElement).value;
 
-  useEffect(() => {
-    fetchItems();
-  }, []);
+              if (currentItem) {
+                handleUpdate(currentItem.id, title, description);
+              } else {
+                handleCreate(title, description);
+              }
+            }}
+          >
+            <div>
+              <label htmlFor="title">Title</label>
+              <input id="title" name="title" defaultValue={currentItem?.title || ''} />
+            </div>
+            <div>
+              <label htmlFor="description">Description</label>
+              <input id="description" name="description" defaultValue={currentItem?.description || ''} />
+            </div>
+            <button type="submit">Save</button>
+          </form>
+        )}
 
-  const handleCreate = async (title: string, description: string) => {
-    // console.log('[TEST_DEBUG] handleCreate called');
-    // const { data, error } = await supabase // Original
-    const { error } = await supabase // Remove unused 'data'
-      .from('items')
-      .insert([{ title, description }]);
-    // console.log('[TEST_DEBUG] handleCreate insert response:', { data, error });
-    
-    if (error) {
-      setError(error.message);
-    } else {
-      await fetchItems();
-      setIsEditing(false);
-    }
-  };
-
-  const handleUpdate = async (id: string, title: string, description: string) => {
-    // console.log('[TEST_DEBUG] handleUpdate called');
-    // const { data, error } = await supabase // Original
-    const { error } = await supabase // Remove unused 'data'
-      .from('items')
-      .update({ title, description })
-      .eq('id', id);
-    // console.log('[TEST_DEBUG] handleUpdate update response:', { data, error });
-
-    if (error) {
-      setError(error.message);
-    } else {
-      await fetchItems();
-      setIsEditing(false);
-      setCurrentItem(null);
-    }
-  };
-
-  const handleDelete = async (id: string) => {
-    // console.log('[TEST_DEBUG] handleDelete called');
-    // const { data, error } = await supabase // Original
-    const { error } = await supabase // Remove unused 'data'
-      .from('items')
-      .delete()
-      .eq('id', id);
-    // console.log('[TEST_DEBUG] handleDelete delete response:', { data, error });
-
-    if (error) {
-      setError(error.message);
-    } else {
-      await fetchItems();
-    }
-  };
-
-  return (
-    <div>
-      {error && <div role="alert">{error}</div>}
-      
-      <button onClick={() => setIsEditing(true)}>Create New</button>
-
-      {isEditing && (
-        <form onSubmit={(e) => {
-          e.preventDefault();
-          const form = e.target as HTMLFormElement;
-          const title = (form.elements.namedItem('title') as HTMLInputElement).value;
-          const description = (form.elements.namedItem('description') as HTMLInputElement).value;
-          
-          if (currentItem) {
-            handleUpdate(currentItem.id, title, description);
-          } else {
-            handleCreate(title, description);
-          }
-        }}>
-          <div>
-            <label htmlFor="title">Title</label>
-            <input
-              id="title"
-              name="title"
-              defaultValue={currentItem?.title || ''}
-            />
-          </div>
-          <div>
-            <label htmlFor="description">Description</label>
-            <input
-              id="description"
-              name="description"
-              defaultValue={currentItem?.description || ''}
-            />
-          </div>
-          <button type="submit">Save</button>
-        </form>
-      )}
-
-      {items.length === 0 ? (
-        <div>No items found</div>
-      ) : (
-        <ul>
-          {items.map((item) => (
-            <li key={item.id}>
-              <span>{item.title}</span>
-              <button onClick={() => {
-                setCurrentItem(item);
-                setIsEditing(true);
-              }}>Edit</button>
-              <button onClick={() => {
-                if (window.confirm('Are you sure?')) {
-                  handleDelete(item.id);
-                }
-              }}>Delete</button>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
-}; 
+        {items.length === 0 ? (
+          <div>No items found</div>
+        ) : (
+          <ul>
+            {items.map((item) => (
+              <li key={item.id}>
+                <span>{item.title}</span>
+                <button
+                  onClick={() => {
+                    setCurrentItem(item);
+                    setIsEditing(true);
+                  }}
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={() => {
+                    /* istanbul ignore next */
+                    if (window.confirm('Are you sure?')) {
+                      handleDelete(item.id);
+                    }
+                  }}
+                >
+                  Delete
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    )}
+  </HeadlessDashboard>
+);

--- a/src/ui/styled/gdpr/ConsentManagement.tsx
+++ b/src/ui/styled/gdpr/ConsentManagement.tsx
@@ -1,59 +1,37 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { usePreferencesStore } from '@/lib/stores/preferences.store';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { ConsentManagement as HeadlessConsentManagement } from '../../headless/gdpr/ConsentManagement';
 
 export function ConsentManagement() {
-  const { preferences, fetchPreferences, updatePreferences, isLoading, error } = usePreferencesStore();
-  const [marketing, setMarketing] = useState(false);
-  const [submitted, setSubmitted] = useState(false);
-
-  useEffect(() => {
-    if (!preferences) fetchPreferences();
-  }, [preferences, fetchPreferences]);
-
-  useEffect(() => {
-    if (preferences) {
-      setMarketing(!!preferences.notifications?.marketing);
-    }
-  }, [preferences]);
-
-  const handleSave = async () => {
-    setSubmitted(false);
-    await updatePreferences({
-      notifications: {
-        ...preferences?.notifications,
-        marketing,
-      },
-    });
-    setSubmitted(true);
-  };
-
   return (
-    <div className="space-y-4 w-full max-w-md mx-auto">
-      {submitted && error && (
-        <Alert variant="destructive" role="alert">
-          <AlertDescription>{error}</AlertDescription>
-        </Alert>
+    <HeadlessConsentManagement
+      render={({ marketing, setMarketing, isLoading, error, submitted, handleSave }) => (
+        <div className="space-y-4 w-full max-w-md mx-auto">
+          {submitted && error && (
+            <Alert variant="destructive" role="alert">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          {submitted && !error && (
+            <Alert>
+              <AlertDescription>Preferences updated</AlertDescription>
+            </Alert>
+          )}
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id="marketing-consent"
+              checked={marketing}
+              onCheckedChange={val => setMarketing(val === true)}
+            />
+            <Label htmlFor="marketing-consent">Allow marketing emails</Label>
+          </div>
+          <Button onClick={handleSave} disabled={isLoading}>Save</Button>
+        </div>
       )}
-      {submitted && !error && (
-        <Alert>
-          <AlertDescription>Preferences updated</AlertDescription>
-        </Alert>
-      )}
-      <div className="flex items-center space-x-2">
-        <Checkbox
-          id="marketing-consent"
-          checked={marketing}
-          onCheckedChange={val => setMarketing(val === true)}
-        />
-        <Label htmlFor="marketing-consent">Allow marketing emails</Label>
-      </div>
-      <Button onClick={handleSave} disabled={isLoading}>Save</Button>
-    </div>
+    />
   );
 }

--- a/src/ui/styled/layout/Features.tsx
+++ b/src/ui/styled/layout/Features.tsx
@@ -1,19 +1,9 @@
 import { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 import { Box, Layers, Zap } from 'lucide-react';
+import { Features as HeadlessFeatures, FeatureItem, FeaturesProps as HeadlessProps } from '../../headless/layout/Features';
 
-export interface FeatureItem {
-  name: ReactNode;
-  description: ReactNode;
-  icon: React.ComponentType<{ className?: string }>;
-  onClick?: () => void;
-  href?: string;
-}
-
-interface FeaturesProps {
-  title?: ReactNode;
-  description?: ReactNode;
-  features?: FeatureItem[];
+export interface FeaturesProps extends Omit<HeadlessProps, 'children'> {
   className?: string;
 }
 
@@ -36,46 +26,54 @@ const defaultFeatures: FeatureItem[] = [
 ];
 
 export function Features({ title, description, features, className }: FeaturesProps) {
-  const items = features ?? defaultFeatures;
   return (
-    <div className={cn('py-24 sm:py-32', className)}>
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
-            {title ?? 'Everything you need to build modern apps'}
-          </h2>
-          <p className="mt-6 text-lg leading-8 text-muted-foreground">
-            {description ?? 'Start with our comprehensive library of components and templates. Focus on your unique features while we handle the fundamentals.'}
-          </p>
+    <HeadlessFeatures title={title} description={description} features={features ?? defaultFeatures}>
+      {({ title, description, features }) => (
+        <div className={cn('py-24 sm:py-32', className)}>
+          <div className="mx-auto max-w-7xl px-6 lg:px-8">
+            <div className="mx-auto max-w-2xl text-center">
+              <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">{title}</h2>
+              <p className="mt-6 text-lg leading-8 text-muted-foreground">{description}</p>
+            </div>
+            <div className="mx-auto mt-16 max-w-2xl sm:mt-20 lg:mt-24 lg:max-w-none">
+              <dl className="grid max-w-xl grid-cols-1 gap-x-8 gap-y-16 lg:max-w-none lg:grid-cols-3">
+                {features.map((feature) => (
+                  <div key={feature.name?.toString()} className="flex flex-col">
+                    {feature.href ? (
+                      <a
+                        href={feature.href}
+                        className="flex items-center gap-x-3 text-lg font-semibold leading-7 hover:text-primary focus:text-primary transition-colors"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <feature.icon className="h-5 w-5 flex-none text-primary" aria-hidden="true" />
+                        {feature.name}
+                      </a>
+                    ) : feature.onClick ? (
+                      <button
+                        type="button"
+                        onClick={feature.onClick}
+                        className="flex items-center gap-x-3 text-lg font-semibold leading-7 hover:text-primary focus:text-primary transition-colors bg-transparent border-none p-0 m-0 cursor-pointer"
+                      >
+                        <feature.icon className="h-5 w-5 flex-none text-primary" aria-hidden="true" />
+                        {feature.name}
+                      </button>
+                    ) : (
+                      <dt className="flex items-center gap-x-3 text-lg font-semibold leading-7">
+                        <feature.icon className="h-5 w-5 flex-none text-primary" aria-hidden="true" />
+                        {feature.name}
+                      </dt>
+                    )}
+                    <dd className="mt-4 flex flex-auto flex-col text-base leading-7 text-muted-foreground">
+                      <p className="flex-auto">{feature.description}</p>
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          </div>
         </div>
-        <div className="mx-auto mt-16 max-w-2xl sm:mt-20 lg:mt-24 lg:max-w-none">
-          <dl className="grid max-w-xl grid-cols-1 gap-x-8 gap-y-16 lg:max-w-none lg:grid-cols-3">
-            {items.map((feature) => (
-              <div key={feature.name?.toString()} className="flex flex-col">
-                {feature.href ? (
-                  <a href={feature.href} className="flex items-center gap-x-3 text-lg font-semibold leading-7 hover:text-primary focus:text-primary transition-colors" target="_blank" rel="noopener noreferrer">
-                    <feature.icon className="h-5 w-5 flex-none text-primary" aria-hidden="true" />
-                    {feature.name}
-                  </a>
-                ) : feature.onClick ? (
-                  <button type="button" onClick={feature.onClick} className="flex items-center gap-x-3 text-lg font-semibold leading-7 hover:text-primary focus:text-primary transition-colors bg-transparent border-none p-0 m-0 cursor-pointer">
-                    <feature.icon className="h-5 w-5 flex-none text-primary" aria-hidden="true" />
-                    {feature.name}
-                  </button>
-                ) : (
-                  <dt className="flex items-center gap-x-3 text-lg font-semibold leading-7">
-                    <feature.icon className="h-5 w-5 flex-none text-primary" aria-hidden="true" />
-                    {feature.name}
-                  </dt>
-                )}
-                <dd className="mt-4 flex flex-auto flex-col text-base leading-7 text-muted-foreground">
-                  <p className="flex-auto">{feature.description}</p>
-                </dd>
-              </div>
-            ))}
-          </dl>
-        </div>
-      </div>
-    </div>
+      )}
+    </HeadlessFeatures>
   );
 }

--- a/src/ui/styled/layout/Footer.tsx
+++ b/src/ui/styled/layout/Footer.tsx
@@ -1,48 +1,30 @@
 import { useTranslation } from 'react-i18next';
-import { useUserManagement } from '@/lib/auth/UserManagementProvider';
-import { getPlatformClasses } from '@/hooks/usePlatformStyles';
+import { Footer as HeadlessFooter, FooterProps as HeadlessProps } from '../../headless/layout/Footer';
 
-interface FooterProps {
-  position?: 'static' | 'sticky' | 'fixed';
-}
+interface FooterProps extends Omit<HeadlessProps, 'children'> {}
 
 export function Footer({ position = 'static' }: FooterProps) {
   const { t } = useTranslation();
-  const { platform, isNative } = useUserManagement();
-  
-  // Footer may not be necessary on mobile platforms
-  if (isNative && platform !== 'web') {
-    return null;
-  }
-  
-  const footerClasses = getPlatformClasses({
-    base: `w-full py-6 border-t ${position === 'sticky' ? 'sticky bottom-0' : position === 'fixed' ? 'fixed bottom-0' : ''} bg-background`,
-    web: 'px-8',
-    mobile: 'px-4 py-3',
-  }, { platform, isNative });
-
   return (
-    <footer className={footerClasses}>
-      <div className="container mx-auto flex flex-col items-center justify-between gap-4 md:h-16 md:flex-row">
-        <p className="text-sm text-muted-foreground">
-          &copy; {new Date().getFullYear()} User Management. {t('common.allRightsReserved')}
-        </p>
-        
-        <nav className="flex items-center gap-4 text-sm">
-          <a
-            href="#"
-            className="text-muted-foreground underline-offset-4 hover:underline"
-          >
-            {t('common.privacy')}
-          </a>
-          <a
-            href="#"
-            className="text-muted-foreground underline-offset-4 hover:underline"
-          >
-            {t('common.terms')}
-          </a>
-        </nav>
-      </div>
-    </footer>
+    <HeadlessFooter position={position}>
+      {({ footerClasses, year }) => (
+        <footer className={footerClasses}>
+          <div className="container mx-auto flex flex-col items-center justify-between gap-4 md:h-16 md:flex-row">
+            <p className="text-sm text-muted-foreground">
+              &copy; {year} User Management. {t('common.allRightsReserved')}
+            </p>
+
+            <nav className="flex items-center gap-4 text-sm">
+              <a href="#" className="text-muted-foreground underline-offset-4 hover:underline">
+                {t('common.privacy')}
+              </a>
+              <a href="#" className="text-muted-foreground underline-offset-4 hover:underline">
+                {t('common.terms')}
+              </a>
+            </nav>
+          </div>
+        </footer>
+      )}
+    </HeadlessFooter>
   );
 }

--- a/src/ui/styled/search/SearchPage.tsx
+++ b/src/ui/styled/search/SearchPage.tsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { supabase } from '@/lib/database/supabase';
-import { useDebounce } from '@/hooks/useDebounce';
+import { SearchPage as HeadlessSearchPage } from '../../headless/search/SearchPage';
 
 interface SearchItem {
   id: string;
@@ -15,171 +15,133 @@ interface SearchItem {
 }
 
 const SearchPage: React.FC = () => {
-  const [searchTerm, setSearchTerm] = useState('');
-  const debouncedSearchTerm = useDebounce(searchTerm, 300);
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const [startDate, setStartDate] = useState<Date | undefined>();
   const [endDate, setEndDate] = useState<Date | undefined>();
   const [items, setItems] = useState<SearchItem[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const categories = ['report', 'presentation', 'spreadsheet', 'other'];
 
-  // Dummy categories for filter options
-  const categories = ['report', 'presentation', 'spreadsheet', 'other']; 
-
-  // Effect for data loading and filtering using Supabase
-  useEffect(() => {
-    const fetchData = async () => {
-        setLoading(true);
-        setError(null);
-        if (process.env.NODE_ENV === 'development') { console.log('Fetching/filtering data with:', { debouncedSearchTerm, selectedCategories, startDate, endDate }); }
-
-        try {
-            let query = supabase
-                .from('items') // Replace 'items' with your actual table name
-                .select('*'); // Select all columns or specify needed ones
-
-            // Apply DEBOUNCED search term filter
-            if (debouncedSearchTerm) {
-                query = query.ilike('title', `%${debouncedSearchTerm}%`);
-            }
-
-            // Apply category filter
-            if (selectedCategories.length > 0) {
-                query = query.in('category', selectedCategories);
-            }
-
-            // Apply date range filter
-            if (startDate) {
-                 query = query.gte('date', startDate.toISOString().split('T')[0]);
-            }
-            if (endDate) {
-                query = query.lte('date', endDate.toISOString().split('T')[0]);
-            }
-
-            // Execute the query
-            const { data, error: dbError } = await query;
-
-            if (dbError) {
-                throw dbError;
-            }
-
-            // Update state on success: set items first, then loading false
-            setItems(data || []); 
-            setError(null); // Explicitly clear error
-            setLoading(false); // Set loading false AFTER data is set
-
-        } catch (err: any) { 
-            if (process.env.NODE_ENV === 'development') { console.error("Error fetching search data:", err); }
-            // Update state on error: set error and clear items first, then loading false
-            setError(err.message || 'Failed to fetch search results.'); 
-            setItems([]); // Clear items on error
-            setLoading(false); // Set loading false AFTER error is set
-        }
-        // setLoading is now handled within try/catch, so no finally block needed for it.
-    };
-
-    fetchData();
-
-  }, [debouncedSearchTerm, selectedCategories, startDate, endDate]);
+  const onSearch = useCallback(
+    async (query: string) => {
+      let q = supabase.from('items').select('*');
+      if (query) q = q.ilike('title', `%${query}%`);
+      if (selectedCategories.length) q = q.in('category', selectedCategories);
+      if (startDate) q = q.gte('date', startDate.toISOString().split('T')[0]);
+      if (endDate) q = q.lte('date', endDate.toISOString().split('T')[0]);
+      const { data, error } = await q;
+      if (error) throw error;
+      setItems(data || []);
+      return data || [];
+    },
+    [selectedCategories, startDate, endDate]
+  );
 
   const handleCategoryChange = (category: string) => {
-    setSelectedCategories(prev => 
-      prev.includes(category) 
-        ? prev.filter(c => c !== category) 
-        : [...prev, category]
+    setSelectedCategories(prev =>
+      prev.includes(category) ? prev.filter(c => c !== category) : [...prev, category]
     );
   };
 
   const handleDateApply = () => {
-    // This function might not be strictly needed anymore as useEffect handles data fetching
-    // based on state changes. Keep it if there's a specific reason to manually trigger.
-    if (process.env.NODE_ENV === 'development') { console.log("Applying date range (useEffect will fetch):", startDate, endDate); }
+    // Intentionally empty - onSearch handles updates
   };
 
-  const resetFilters = () => {
+  const resetFilters = (setSearchTerm: (v: string) => void) => {
     setSearchTerm('');
     setSelectedCategories([]);
     setStartDate(undefined);
     setEndDate(undefined);
-    // useEffect will automatically refetch due to state changes
   };
 
   return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Search</h1>
+    <HeadlessSearchPage
+      onSearch={onSearch}
+      render={({ searchTerm, setSearchTerm, results, isLoading, error }) => (
+        <div className="p-4 space-y-4">
+          <h1 className="text-2xl font-bold">Search</h1>
 
-      {/* Search Input */}
-      <Input
-        type="search"
-        aria-label="Search box"
-        role="searchbox"
-        placeholder="Search items..."
-        value={searchTerm}
-        onChange={(e) => setSearchTerm(e.target.value)}
-        className="max-w-sm"
-      />
+          <Input
+            type="search"
+            aria-label="Search box"
+            role="searchbox"
+            placeholder="Search items..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="max-w-sm"
+          />
 
-      <div className="flex flex-wrap gap-4">
-        {/* Category Filter */}
-        <Card>
-            <CardHeader><Label>Category</Label></CardHeader>
-            <CardContent className="space-y-2">
-            {categories.map((category) => (
-                <div key={category} className="flex items-center space-x-2">
-                <Checkbox 
-                    id={`category-${category}`} 
-                    checked={selectedCategories.includes(category)}
-                    onCheckedChange={() => handleCategoryChange(category)} 
-                />
-                <Label htmlFor={`category-${category}`} className="capitalize">{category}</Label>
+          <div className="flex flex-wrap gap-4">
+            <Card>
+              <CardHeader><Label>Category</Label></CardHeader>
+              <CardContent className="space-y-2">
+                {categories.map((category) => (
+                  <div key={category} className="flex items-center space-x-2">
+                    <Checkbox
+                      id={`category-${category}`}
+                      checked={selectedCategories.includes(category)}
+                      onCheckedChange={() => handleCategoryChange(category)}
+                    />
+                    <Label htmlFor={`category-${category}`} className="capitalize">
+                      {category}
+                    </Label>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader><Label htmlFor="date-range-start">Date Range</Label></CardHeader>
+              <CardContent className="space-y-2">
+                <div>
+                  <Label htmlFor="date-range-start">Start Date</Label>
+                  <Input
+                    type="date"
+                    id="date-range-start"
+                    aria-label="start date"
+                    value={startDate?.toISOString().split('T')[0] || ''}
+                    onChange={(e) => setStartDate(e.target.value ? new Date(e.target.value) : undefined)}
+                  />
                 </div>
-            ))}
-            </CardContent>
-        </Card>
+                <div>
+                  <Label htmlFor="date-range-end">End Date</Label>
+                  <Input
+                    type="date"
+                    id="date-range-end"
+                    aria-label="end date"
+                    value={endDate?.toISOString().split('T')[0] || ''}
+                    onChange={(e) => setEndDate(e.target.value ? new Date(e.target.value) : undefined)}
+                  />
+                </div>
+              </CardContent>
+            </Card>
+          </div>
 
-        {/* Date Range Filter */}
-        <Card>
-          <CardHeader><Label htmlFor='date-range-start'>Date Range</Label></CardHeader>
-          <CardContent className="space-y-2">
-            <div>
-                <Label htmlFor="date-range-start">Start Date</Label>
-                <Input type="date" id="date-range-start" aria-label="start date" value={startDate?.toISOString().split('T')[0] || ''} onChange={e => setStartDate(e.target.value ? new Date(e.target.value) : undefined)} />
-            </div>
-             <div>
-                <Label htmlFor="date-range-end">End Date</Label>
-                 <Input type="date" id="date-range-end" aria-label="end date" value={endDate?.toISOString().split('T')[0] || ''} onChange={e => setEndDate(e.target.value ? new Date(e.target.value) : undefined)} />
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-      
-      {/* Reset Filters Button */}
-      <Button variant="outline" onClick={resetFilters}>Reset Filters</Button>
+          <Button variant="outline" onClick={() => resetFilters(setSearchTerm)}>Reset Filters</Button>
 
-      {/* Results Area */}
-      <div className="mt-4">
-        {loading && <p>Loading...</p>}
-        {error && <p className="text-red-500">{error}</p>}
-        {!loading && !error && items.length === 0 && <p>No results found.</p>}
-        {!loading && !error && items.length > 0 && (
-          <ul className="space-y-2 list-none p-0">
-            {items.map(item => (
-              <li key={item.id} role="listitem">
-                <Card>
-                  <CardHeader><CardTitle>{item.title}</CardTitle></CardHeader>
-                  <CardContent>
-                    <p>Category: {item.category}</p>
-                    <p>Date: {item.date}</p>
-                  </CardContent>
-                </Card>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-    </div>
+          <div className="mt-4">
+            {isLoading && <p>Loading...</p>}
+            {error && <p className="text-red-500">{error}</p>}
+            {!isLoading && !error && results.length === 0 && <p>No results found.</p>}
+            {!isLoading && !error && results.length > 0 && (
+              <ul className="space-y-2 list-none p-0">
+                {results.map((item: SearchItem) => (
+                  <li key={item.id} role="listitem">
+                    <Card>
+                      <CardHeader><CardTitle>{item.title}</CardTitle></CardHeader>
+                      <CardContent>
+                        <p>Category: {item.category}</p>
+                        <p>Date: {item.date}</p>
+                      </CardContent>
+                    </Card>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    />
   );
 };
 
-export default SearchPage; 
+export default SearchPage;


### PR DESCRIPTION
## Summary
- use headless Dashboard, ConsentManagement, SearchPage, Features, and Footer inside styled counterparts
- add basic tests covering these wrappers

## Testing
- `npx vitest run --coverage` *(fails: 71 failed, 78 passed)*