### PR TITLE
Improve service error handling and events

### DIFF
--- a/src/lib/utils/__tests__/error.test.ts
+++ b/src/lib/utils/__tests__/error.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { translateError } from '../error';
+
+describe('translateError', () => {
+  it('returns translated message for known code', () => {
+    const error = { code: 'INVALID_CREDENTIALS' };
+    expect(translateError(error)).toBe('Invalid email or password.');
+  });
+
+  it('prefers message from response when available', () => {
+    const error = { response: { data: { error: 'Custom message' } } };
+    expect(translateError(error)).toBe('Custom message');
+  });
+
+  it('falls back to default message', () => {
+    const error = {};
+    expect(translateError(error, { defaultMessage: 'Default' })).toBe('Default');
+  });
+});

--- a/src/lib/utils/__tests__/typed-event-emitter.test.ts
+++ b/src/lib/utils/__tests__/typed-event-emitter.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { TypedEventEmitter } from '../typed-event-emitter';
+
+interface TestEvent {
+  type: 'a' | 'b';
+  payload: string;
+}
+
+describe('TypedEventEmitter', () => {
+  it('emits events to subscribers', () => {
+    const emitter = new TypedEventEmitter<TestEvent>();
+    const received: TestEvent[] = [];
+    emitter.on(e => received.push(e));
+
+    emitter.emit({ type: 'a', payload: 'foo' });
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual({ type: 'a', payload: 'foo' });
+  });
+
+  it('filters by type with onType', () => {
+    const emitter = new TypedEventEmitter<TestEvent>();
+    const received: TestEvent[] = [];
+    emitter.onType('b', e => received.push(e));
+
+    emitter.emit({ type: 'a', payload: 'foo' });
+    emitter.emit({ type: 'b', payload: 'bar' });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual({ type: 'b', payload: 'bar' });
+  });
+});

--- a/src/lib/utils/error.ts
+++ b/src/lib/utils/error.ts
@@ -1,0 +1,32 @@
+export interface TranslateErrorOptions {
+  /** Default message if no specific message is found */
+  defaultMessage?: string;
+}
+
+/**
+ * Known error code translations
+ */
+const ERROR_TRANSLATIONS: Record<string, string> = {
+  EMAIL_NOT_VERIFIED: 'Email not verified. Please verify your email.',
+  INVALID_CREDENTIALS: 'Invalid email or password.',
+  RATE_LIMIT_EXCEEDED: 'Too many requests. Please try again later.',
+  MFA_REQUIRED: 'Multi-factor authentication required.',
+  TEAM_NOT_FOUND: 'Team not found.',
+  USER_NOT_FOUND: 'User not found.'
+};
+
+/**
+ * Translate an error object into a user-friendly message.
+ * Falls back to the provided default message when no translation is found.
+ */
+export function translateError(error: any, options: TranslateErrorOptions = {}): string {
+  const code = error?.code || error?.response?.data?.code;
+  if (code && ERROR_TRANSLATIONS[code]) {
+    return ERROR_TRANSLATIONS[code];
+  }
+  const message = error?.response?.data?.error || error?.message;
+  if (typeof message === 'string' && message.trim().length > 0) {
+    return message;
+  }
+  return options.defaultMessage || 'An unexpected error occurred';
+}

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -4,3 +4,6 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export * from './error'
+export * from './typed-event-emitter'

--- a/src/lib/utils/typed-event-emitter.ts
+++ b/src/lib/utils/typed-event-emitter.ts
@@ -1,0 +1,26 @@
+export class TypedEventEmitter<T extends { type: string }> {
+  private handlers: Array<(event: T) => void> = [];
+
+  /** Emit an event to all listeners */
+  emit(event: T): void {
+    this.handlers.forEach(h => h(event));
+  }
+
+  /** Subscribe to all events */
+  on(handler: (event: T) => void): () => void {
+    this.handlers.push(handler);
+    return () => {
+      this.handlers = this.handlers.filter(h => h !== handler);
+    };
+  }
+
+  /** Subscribe only to a specific event type */
+  onType<K extends T['type']>(type: K, handler: (event: Extract<T, { type: K }>) => void): () => void {
+    const wrapped = (event: T) => {
+      if (event.type === type) {
+        handler(event as Extract<T, { type: K }>);
+      }
+    };
+    return this.on(wrapped);
+  }
+}

--- a/src/services/auth/default-auth.service.ts
+++ b/src/services/auth/default-auth.service.ts
@@ -18,18 +18,22 @@ import {
   User 
 } from '@/core/auth/models';
 import { AuthEventHandler, AuthEventTypes } from '@/core/auth/events';
+import { translateError } from '@/lib/utils/error';
+import { TypedEventEmitter } from '@/lib/utils/typed-event-emitter';
 
 /**
  * Default implementation of the AuthService interface
  */
