### PR TITLE
Add tests for MFA and profile components

### DIFF
--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/alert';

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/button';

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/card';

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/dialog';

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/form';

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/input';

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/label';

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/radio-group';

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/separator';

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/switch';

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/tabs';

--- a/src/ui/styled/auth/__tests__/ChangePasswordForm.test.tsx
+++ b/src/ui/styled/auth/__tests__/ChangePasswordForm.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ChangePasswordForm } from '../ChangePasswordForm';
+
+let formState: any;
+
+vi.mock('../../../headless/auth/ChangePasswordForm', () => ({
+  ChangePasswordForm: ({ children }: any) => children(formState)
+}));
+
+describe('ChangePasswordForm styled component', () => {
+  beforeEach(() => {
+    formState = {
+      handleSubmit: vi.fn((e: any) => e.preventDefault()),
+      currentPasswordValue: '',
+      setCurrentPasswordValue: vi.fn(),
+      newPasswordValue: '',
+      setNewPasswordValue: vi.fn(),
+      confirmPasswordValue: '',
+      setConfirmPasswordValue: vi.fn(),
+      isSubmitting: false,
+      isValid: true,
+      errors: {},
+      touched: { currentPassword: false, newPassword: false, confirmPassword: false },
+      handleBlur: vi.fn(),
+      successMessage: null
+    };
+  });
+
+  it('submits the form via headless handler', async () => {
+    const user = userEvent.setup();
+    render(<ChangePasswordForm />);
+    await user.type(screen.getByLabelText('Current Password'), 'old');
+    await user.type(screen.getByLabelText('New Password'), 'newpass1A');
+    await user.type(screen.getByLabelText('Confirm New Password'), 'newpass1A');
+    await user.click(screen.getByRole('button', { name: 'Update Password' }));
+    expect(formState.handleSubmit).toHaveBeenCalled();
+  });
+
+  it('shows success alert when provided', () => {
+    formState.successMessage = 'done';
+    render(<ChangePasswordForm />);
+    expect(screen.getByText('Success!')).toBeInTheDocument();
+    expect(screen.getByText('done')).toBeInTheDocument();
+  });
+});

--- a/src/ui/styled/auth/__tests__/MFASetup.test.tsx
+++ b/src/ui/styled/auth/__tests__/MFASetup.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, beforeEach, describe, it, expect } from 'vitest';
+import { MFASetup } from '../MFASetup';
+
+let state: any;
+
+vi.mock('../../../headless/auth/MFASetup', () => ({
+  MFASetup: ({ render }: any) => render(state)
+}));
+
+describe('MFASetup styled component', () => {
+  beforeEach(() => {
+    state = {
+      handleSubmit: vi.fn(),
+      verificationCode: '',
+      setVerificationCode: vi.fn(),
+      selectedMethod: 'totp',
+      setSelectedMethod: vi.fn(),
+      availableMethods: [{ id: 'totp', name: 'TOTP', description: 'desc' }],
+      qrCodeUrl: 'qr.png',
+      secretKey: 'SECRET',
+      isSubmitting: false,
+      isSuccess: false,
+      errors: {},
+      backupCodes: [],
+      handleBackupCodeDownload: vi.fn(),
+      handleBackupCodeCopy: vi.fn()
+    };
+  });
+
+  it('renders setup form when not completed', () => {
+    render(<MFASetup />);
+    expect(screen.getByText('Select Authentication Method')).toBeInTheDocument();
+    expect(screen.getByLabelText('Verification Code')).toBeInTheDocument();
+  });
+
+  it('renders success state and handles actions', async () => {
+    const user = userEvent.setup();
+    state.isSuccess = true;
+    state.backupCodes = ['111', '222'];
+    render(<MFASetup />);
+    expect(screen.getByText('Two-Factor Authentication Enabled')).toBeInTheDocument();
+    expect(screen.getByText('111')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /download codes/i }));
+    expect(state.handleBackupCodeDownload).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /copy codes/i }));
+    expect(state.handleBackupCodeCopy).toHaveBeenCalled();
+  });
+});

