### PR TITLE
Add integration tests for auth hook usage

### DIFF
--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/textarea';

--- a/src/components/ui/use-toast.ts
+++ b/src/components/ui/use-toast.ts
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/use-toast';

--- a/src/ui/headless/auth/__tests__/MFASetup.integration.test.tsx
+++ b/src/ui/headless/auth/__tests__/MFASetup.integration.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { MFASetup } from '../MFASetup';
+import { useAuth } from '@/hooks/auth/useMFA';
+
+vi.mock('@/hooks/auth/useMFA', () => ({
+  useAuth: vi.fn(),
+}));
+
+// Helper to render component and return props from render prop
+function renderSetup() {
+  let captured: any;
+  render(
+    <MFASetup
+      render={(props) => {
+        captured = props;
+        return null;
+      }}
+    />
+  );
+  if (!captured) throw new Error('Props not captured');
+  return captured;
+}
+
+describe('MFASetup integration', () => {
+  it('calls setupMFA when handleStartSetup is invoked', async () => {
+    const setupMFA = vi.fn().mockResolvedValue({ success: true });
+    (useAuth as any).mockReturnValue({
+      setupMFA,
+      verifyMFA: vi.fn(),
+      isLoading: false,
+      error: null,
+    });
+
+    const props = renderSetup();
+    await act(async () => {
+      await props.handleStartSetup();
+    });
+    expect(setupMFA).toHaveBeenCalled();
+  });
+
+});

--- a/src/ui/styled/profile/__tests__/ProfileForm.test.tsx
+++ b/src/ui/styled/profile/__tests__/ProfileForm.test.tsx
@@ -17,6 +17,9 @@ vi.mock('@/hooks/auth/useAuth', () => ({
 vi.mock('@/components/ui/use-toast', () => ({
   useToast: () => ({ toast: vi.fn() }),
 }));
+vi.mock('@/components/ui/textarea', () => ({
+  Textarea: (props: any) => <textarea {...props} />,
+}));
 
 describe('ProfileForm component', () => {
   beforeEach(() => {
@@ -56,5 +59,10 @@ describe('ProfileForm component', () => {
     await waitFor(() => {
       expect(updateProfileMock).toHaveBeenCalled();
     });
+  });
+
+  it('displays the current user\'s email from the auth hook', () => {
+    render(<ProfileForm />);
+    expect(screen.getByText('user@example.com')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add missing textarea and use-toast UI exports
- test MFASetup component integration with useMFA hook
- test ProfileForm renders email from useAuth hook

## Testing
- `npx vitest run src/ui/headless/auth/__tests__/MFASetup.integration.test.tsx src/ui/styled/profile/__tests__/ProfileForm.test.tsx --testNamePattern "displays the current user's email|MFASetup" --coverage`