-export class DefaultAuthService implements AuthService {
+export class DefaultAuthService
+  extends TypedEventEmitter<AuthEventTypes>
+  implements AuthService
+{
   private user: User | null = null;
   private token: string | null = null;
   private isLoading = false;
   private error: string | null = null;
   private successMessage: string | null = null;
   private mfaEnabled = false;
-  private eventHandlers: AuthEventHandler[] = [];
   
   // Session management
   private sessionCheckTimer: NodeJS.Timeout | null = null;
@@ -47,6 +51,7 @@ export class DefaultAuthService implements AuthService {
     private apiClient: any, // This would be replaced with a proper API client interface
     private authDataProvider: any // This would be replaced with a proper auth data provider interface
   ) {
+    super();
     // Initialize session check if there's a stored token
     this.initializeFromStorage();
   }
@@ -144,7 +149,7 @@ export class DefaultAuthService implements AuthService {
    * @param event - The event to emit
    */
   private emitEvent(event: AuthEventTypes): void {
-    this.eventHandlers.forEach(handler => handler(event));
+    this.emit(event);
   }
 
   /**
@@ -192,7 +197,7 @@ export class DefaultAuthService implements AuthService {
         token: response.data.token
       };
     } catch (error: any) {
-      const errorMessage = error.response?.data?.error || 'An error occurred during login';
+      const errorMessage = translateError(error, { defaultMessage: 'An error occurred during login' });
       const errorCode = error.response?.data?.code;
       
       this.isLoading = false;
@@ -241,7 +246,7 @@ export class DefaultAuthService implements AuthService {
       
       return { success: true };
     } catch (error: any) {
-      const errorMessage = error.response?.data?.error || error.message || 'Registration failed';
+      const errorMessage = translateError(error, { defaultMessage: 'Registration failed' });
       
       this.isLoading = false;
       this.error = errorMessage;
@@ -331,7 +336,7 @@ export class DefaultAuthService implements AuthService {
       
       return { success: true, message: 'Password reset email sent.' };
     } catch (error: any) {
-      const errorMessage = error.response?.data?.error || 'Failed to send password reset email.';
+      const errorMessage = translateError(error, { defaultMessage: 'Failed to send password reset email.' });
       
       this.isLoading = false;
       this.error = errorMessage;
@@ -725,18 +730,11 @@ export class DefaultAuthService implements AuthService {
    * @returns Unsubscribe function
    */
   onAuthStateChanged(callback: (user: User | null) => void): () => void {
-    const handler = (event: AuthEventTypes) => {
+    return this.on(event => {
       if (event.type === 'LOGIN' || event.type === 'LOGOUT' || event.type === 'SESSION_TIMEOUT') {
         callback(this.user);
       }
-    };
-    
-    this.eventHandlers.push(handler);
-    
-    // Return unsubscribe function
-    return () => {
-      this.eventHandlers = this.eventHandlers.filter(h => h !== handler);
-    };
+    });
   }
 
   /**
@@ -746,11 +744,6 @@ export class DefaultAuthService implements AuthService {
    * @returns Unsubscribe function
    */
   onAuthEvent(handler: AuthEventHandler): () => void {
-    this.eventHandlers.push(handler);
-    
-    // Return unsubscribe function
-    return () => {
-      this.eventHandlers = this.eventHandlers.filter(h => h !== handler);
-    };
+    return this.on(handler);
   }
 }

--- a/src/services/permission/default-permission.service.ts
+++ b/src/services/permission/default-permission.service.ts
@@ -19,16 +19,20 @@ import {
   RoleUpdatePayload,
   DefaultRoleDefinitions
 } from '@/core/permission/models';
-import { 
-  PermissionEventTypes, 
-  PermissionEventHandler 
+import {
+  PermissionEventTypes,
+  PermissionEventHandler
 } from '@/core/permission/events';
+import { translateError } from '@/lib/utils/error';
+import { TypedEventEmitter } from '@/lib/utils/typed-event-emitter';
 
 /**
  * Default implementation of the PermissionService interface
  */
-export class DefaultPermissionService implements PermissionService {
-  private eventHandlers: PermissionEventHandler[] = [];
+export class DefaultPermissionService
+  extends TypedEventEmitter<PermissionEventTypes>
+  implements PermissionService
+{
   
   /**
    * Constructor for DefaultPermissionService
@@ -39,7 +43,9 @@ export class DefaultPermissionService implements PermissionService {
   constructor(
     private apiClient: any, // This would be replaced with a proper API client interface
     private permissionDataProvider: any // This would be replaced with a proper permission data provider interface
-  ) {}
+  ) {
+    super();
+  }
   
   /**
    * Emit a permission event
@@ -47,7 +53,7 @@ export class DefaultPermissionService implements PermissionService {
    * @param event - The event to emit
    */
   private emitEvent(event: PermissionEventTypes): void {
-    this.eventHandlers.forEach(handler => handler(event));
+    this.emit(event);
   }
   
   /**
@@ -470,11 +476,6 @@ export class DefaultPermissionService implements PermissionService {
    * @returns Unsubscribe function
    */
   onPermissionEvent(handler: PermissionEventHandler): () => void {
-    this.eventHandlers.push(handler);
-    
-    // Return unsubscribe function
-    return () => {
-      this.eventHandlers = this.eventHandlers.filter(h => h !== handler);
-    };
+    return this.on(handler);
   }
 }


### PR DESCRIPTION
## Summary
- add utility to translate errors
- add generic typed event emitter
- use new emitter in default service classes
- normalize error handling via new translateError
- export new utilities
- test utilities

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*