### PR TITLE
Add integration tests for useAuth hook

### DIFF
--- a/src/hooks/auth/__tests__/use-auth.integration.test.ts
+++ b/src/hooks/auth/__tests__/use-auth.integration.test.ts
@@ -1,0 +1,126 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useAuth } from '../useAuth';
+import { UserManagementConfiguration } from '@/core/config';
+import type { AuthService } from '@/core/auth/interfaces';
+import type { AuthDataProvider } from '@/adapters/auth/interfaces';
+import { DefaultAuthService } from '@/services/auth/default-auth.service';
+
+// helper to build minimal auth service mocks
+function createMockAuthService(): AuthService {
+  return {
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    getCurrentUser: vi.fn(),
+    isAuthenticated: vi.fn(),
+    resetPassword: vi.fn(),
+    updatePassword: vi.fn(),
+    sendVerificationEmail: vi.fn(),
+    verifyEmail: vi.fn(),
+    deleteAccount: vi.fn(),
+    setupMFA: vi.fn(),
+    verifyMFA: vi.fn(),
+    disableMFA: vi.fn(),
+    refreshToken: vi.fn(),
+    handleSessionTimeout: vi.fn(),
+    onAuthStateChanged: vi.fn().mockReturnValue(() => {}),
+  };
+}
+
+function createMockAdapter(): AuthDataProvider {
+  return {
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    getCurrentUser: vi.fn(),
+    resetPassword: vi.fn(),
+    updatePassword: vi.fn(),
+    sendVerificationEmail: vi.fn(),
+    verifyEmail: vi.fn(),
+    deleteAccount: vi.fn(),
+    setupMFA: vi.fn(),
+    verifyMFA: vi.fn(),
+    disableMFA: vi.fn(),
+    refreshToken: vi.fn(),
+    onAuthStateChanged: vi.fn().mockReturnValue(() => {}),
+  };
+}
+
+describe('useAuth integration', () => {
+  beforeEach(() => {
+    UserManagementConfiguration.reset();
+  });
+
+  afterEach(() => {
+    UserManagementConfiguration.reset();
+    vi.restoreAllMocks();
+  });
+
+  it('calls the auth service from the hook', async () => {
+    const service = createMockAuthService();
+    (service.login as any).mockResolvedValue({ success: true, user: { id: '1', email: 'a@test.com' } });
+
+    UserManagementConfiguration.configureServiceProviders({ authService: service });
+
+    const { result } = renderHook(() => useAuth());
+
+    await act(async () => {
+      await result.current.login({ email: 'a@test.com', password: 'pass' });
+    });
+
+    expect(service.login).toHaveBeenCalledWith({ email: 'a@test.com', password: 'pass' });
+  });
+
+  it('auth service uses the configured adapter', async () => {
+    const adapter = createMockAdapter();
+    (adapter.login as any).mockResolvedValue({ success: true, user: { id: '2', email: 'b@test.com' } });
+
+    // Minimal service that delegates to adapter
+    const service: AuthService = {
+      ...createMockAuthService(),
+      login: (creds) => adapter.login(creds),
+    };
+
+    UserManagementConfiguration.configureServiceProviders({ authService: service });
+
+    const { result } = renderHook(() => useAuth());
+
+    await act(async () => {
+      await result.current.login({ email: 'b@test.com', password: 'pw' });
+    });
+
+    expect(adapter.login).toHaveBeenCalledWith({ email: 'b@test.com', password: 'pw' });
+  });
+
+  it('handles API responses and errors from the service', async () => {
+    const adapter = createMockAdapter();
+    const apiClient = {
+      post: vi
+        .fn()
+        .mockResolvedValueOnce({ data: { user: { id: '3', email: 'c@test.com' }, token: 'tok' } })
+        .mockRejectedValueOnce({ response: { data: { error: 'Invalid credentials' } } }),
+    } as any;
+
+    const service = new DefaultAuthService(apiClient, adapter);
+    UserManagementConfiguration.configureServiceProviders({ authService: service });
+
+    const { result } = renderHook(() => useAuth());
+
+    // allow effect subscription to run
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.login({ email: 'c@test.com', password: 'good' });
+    });
+
+    expect(apiClient.post).toHaveBeenCalledWith('/api/auth/login', { email: 'c@test.com', password: 'good' });
+
+    await act(async () => {
+      await result.current.login({ email: 'c@test.com', password: 'bad' });
+    });
+
+    expect(result.current.error).toBe('Invalid credentials');
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add integration tests for the useAuth hook covering service calls, adapter usage and API handling

## Testing
- `npx vitest run --coverage src/hooks/auth/__tests__/use-auth.integration.test.ts`