### PR TITLE
Add tests for key UI components

### DIFF
--- a/src/ui/styled/layout/__tests__/Header.test.tsx
+++ b/src/ui/styled/layout/__tests__/Header.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@/tests/test-utils';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Header } from '../Header';
+
+let authState: any;
+let logoutMock: any;
+
+vi.mock('@/hooks/auth/useAuth', () => ({
+  useAuth: () => authState,
+}));
+vi.mock('@/lib/auth/UserManagementProvider', () => ({
+  useUserManagement: () => ({ isNative: false, platform: 'web' }),
+}));
+vi.mock('@/lib/utils/responsive', () => ({
+  useIsMobile: () => false,
+}));
+vi.mock('@/hooks/utils/usePlatformStyles', () => ({
+  getPlatformClasses: () => 'header',
+}));
+
+describe('Header component', () => {
+  beforeEach(() => {
+    logoutMock = vi.fn();
+    authState = { user: null, isLoading: false, logout: logoutMock };
+  });
+
+  it('shows login link when user is not authenticated', () => {
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link', { name: /login/i })).toBeInTheDocument();
+  });
+
+  it('calls logout when logout menu item is clicked', async () => {
+    authState.user = { id: '1' };
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    );
+    await user.click(screen.getByRole('button', { name: /profile.menu/i }));
+    await user.click(screen.getByRole('menuitem', { name: /logout/i }));
+    expect(logoutMock).toHaveBeenCalled();
+  });
+});

--- a/src/ui/styled/profile/__tests__/ProfileForm.test.tsx
+++ b/src/ui/styled/profile/__tests__/ProfileForm.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen, waitFor } from '@/tests/test-utils';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ProfileForm } from '../ProfileForm';
+import { createMockProfileStore } from '@/tests/mocks/profile.store.mock';
+
+let store: any;
+let updateProfileMock: any;
+
+vi.mock('@/lib/stores/profile.store', () => ({
+  useProfileStore: () => store,
+}));
+vi.mock('@/hooks/auth/useAuth', () => ({
+  useAuth: () => ({ user: { email: 'user@example.com' } }),
+}));
+vi.mock('@/components/ui/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+describe('ProfileForm component', () => {
+  beforeEach(() => {
+    updateProfileMock = vi.fn();
+    store = createMockProfileStore(
+      {
+        profile: {
+          id: '1',
+          first_name: 'John',
+          last_name: 'Doe',
+          bio: 'Old bio',
+          phone_number: '123',
+          address: '123 St',
+          city: 'City',
+          state: 'State',
+          country: 'Country',
+          postal_code: '12345',
+          website: 'https://example.com',
+          is_public: true,
+        },
+        isLoading: false,
+        error: null,
+      },
+      { updateProfile: updateProfileMock, fetchProfile: vi.fn() }
+    );
+  });
+
+  it('toggles edit mode and submits updates', async () => {
+    const user = userEvent.setup();
+    render(<ProfileForm />);
+
+    await user.click(screen.getByRole('button', { name: /edit profile/i }));
+    await user.clear(screen.getByLabelText('Bio'));
+    await user.type(screen.getByLabelText('Bio'), 'New bio');
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(updateProfileMock).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/ui/styled/session/__tests__/SessionTimeout.test.tsx
+++ b/src/ui/styled/session/__tests__/SessionTimeout.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen } from '@/tests/test-utils';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SessionTimeout } from '../SessionTimeout';
+
+let logoutMock: any;
+
+vi.mock('@/hooks/auth/useAuth', () => ({
+  useAuth: () => ({ logout: logoutMock }),
+}));
+
+describe('SessionTimeout component', () => {
+  beforeEach(() => {
+    logoutMock = vi.fn();
+  });
+
+  it('calls logout and onClose when button clicked', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<SessionTimeout isOpen={true} onClose={onClose} />);
+    await user.click(screen.getByRole('button', { name: /log in again/i }));
+    expect(logoutMock).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/ui/styled/settings/__tests__/AccountDeletion.test.tsx
+++ b/src/ui/styled/settings/__tests__/AccountDeletion.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen } from '@/tests/test-utils';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AccountDeletion } from '../AccountDeletion';
+
+let deleteAccountMock: any;
+
+vi.mock('@/hooks/auth/useAuth', () => ({
+  useAuth: () => ({
+    deleteAccount: deleteAccountMock,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('@/components/ui/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+describe('AccountDeletion component', () => {
+  beforeEach(() => {
+    deleteAccountMock = vi.fn();
+  });
+
+  it('opens dialog and confirms deletion', async () => {
+    const user = userEvent.setup();
+    render(<AccountDeletion />);
+
+    await user.click(screen.getByRole('button', { name: /delete/i }));
+    await user.type(screen.getByLabelText(/password/i), 'pass');
+    await user.type(screen.getByPlaceholderText('DELETE'), 'DELETE');
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+    expect(deleteAccountMock).toHaveBeenCalledWith('pass');
+  });
+});


### PR DESCRIPTION
## Summary
- add Header component tests for login/logout display
- add ProfileForm tests covering edit and submit
- add SessionTimeout test for logout
- add AccountDeletion dialog confirmation test

## Testing
- `npm run test:coverage` *(fails: useAuthStore is not defined and other errors)*