### PR TITLE
Fix 20 lint issues

### DIFF
--- a/app/api/retention/reactivate/route.ts
+++ b/app/api/retention/reactivate/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { getSession } from '@/lib/auth/session';
 import { retentionService } from '@/lib/services/retention.service';
 
@@ -8,7 +8,7 @@ import { retentionService } from '@/lib/services/retention.service';
  * POST /api/retention/reactivate
  * Reactivates the user's account if it's in an inactive state
  */
-export async function POST(_request: NextRequest) {
+export async function POST() {
   try {
     // Get user session 
     const session = await getSession();

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -14,7 +14,6 @@ const SettingsSchema = z.object({
   // visibility: z.enum(['public', 'private']).optional(), 
 }).partial(); 
 
-type UserSettings = z.infer<typeof SettingsSchema>;
 
 // Fields to select/update in the profiles/user_preferences table
 // Need to decide if this API updates profiles OR user_preferences, or both?

--- a/app/api/team/invites/route.ts
+++ b/app/api/team/invites/route.ts
@@ -7,7 +7,6 @@ import { createProtectedHandler } from '@/middleware/permissions';
 import { Permission } from '@/lib/rbac/roles';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth/index';
-import { checkRolePermission } from '@/lib/rbac/roleService';
 
 const inviteSchema = z.object({
   email: z.string().email(),
@@ -15,7 +14,6 @@ const inviteSchema = z.object({
   teamLicenseId: z.string(),
 });
 
-type InviteRequest = z.infer<typeof inviteSchema>;
 
 // Define the main handler logic
 async function handler(req: NextRequest) {
@@ -38,7 +36,6 @@ async function handler(req: NextRequest) {
       return NextResponse.json({ error: 'Invoking user not found or not part of any team' }, { status: 403 });
     }
     // Assuming user belongs to one team for this context
-    const invokingUserRole = invokingUser.teamMemberships[0].role;
     const invokingUserTeamId = invokingUser.teamMemberships[0].teamId;
 
     const body = await req.json();
@@ -106,7 +103,7 @@ async function handler(req: NextRequest) {
 
     // Create invite
     const inviteToken = generateInviteToken();
-    const invite = await prisma.teamMember.create({
+    await prisma.teamMember.create({
       data: {
         teamLicenseId: validatedData.teamLicenseId,
         role: validatedData.role,

--- a/app/api/team/members/__tests__/route.test.ts
+++ b/app/api/team/members/__tests__/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { prisma } from '@/lib/database/prisma';
 import { GET } from '@/app/api/team/members/route';

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,7 +1,6 @@
 'use client'; // Required for hooks
 import '@/lib/i18n';
 
-import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Skeleton } from '@/ui/primitives/skeleton';
 import { Alert, AlertDescription } from '@/ui/primitives/alert';
@@ -26,10 +25,7 @@ export default function ProfilePage() {
     removeAvatar
   } = useUserProfile();
   
-  const {
-    changePassword,
-    deleteAccount
-  } = useAccountSettings();
+  useAccountSettings();
 
   // Show loading skeleton
   if (isLoading && !profile) {

--- a/app/settings/account/DeleteAccountDialog.tsx
+++ b/app/settings/account/DeleteAccountDialog.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDeleteAccount } from '@/hooks/useDeleteAccount';
 import { Button } from '@/ui/primitives/button';
 import { Input } from '@/ui/primitives/input';
@@ -12,7 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/ui/primitives/dialog';
-import { AlertCircle, Loader2 } from 'lucide-react';
+import { AlertCircle } from 'lucide-react';
 import { Alert, AlertDescription } from '@/ui/primitives/alert';
 
 interface DeleteAccountDialogProps {
@@ -23,7 +22,6 @@ interface DeleteAccountDialogProps {
 const CONFIRMATION_TEXT = 'DELETE';
 
 const DeleteAccountDialog: React.FC<DeleteAccountDialogProps> = ({ open, onClose }) => {
-  const { t } = useTranslation();
   const [confirmText, setConfirmText] = useState('');
   const { deleteAccount, isLoading, error } = useDeleteAccount();
 
@@ -63,7 +61,7 @@ const DeleteAccountDialog: React.FC<DeleteAccountDialogProps> = ({ open, onClose
               Confirm deletion
             </Label>
             <p className="text-sm text-muted-foreground">
-              Please type "DELETE" to confirm you want to delete your account
+              Please type &quot;DELETE&quot; to confirm you want to delete your account
             </p>
             <Input
               id="confirm-deletion"

--- a/app/settings/security/page.tsx
+++ b/app/settings/security/page.tsx
@@ -20,7 +20,6 @@ export default function SecuritySettingsPage() {
     setupMFA,
     verifyMFA,
     disableMFA,
-    setupData,
     isLoading,
     error,
     isMFAEnabled

--- a/app/teams/invitations/page.tsx
+++ b/app/teams/invitations/page.tsx
@@ -32,7 +32,6 @@ export default function TeamInvitationsPage() {
   } = useTeams();
   
   const {
-    invitations,
     pendingInvitations,
     sentInvitations,
     createInvitation,

--- a/app/teams/manage/page.tsx
+++ b/app/teams/manage/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Metadata } from 'next';
 import { Skeleton } from '@/ui/primitives/skeleton';
 import { Alert, AlertDescription } from '@/ui/primitives/alert';

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -28,8 +28,6 @@ export default function TeamDashboardPage() {
     selectedTeam,
     setSelectedTeam,
     createTeam,
-    updateTeam,
-    deleteTeam,
     isLoading: teamsLoading,
     error: teamsError
   } = useTeams();
@@ -45,7 +43,6 @@ export default function TeamDashboardPage() {
   
   const {
     invitations,
-    createInvitation,
     cancelInvitation,
     resendInvitation,
     isLoading: invitationsLoading,
@@ -201,7 +198,7 @@ export default function TeamDashboardPage() {
             <Card>
               <CardContent className="pt-6">
                 <p className="text-center text-muted-foreground">
-                  You don't have any teams yet. Create a team to get started.
+                  You don&apos;t have any teams yet. Create a team to get started.
                 </p>
               </CardContent>
             </Card>

--- a/app/update-password/page.tsx
+++ b/app/update-password/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';
 

--- a/src/components/account/DeleteAccountDialog.tsx
+++ b/src/components/account/DeleteAccountDialog.tsx
@@ -61,7 +61,7 @@ const DeleteAccountDialog: React.FC<DeleteAccountDialogProps> = ({ open, onClose
               Confirm deletion
             </Label>
             <p className="text-sm text-muted-foreground">
-              Please type "DELETE" to confirm you want to delete your account
+              Please type &quot;DELETE&quot; to confirm you want to delete your account
             </p>
             <Input
               id="confirm-deletion"


### PR DESCRIPTION
## Summary
- remove unused imports and variables
- fix react/no-unescaped-entities in DeleteAccountDialog components
- fix unescaped apostrophe in Teams page
- tidy imports across several pages

## Testing
- `npm run lint --silent -- --quiet`
- `npx vitest run --coverage` *(fails: 69 failed, 81 passed)*