### PR TITLE
Remove outdated comment in InviteMemberForm test

### DIFF
--- a/src/components/team/__tests__/InviteMemberForm.test.tsx
+++ b/src/components/team/__tests__/InviteMemberForm.test.tsx
@@ -55,7 +55,7 @@ describe('InviteMemberForm', () => {
     expect(mockSendInvite).not.toHaveBeenCalled(); 
   });
 
-  // Un-skip the test and fix interaction with Radix UI Select
+  // Test form submission with valid data and correct Radix UI Select interaction
   it('submits form with valid data', async () => {
     const user = userEvent.setup();
     await act(async () => {


### PR DESCRIPTION
## Summary
- update InviteMemberForm test comment to reflect that it already runs

## Testing
- `npx vitest run --coverage` *(fails: 69 failed, 80 passed)*