### PR TITLE
Add basic Supabase adapter tests

### DIFF
--- a/src/adapters/auth/__tests__/supabase-auth-provider.test.ts
+++ b/src/adapters/auth/__tests__/supabase-auth-provider.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SupabaseAuthProvider } from '../supabase-auth-provider';
+import { supabase, resetSupabaseMock } from '@/tests/mocks/supabase';
+import type { LoginPayload, RegistrationPayload } from '@/core/auth/models';
+
+const SUPABASE_URL = 'http://localhost';
+const SUPABASE_KEY = 'anon';
+
+describe('SupabaseAuthProvider', () => {
+  beforeEach(() => {
+    resetSupabaseMock();
+  });
+
+  it('logs in a user using Supabase', async () => {
+    const provider = new SupabaseAuthProvider(SUPABASE_URL, SUPABASE_KEY);
+    const credentials: LoginPayload = { email: 'test@example.com', password: 'pw' };
+
+    const result = await provider.login(credentials);
+
+    expect(supabase.auth.signInWithPassword).toHaveBeenCalledWith({ email: 'test@example.com', password: 'pw' });
+    expect(result.success).toBe(true);
+    expect(result.user?.id).toBe('user-123');
+  });
+
+  it('registers a user using Supabase', async () => {
+    const provider = new SupabaseAuthProvider(SUPABASE_URL, SUPABASE_KEY);
+    const payload: RegistrationPayload = {
+      email: 'new@example.com',
+      password: 'pw',
+      firstName: 'New',
+      lastName: 'User'
+    };
+
+    const result = await provider.register(payload);
+
+    expect(supabase.auth.signUp).toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(result.user?.id).toBe('user-123');
+  });
+});

--- a/src/adapters/permission/__tests__/supabase-permission-provider.test.ts
+++ b/src/adapters/permission/__tests__/supabase-permission-provider.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SupabasePermissionProvider } from '../supabase-permission-provider';
+import { setTableMockData, resetSupabaseMock } from '@/tests/mocks/supabase';
+import type { Permission } from '@/core/permission/models';
+
+const SUPABASE_URL = 'http://localhost';
+const SUPABASE_KEY = 'anon';
+
+const userRoles = [
+  { user_id: 'user-1', role_id: 'role-1' }
+];
+const rolePermissions = [
+  { id: 'rp1', role_id: 'role-1', permission_name: 'edit', resource: 'doc' }
+];
+
+describe('SupabasePermissionProvider', () => {
+  beforeEach(() => {
+    resetSupabaseMock();
+    setTableMockData('user_roles', { data: userRoles, error: null });
+    setTableMockData('role_permissions', { data: rolePermissions, error: null });
+  });
+
+  it('checks user permission', async () => {
+    const provider = new SupabasePermissionProvider(SUPABASE_URL, SUPABASE_KEY);
+    const perm: Permission = { name: 'edit', resource: 'doc' };
+    const result = await provider.hasPermission('user-1', perm);
+
+    expect(result).toBe(true);
+  });
+});

--- a/src/adapters/team/__tests__/supabase-team-provider.test.ts
+++ b/src/adapters/team/__tests__/supabase-team-provider.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SupabaseTeamProvider } from '../supabase-team-provider';
+import { setTableMockData, resetSupabaseMock } from '@/tests/mocks/supabase';
+
+const SUPABASE_URL = 'http://localhost';
+const SUPABASE_KEY = 'anon';
+
+const teamRecord = {
+  id: 'team-1',
+  name: 'Team 1',
+  description: 'Desc',
+  owner_id: 'user-1',
+  is_public: false,
+  settings: {},
+  created_at: '2023-01-01T00:00:00Z',
+  updated_at: '2023-01-02T00:00:00Z'
+};
+
+describe('SupabaseTeamProvider', () => {
+  beforeEach(() => {
+    resetSupabaseMock();
+    setTableMockData('teams', { data: [teamRecord], error: null });
+  });
+
+  it('retrieves a team by id', async () => {
+    const provider = new SupabaseTeamProvider(SUPABASE_URL, SUPABASE_KEY);
+    const result = await provider.getTeam('team-1');
+
+    expect(result).toEqual({
+      id: 'team-1',
+      name: 'Team 1',
+      description: 'Desc',
+      ownerId: 'user-1',
+      isPublic: false,
+      settings: {},
+      createdAt: new Date('2023-01-01T00:00:00Z'),
+      updatedAt: new Date('2023-01-02T00:00:00Z')
+    });
+  });
+});

--- a/src/adapters/user/__tests__/supabase-user-provider.test.ts
+++ b/src/adapters/user/__tests__/supabase-user-provider.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SupabaseUserProvider } from '../supabase-user-provider';
+import { setTableMockData, resetSupabaseMock } from '@/tests/mocks/supabase';
+
+const SUPABASE_URL = 'http://localhost';
+const SUPABASE_KEY = 'anon';
+
+const sampleProfile = {
+  user_id: 'user-1',
+  email: 'user@example.com',
+  first_name: 'Test',
+  last_name: 'User',
+  display_name: 'Tester',
+  bio: 'bio',
+  location: 'here',
+  website: 'https://example.com',
+  avatar_url: 'https://example.com/avatar.png',
+  is_active: true,
+  account_type: 'personal',
+  account_data: {},
+  created_at: '2023-01-01T00:00:00Z',
+  updated_at: '2023-01-02T00:00:00Z',
+  deactivated_at: null,
+  deactivation_reason: null
+};
+
+describe('SupabaseUserProvider', () => {
+  beforeEach(() => {
+    resetSupabaseMock();
+    setTableMockData('profiles', { data: [sampleProfile], error: null });
+  });
+
+  it('retrieves a user profile', async () => {
+    const provider = new SupabaseUserProvider(SUPABASE_URL, SUPABASE_KEY);
+    const result = await provider.getUserProfile('user-1');
+
+    expect(result).toEqual({
+      userId: 'user-1',
+      email: 'user@example.com',
+      firstName: 'Test',
+      lastName: 'User',
+      displayName: 'Tester',
+      bio: 'bio',
+      location: 'here',
+      website: 'https://example.com',
+      avatarUrl: 'https://example.com/avatar.png',
+      isActive: true,
+      accountType: 'personal',
+      accountData: {},
+      createdAt: new Date('2023-01-01T00:00:00Z'),
+      updatedAt: new Date('2023-01-02T00:00:00Z'),
+      deactivatedAt: null,
+      deactivationReason: null
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for each Supabase adapter implementation
- tests use the existing supabase mock to verify behaviour

## Testing
- `npx vitest run --coverage src/adapters/auth/__tests__/supabase-auth-provider.test.ts src/adapters/user/__tests__/supabase-user-provider.test.ts src/adapters/team/__tests__/supabase-team-provider.test.ts src/adapters/permission/__tests__/supabase-permission-provider.test.ts`