### PR TITLE
Fix admin tests

### DIFF
--- a/src/ui/styled/account/__tests__/DeleteAccountDialog.test.tsx
+++ b/src/ui/styled/account/__tests__/DeleteAccountDialog.test.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest'; // Import vi
 import DeleteAccountDialog from '@/ui/styled/account/DeleteAccountDialog';
 import { useDeleteAccount } from '@/hooks/useDeleteAccount';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 
 // Mock the custom hook
 vi.mock('@/hooks/useDeleteAccount');


### PR DESCRIPTION
## Summary
- update DeleteAccountDialog test to use React's act
- rewrite AdminDashboard tests to use fetch mocks and check for periodic refresh
- update RoleManagementPanel tests to work with current RBAC API

## Testing
- `npx vitest run src/ui/styled/admin/__tests__/AdminDashboard.test.tsx --run --silent`
- `npx vitest run src/ui/styled/admin/__tests__/RoleManagementPanel.test.tsx --run --silent`
- `npx vitest run src/ui/styled/account/__tests__/DeleteAccountDialog.test.tsx --run --silent`