--- a/src/ui/styled/auth/__tests__/MFAVerificationForm.test.tsx
+++ b/src/ui/styled/auth/__tests__/MFAVerificationForm.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { MFAVerificationForm } from '../MFAVerificationForm';
+import { api } from '@/lib/api/axios';
+
+vi.mock('@/lib/api/axios', () => ({ api: { post: vi.fn() } }));
+
+const mockPost = api.post as unknown as ReturnType<typeof vi.fn>;
+
+describe('MFAVerificationForm styled component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('submits code and calls onSuccess', async () => {
+    const user = userEvent.setup();
+    mockPost.mockResolvedValueOnce({ data: { user: { id: 'u1' }, token: 'tok' } });
+    const onSuccess = vi.fn();
+    render(<MFAVerificationForm accessToken="abc" onSuccess={onSuccess} />);
+    await user.type(screen.getByPlaceholderText('000000'), '123456');
+    await user.click(screen.getByRole('button', { name: '[i18n:auth.mfa.verifyButton]' }));
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith({ id: 'u1' }, 'tok');
+    });
+  });
+
+  it('shows error on failure', async () => {
+    const user = userEvent.setup();
+    mockPost.mockRejectedValueOnce({ response: { data: { error: 'Invalid' } } });
+    render(<MFAVerificationForm accessToken="abc" onSuccess={vi.fn()} />);
+    await user.type(screen.getByPlaceholderText('000000'), '123456');
+    await user.click(screen.getByRole('button', { name: '[i18n:auth.mfa.verifyButton]' }));
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Invalid');
+    });
+  });
+
+  it('toggles backup code input', async () => {
+    const user = userEvent.setup();
+    render(<MFAVerificationForm accessToken="abc" onSuccess={vi.fn()} />);
+    await user.click(screen.getByRole('button', { name: '[i18n:auth.mfa.useBackupCode]' }));
+    expect(screen.getByPlaceholderText('XXXX-XXXX')).toBeInTheDocument();
+  });
+});

--- a/src/ui/styled/profile/__tests__/AccountSettings.test.tsx
+++ b/src/ui/styled/profile/__tests__/AccountSettings.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { AccountSettings } from '../AccountSettings';
+
+let accState: any;
+
+vi.mock('../../../headless/profile/AccountSettings', () => ({
+  AccountSettings: ({ render }: any) => render(accState)
+}));
+
+describe('AccountSettings styled component', () => {
+  beforeEach(() => {
+    accState = {
+      handlePasswordChange: vi.fn((e: any) => e.preventDefault()),
+      handleDeleteAccount: vi.fn(),
+      handlePrivacySettingsChange: vi.fn((e: any) => e.preventDefault()),
+      handleSecuritySettingsChange: vi.fn((e: any) => e.preventDefault()),
+      passwordForm: { currentPassword: '', newPassword: '', confirmPassword: '' },
+      updatePasswordForm: vi.fn(),
+      deleteAccountConfirmation: '',
+      updateDeleteConfirmation: vi.fn(),
+      privacySettings: {
+        profileVisibility: 'public',
+        activityTracking: false,
+        communicationEmails: false,
+        marketingEmails: false
+      },
+      securitySettings: {
+        twoFactorEnabled: false,
+        loginNotifications: false,
+        deviceManagement: false
+      },
+      isSubmitting: false,
+      isSuccess: false,
+      errors: {},
+      touched: { currentPassword: false, newPassword: false, confirmPassword: false },
+      handleBlur: vi.fn(),
+      sessions: [],
+      handleSessionLogout: vi.fn(),
+      connectedAccounts: [],
+      handleDisconnectAccount: vi.fn(),
+      handleConnectAccount: vi.fn(),
+      exportData: vi.fn(),
+      isExporting: false
+    };
+  });
+
+  it('submits password form via handler', async () => {
+    const user = userEvent.setup();
+    render(<AccountSettings />);
+    await user.type(screen.getByLabelText('Current Password'), 'old');
+    await user.type(screen.getByLabelText('New Password'), 'newpass1A');
+    await user.type(screen.getByLabelText('Confirm New Password'), 'newpass1A');
+    await user.click(screen.getByRole('button', { name: /update password/i }));
+    expect(accState.handlePasswordChange).toHaveBeenCalled();
+  });
+
+  it('shows success alert when isSuccess is true', () => {
+    accState.isSuccess = true;
+    render(<AccountSettings />);
+    expect(screen.getByText('Settings updated successfully')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- create re-exports for UI primitives under `src/components/ui`
- add MFASetup tests
- add MFAVerificationForm tests
- add ChangePasswordForm tests
- add AccountSettings tests

## Testing
- `npx vitest run --coverage src/ui/styled/auth/__tests__/MFASetup.test.tsx src/ui/styled/auth/__tests__/MFAVerificationForm.test.tsx src/ui/styled/auth/__tests__/ChangePasswordForm.test.tsx src/ui/styled/profile/__tests__/AccountSettings.test.tsx`