### PR TITLE
Fix toast listener duplication

### DIFF
--- a/src/lib/hooks/__tests__/use-toast.test.tsx
+++ b/src/lib/hooks/__tests__/use-toast.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
+import { describe, test, expect } from 'vitest';
+import { useToast, toast } from '../use-toast';
+
+const renderCounts = { current: 0 };
+
+const TestComponent = () => {
+  renderCounts.current += 1;
+  useToast();
+  return null;
+};
+
+describe('useToast', () => {
+  test('registers listener only once', async () => {
+    render(<TestComponent />);
+
+    expect(renderCounts.current).toBe(1);
+
+    act(() => {
+      toast({ title: 'first' });
+    });
+
+    await waitFor(() => expect(renderCounts.current).toBe(2));
+
+    act(() => {
+      toast({ title: 'second' });
+    });
+
+    await waitFor(() => expect(renderCounts.current).toBe(3));
+  });
+});

--- a/src/lib/hooks/use-toast.tsx
+++ b/src/lib/hooks/use-toast.tsx
@@ -177,7 +177,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- ensure toast listener hook registers only once
- add regression test for multiple toast calls

## Testing
- `npx vitest run --coverage` *(fails: AuthService not registered; environment lacks network access)*