### PR TITLE
Refactor admin styled components to use headless logic

### DIFF
--- a/src/tests/integration/admin-users-flow.test.tsx
+++ b/src/tests/integration/admin-users-flow.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { AdminUsers } from '../../components/admin/AdminUsers';
+import { AdminUsers } from '@/ui/styled/admin/AdminUsers';
 import { describe, expect, beforeEach, vi } from 'vitest';
 import { UserType } from '@/types/user-type';
 
@@ -18,7 +18,7 @@ let fetchUsersMock: () => Promise<typeof mockUsersList>;
 let handleRoleChangeMock: (user: any, newRole: string) => Promise<any>;
 
 // Mock the AdminUsers component's dependencies
-vi.mock('../../components/admin/AdminUsers', async (importOriginal: () => Promise<any>) => {
+vi.mock('@/ui/styled/admin/AdminUsers', async (importOriginal: () => Promise<any>) => {
   const actual = await importOriginal();
   return {
     ...actual,

--- a/src/ui/styled/admin/AdminDashboard.tsx
+++ b/src/ui/styled/admin/AdminDashboard.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from '@tanstack/react-query';
 import {
   Card,
   CardContent,
@@ -18,222 +17,187 @@ import {
   CreditCard,
   Activity,
 } from 'lucide-react';
-
-interface DashboardData {
-  team: {
-    activeMembers: number;
-    pendingMembers: number;
-    totalMembers: number;
-    seatUsage: {
-      used: number;
-      total: number;
-      percentage: number;
-    };
-  };
-  subscription: {
-    plan: string;
-    status: string;
-    trialEndsAt: string | null;
-    currentPeriodEndsAt: string | null;
-  };
-  recentActivity: Array<{
-    id: string;
-    type: string;
-    description: string;
-    createdAt: string;
-    user: {
-      id: string;
-      name: string;
-      email: string;
-    };
-  }>;
-}
-
-async function fetchDashboardData(): Promise<DashboardData> {
-  const response = await fetch('/api/admin/dashboard');
-  if (!response.ok) {
-    throw new Error('Failed to fetch dashboard data');
-  }
-  return response.json();
-}
+import {
+  AdminDashboard as HeadlessAdminDashboard,
+} from '@/ui/headless/admin/AdminDashboard';
 
 export function AdminDashboard() {
-  const { data, isLoading, isError } = useQuery({
-    queryKey: ['admin-dashboard'],
-    queryFn: fetchDashboardData,
-    refetchInterval: 30000, // Refresh every 30 seconds
-  });
-
-  if (isError) {
-    return (
-      <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive">
-        <AlertCircle className="h-6 w-6 mb-2" />
-        <h2 className="text-lg font-semibold">Error Loading Dashboard</h2>
-        <p>Failed to load dashboard data. Please try again later.</p>
-      </div>
-    );
-  }
-
   return (
-    <div className="space-y-8">
-      {/* Team Overview Section */}
-      <section>
-        <h2 className="text-2xl font-bold tracking-tight mb-4">Team Overview</h2>
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Total Members</CardTitle>
-              <Users className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              {isLoading ? (
-                <Skeleton className="h-7 w-16" />
-              ) : (
-                <div className="text-2xl font-bold">{data?.team.totalMembers}</div>
-              )}
-            </CardContent>
-          </Card>
+    <HeadlessAdminDashboard>
+      {({ data, isLoading, isError }) => {
+        if (isError) {
+          return (
+            <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive">
+              <AlertCircle className="h-6 w-6 mb-2" />
+              <h2 className="text-lg font-semibold">Error Loading Dashboard</h2>
+              <p>Failed to load dashboard data. Please try again later.</p>
+            </div>
+          );
+        }
 
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Active Members</CardTitle>
-              <CheckCircle className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              {isLoading ? (
-                <Skeleton className="h-7 w-16" />
-              ) : (
-                <div className="text-2xl font-bold">{data?.team.activeMembers}</div>
-              )}
-            </CardContent>
-          </Card>
+        return (
+          <div className="space-y-8">
+            {/* Team Overview Section */}
+            <section>
+              <h2 className="text-2xl font-bold tracking-tight mb-4">Team Overview</h2>
+              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+                <Card>
+                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                    <CardTitle className="text-sm font-medium">Total Members</CardTitle>
+                    <Users className="h-4 w-4 text-muted-foreground" />
+                  </CardHeader>
+                  <CardContent>
+                    {isLoading ? (
+                      <Skeleton className="h-7 w-16" />
+                    ) : (
+                      <div className="text-2xl font-bold">{data?.team.totalMembers}</div>
+                    )}
+                  </CardContent>
+                </Card>
 
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Pending Invites</CardTitle>
-              <Clock className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              {isLoading ? (
-                <Skeleton className="h-7 w-16" />
-              ) : (
-                <div className="text-2xl font-bold">{data?.team.pendingMembers}</div>
-              )}
-            </CardContent>
-          </Card>
+                <Card>
+                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                    <CardTitle className="text-sm font-medium">Active Members</CardTitle>
+                    <CheckCircle className="h-4 w-4 text-muted-foreground" />
+                  </CardHeader>
+                  <CardContent>
+                    {isLoading ? (
+                      <Skeleton className="h-7 w-16" />
+                    ) : (
+                      <div className="text-2xl font-bold">{data?.team.activeMembers}</div>
+                    )}
+                  </CardContent>
+                </Card>
 
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Seat Usage</CardTitle>
-              <Users className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              {isLoading ? (
-                <Skeleton className="h-7 w-full" />
-              ) : (
-                <div className="space-y-2">
-                  <div className="text-2xl font-bold">
-                    {data?.team.seatUsage.used}/{data?.team.seatUsage.total}
-                  </div>
-                  <Progress value={data?.team.seatUsage.percentage} />
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </div>
-      </section>
+                <Card>
+                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                    <CardTitle className="text-sm font-medium">Pending Invites</CardTitle>
+                    <Clock className="h-4 w-4 text-muted-foreground" />
+                  </CardHeader>
+                  <CardContent>
+                    {isLoading ? (
+                      <Skeleton className="h-7 w-16" />
+                    ) : (
+                      <div className="text-2xl font-bold">{data?.team.pendingMembers}</div>
+                    )}
+                  </CardContent>
+                </Card>
 
-      {/* Subscription Status Section */}
-      <section>
-        <h2 className="text-2xl font-bold tracking-tight mb-4">Subscription Status</h2>
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <CreditCard className="h-5 w-5" />
-              Current Plan
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {isLoading ? (
-              <div className="space-y-3">
-                <Skeleton className="h-6 w-32" />
-                <Skeleton className="h-4 w-48" />
-                <Skeleton className="h-4 w-40" />
+                <Card>
+                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                    <CardTitle className="text-sm font-medium">Seat Usage</CardTitle>
+                    <Users className="h-4 w-4 text-muted-foreground" />
+                  </CardHeader>
+                  <CardContent>
+                    {isLoading ? (
+                      <Skeleton className="h-7 w-full" />
+                    ) : (
+                      <div className="space-y-2">
+                        <div className="text-2xl font-bold">
+                          {data?.team.seatUsage.used}/{data?.team.seatUsage.total}
+                        </div>
+                        <Progress value={data?.team.seatUsage.percentage} />
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
               </div>
-            ) : (
-              <>
-                <div className="flex items-center gap-3">
-                  <span className="text-xl font-bold capitalize">{data?.subscription.plan}</span>
-                  <Badge variant={data?.subscription.status === 'active' ? 'default' : 'secondary'}>
-                    {data?.subscription.status}
-                  </Badge>
-                </div>
-                {data?.subscription.trialEndsAt && (
-                  <p className="text-sm text-muted-foreground">
-                    Trial ends {formatDistanceToNow(new Date(data.subscription.trialEndsAt), { addSuffix: true })}
-                  </p>
-                )}
-                {data?.subscription.currentPeriodEndsAt && (
-                  <p className="text-sm text-muted-foreground">
-                    Current period ends {format(new Date(data.subscription.currentPeriodEndsAt), 'MMMM d, yyyy')}
-                  </p>
-                )}
-              </>
-            )}
-          </CardContent>
-        </Card>
-      </section>
+            </section>
 
-      {/* Recent Activity Section */}
-      <section>
-        <h2 className="text-2xl font-bold tracking-tight mb-4">Recent Activity</h2>
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Activity className="h-5 w-5" />
-              Latest Events
-            </CardTitle>
-            <CardDescription>
-              Recent team activity and system events
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {isLoading ? (
-              <div className="space-y-4">
-                {Array.from({ length: 5 }).map((_, i) => (
-                  <div key={i} className="flex items-start gap-4">
-                    <Skeleton className="h-10 w-10 rounded-full" />
-                    <div className="space-y-2">
-                      <Skeleton className="h-4 w-[250px]" />
-                      <Skeleton className="h-3 w-[200px]" />
+            {/* Subscription Status Section */}
+            <section>
+              <h2 className="text-2xl font-bold tracking-tight mb-4">Subscription Status</h2>
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <CreditCard className="h-5 w-5" />
+                    Current Plan
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {isLoading ? (
+                    <div className="space-y-3">
+                      <Skeleton className="h-6 w-32" />
+                      <Skeleton className="h-4 w-48" />
+                      <Skeleton className="h-4 w-40" />
                     </div>
-                  </div>
-                ))}
-              </div>
-            ) : data?.recentActivity.length === 0 ? (
-              <p className="text-center text-muted-foreground py-8">
-                No recent activity to display
-              </p>
-            ) : (
-              <div className="space-y-4">
-                {data?.recentActivity.map((activity) => (
-                  <div key={activity.id} className="flex items-start gap-4">
-                    <div className="w-10 h-10 rounded-full bg-muted flex items-center justify-center">
-                      <Activity className="h-5 w-5" />
+                  ) : (
+                    <>
+                      <div className="flex items-center gap-3">
+                        <span className="text-xl font-bold capitalize">{data?.subscription.plan}</span>
+                        <Badge variant={data?.subscription.status === 'active' ? 'default' : 'secondary'}>
+                          {data?.subscription.status}
+                        </Badge>
+                      </div>
+                      {data?.subscription.trialEndsAt && (
+                        <p className="text-sm text-muted-foreground">
+                          Trial ends {formatDistanceToNow(new Date(data.subscription.trialEndsAt), { addSuffix: true })}
+                        </p>
+                      )}
+                      {data?.subscription.currentPeriodEndsAt && (
+                        <p className="text-sm text-muted-foreground">
+                          Current period ends {format(new Date(data.subscription.currentPeriodEndsAt), 'MMMM d, yyyy')}
+                        </p>
+                      )}
+                    </>
+                  )}
+                </CardContent>
+              </Card>
+            </section>
+
+            {/* Recent Activity Section */}
+            <section>
+              <h2 className="text-2xl font-bold tracking-tight mb-4">Recent Activity</h2>
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <Activity className="h-5 w-5" />
+                    Latest Events
+                  </CardTitle>
+                  <CardDescription>
+                    Recent team activity and system events
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  {isLoading ? (
+                    <div className="space-y-4">
+                      {Array.from({ length: 5 }).map((_, i) => (
+                        <div key={i} className="flex items-start gap-4">
+                          <Skeleton className="h-10 w-10 rounded-full" />
+                          <div className="space-y-2">
+                            <Skeleton className="h-4 w-[250px]" />
+                            <Skeleton className="h-3 w-[200px]" />
+                          </div>
+                        </div>
+                      ))}
                     </div>
-                    <div>
-                      <p className="text-sm">{activity.description}</p>
-                      <p className="text-xs text-muted-foreground">
-                        by {activity.user.name} • {formatDistanceToNow(new Date(activity.createdAt), { addSuffix: true })}
-                      </p>
+                  ) : data?.recentActivity.length === 0 ? (
+                    <p className="text-center text-muted-foreground py-8">
+                      No recent activity to display
+                    </p>
+                  ) : (
+                    <div className="space-y-4">
+                      {data?.recentActivity.map((activity) => (
+                        <div key={activity.id} className="flex items-start gap-4">
+                          <div className="w-10 h-10 rounded-full bg-muted flex items-center justify-center">
+                            <Activity className="h-5 w-5" />
+                          </div>
+                          <div>
+                            <p className="text-sm">{activity.description}</p>
+                            <p className="text-xs text-muted-foreground">
+                              by {activity.user.name} • {formatDistanceToNow(new Date(activity.createdAt), { addSuffix: true })}
+                            </p>
+                          </div>
+                        </div>
+                      ))}
                     </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </section>
-    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </section>
+          </div>
+        );
+      }}
+    </HeadlessAdminDashboard>
   );
 }

--- a/src/ui/styled/admin/AdminUsers.tsx
+++ b/src/ui/styled/admin/AdminUsers.tsx
@@ -1,170 +1,82 @@
-import React, { useEffect, useState, useMemo } from 'react';
-import { supabase } from '@/lib/supabase';
+import React from 'react';
 import { Input } from '@/ui/primitives/input';
 import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '@/ui/primitives/table';
 import { Button } from '@/ui/primitives/button';
 import { Alert } from '@/ui/primitives/alert';
-import type { User as BaseUser } from '@/types/user';
+import {
+  AdminUsers as HeadlessAdminUsers,
+  AdminUsersProps,
+  ROLE_OPTIONS,
+} from '@/ui/headless/admin/AdminUsers';
 
-// Extend User type for admin table compatibility
-interface User extends BaseUser {
-  role?: string;
-  created_at?: string;
-}
-
-// Minimal role options for dropdown
-const ROLE_OPTIONS = [
-  { value: 'user', label: 'User' },
-  { value: 'admin', label: 'Make Admin' },
-];
-
-interface AdminUsersProps {
-  fetchUsers?: () => Promise<User[]>;
-  handleRoleChange?: (user: User, newRole: string) => Promise<any>;
-}
-
-export const AdminUsers: React.FC<AdminUsersProps> = ({ fetchUsers, handleRoleChange }) => {
-  const [users, setUsers] = useState<User[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [search, setSearch] = useState('');
-  const [retryCount, setRetryCount] = useState(0);
-
-  // Default fetchUsers implementation (Supabase)
-  const defaultFetchUsers = async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const { data, error } = await supabase.from('users').select('*').order('created_at', { ascending: false });
-      if (error) throw error;
-      setUsers(data || []);
-    } catch (err: any) {
-      setError(err.message || 'Failed to fetch users');
-      setUsers([]);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // Default handleRoleChange implementation (Supabase)
-  const defaultHandleRoleChange = async (user: User, newRole: string) => {
-    setLoading(true);
-    setError(null);
-    try {
-      const { error } = await supabase.from('users').update({ role: newRole }).eq('id', user.id);
-      if (error) throw error;
-      // Refetch users after update
-      await (fetchUsers || defaultFetchUsers)();
-    } catch (err: any) {
-      setError(err.message || 'Failed to update user role');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // Fetch users on mount and on retry
-  useEffect(() => {
-    setLoading(true);
-    setError(null);
-    if (fetchUsers) {
-      fetchUsers()
-        .then((users) => setUsers(users))
-        .catch((err) => {
-          setError(err.message || 'Failed to fetch users');
-          setUsers([]);
-        })
-        .finally(() => setLoading(false));
-    } else {
-      defaultFetchUsers();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [retryCount]);
-
-  // Filter users by search
-  const filteredUsers = useMemo(() => {
-    if (!search) return users;
-    const s = search.toLowerCase();
-    return users.filter(
-      (u) =>
-        u.email?.toLowerCase().includes(s) ||
-        u.fullName?.toLowerCase().includes(s) ||
-        u.username?.toLowerCase().includes(s)
-    );
-  }, [users, search]);
-
-  // Handle role update
-  const onRoleChange = async (user: User, newRole: string) => {
-    await (handleRoleChange || defaultHandleRoleChange)(user, newRole);
-  };
-
-  // Retry handler
-  const handleRetry = () => setRetryCount((c) => c + 1);
-
-  return (
-    <div className="w-full max-w-4xl mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4">Admin Users</h1>
-      <div className="mb-4 flex gap-2 items-center">
-        <Input
-          placeholder="Search users"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          disabled={loading}
-        />
-      </div>
-      {error && (
-        <Alert variant="destructive" className="mb-4">
-          <div className="flex justify-between items-center">
-            <span>{error}</span>
-            <Button size="sm" onClick={handleRetry} disabled={loading}>
-              Retry
-            </Button>
-          </div>
-        </Alert>
-      )}
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Email</TableHead>
-            <TableHead>Role</TableHead>
-            <TableHead>Created</TableHead>
-            <TableHead>Actions</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {loading ? (
+export const AdminUsers: React.FC<AdminUsersProps> = ({ fetchUsers, handleRoleChange }) => (
+  <HeadlessAdminUsers fetchUsers={fetchUsers} handleRoleChange={handleRoleChange}>
+    {({ users, filteredUsers, loading, error, search, setSearch, onRoleChange, handleRetry }) => (
+      <div className="w-full max-w-4xl mx-auto p-4">
+        <h1 className="text-2xl font-bold mb-4">Admin Users</h1>
+        <div className="mb-4 flex gap-2 items-center">
+          <Input
+            placeholder="Search users"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            disabled={loading}
+          />
+        </div>
+        {error && (
+          <Alert variant="destructive" className="mb-4">
+            <div className="flex justify-between items-center">
+              <span>{error}</span>
+              <Button size="sm" onClick={handleRetry} disabled={loading}>
+                Retry
+              </Button>
+            </div>
+          </Alert>
+        )}
+        <Table>
+          <TableHeader>
             <TableRow>
-              <TableCell colSpan={4}>Loading...</TableCell>
+              <TableHead>Email</TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead>Actions</TableHead>
             </TableRow>
-          ) : filteredUsers.length === 0 ? (
-            <TableRow>
-              <TableCell colSpan={4}>No users found.</TableCell>
-            </TableRow>
-          ) : (
-            filteredUsers.map((user) => (
-              <TableRow key={user.id}>
-                <TableCell>{user.email}</TableCell>
-                <TableCell>{user.role || 'user'}</TableCell>
-                <TableCell>{user.created_at ? new Date(user.created_at).toLocaleDateString() : ''}</TableCell>
-                <TableCell>
-                  <select
-                    value={user.role || 'user'}
-                    onChange={(e) => onRoleChange(user, e.target.value)}
-                    disabled={loading}
-                  >
-                    {ROLE_OPTIONS.map((opt) => (
-                      <option key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </option>
-                    ))}
-                  </select>
-                </TableCell>
+          </TableHeader>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={4}>Loading...</TableCell>
               </TableRow>
-            ))
-          )}
-        </TableBody>
-      </Table>
-    </div>
-  );
-};
+            ) : filteredUsers.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4}>No users found.</TableCell>
+              </TableRow>
+            ) : (
+              filteredUsers.map((user) => (
+                <TableRow key={user.id}>
+                  <TableCell>{user.email}</TableCell>
+                  <TableCell>{user.role || 'user'}</TableCell>
+                  <TableCell>{user.created_at ? new Date(user.created_at).toLocaleDateString() : ''}</TableCell>
+                  <TableCell>
+                    <select
+                      value={user.role || 'user'}
+                      onChange={(e) => onRoleChange(user, e.target.value)}
+                      disabled={loading}
+                    >
+                      {ROLE_OPTIONS.map((opt) => (
+                        <option key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </option>
+                      ))}
+                    </select>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    )}
+  </HeadlessAdminUsers>
+);
 
-export default AdminUsers; 
+export default AdminUsers;

--- a/src/ui/styled/admin/RetentionDashboard.tsx
+++ b/src/ui/styled/admin/RetentionDashboard.tsx
@@ -1,327 +1,185 @@
-import { useState, useEffect } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/ui/primitives/card';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/ui/primitives/table';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/primitives/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/primitives/table';
 import { Badge } from '@/ui/primitives/badge';
 import { Button } from '@/ui/primitives/button';
 import { Input } from '@/ui/primitives/input';
 import { Skeleton } from '@/ui/primitives/skeleton';
+import { RefreshCw, Trash2, Users, Clock, UserX, Archive } from 'lucide-react';
 import { format } from 'date-fns';
-import { Archive, Clock, RefreshCw, Trash2, UserX, Users } from 'lucide-react';
-
-// Fetch retention metrics
-async function fetchRetentionMetrics() {
-  const response = await fetch('/api/admin/retention/metrics');
-  if (!response.ok) {
-    throw new Error('Failed to fetch retention metrics');
-  }
-  return response.json();
-}
-
-// Fetch accounts pending anonymization
-async function fetchPendingAnonymization() {
-  const response = await fetch('/api/admin/retention/pending-anonymization');
-  if (!response.ok) {
-    throw new Error('Failed to fetch accounts pending anonymization');
-  }
-  return response.json();
-}
-
-// Trigger the anonymization process
-async function triggerAnonymization() {
-  const response = await fetch('/api/admin/retention/anonymize', {
-    method: 'POST',
-  });
-  if (!response.ok) {
-    throw new Error('Failed to trigger anonymization process');
-  }
-  return response.json();
-}
-
-// Execute inactive account identification job
-async function identifyInactiveAccounts() {
-  const response = await fetch('/api/admin/retention/identify-inactive', {
-    method: 'POST',
-  });
-  if (!response.ok) {
-    throw new Error('Failed to identify inactive accounts');
-  }
-  return response.json();
-}
+import {
+  RetentionDashboard as HeadlessRetentionDashboard,
+} from '@/ui/headless/admin/RetentionDashboard';
 
 export function RetentionDashboard() {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [isProcessing, setIsProcessing] = useState(false);
-  
-  // Fetch retention metrics
-  const {
-    data: metrics,
-    isLoading: metricsLoading,
-    isError: metricsError,
-    refetch: refetchMetrics
-  } = useQuery({
-    queryKey: ['retention-metrics'],
-    queryFn: fetchRetentionMetrics,
-    refetchInterval: 5 * 60 * 1000, // Refresh every 5 minutes
-  });
-  
-  // Fetch accounts pending anonymization
-  const {
-    data: pendingAccounts,
-    isLoading: pendingLoading,
-    isError: pendingError,
-    refetch: refetchPending
-  } = useQuery({
-    queryKey: ['pending-anonymization'],
-    queryFn: fetchPendingAnonymization,
-    refetchInterval: 5 * 60 * 1000, // Refresh every 5 minutes
-  });
-  
-  // Filter pending accounts by search query
-  const filteredAccounts = pendingAccounts?.accounts.filter(account => {
-    if (!searchQuery) return true;
-    
-    const query = searchQuery.toLowerCase();
-    return (
-      account.email?.toLowerCase().includes(query) ||
-      account.userId?.toLowerCase().includes(query)
-    );
-  }) || [];
-  
-  // Handle running the anonymization process
-  const handleAnonymization = async () => {
-    if (isProcessing) return;
-    
-    try {
-      setIsProcessing(true);
-      await triggerAnonymization();
-      await refetchPending();
-      await refetchMetrics();
-    } catch (error) {
-      console.error('Error triggering anonymization:', error);
-    } finally {
-      setIsProcessing(false);
-    }
-  };
-  
-  // Handle identifying inactive accounts
-  const handleIdentifyInactive = async () => {
-    if (isProcessing) return;
-    
-    try {
-      setIsProcessing(true);
-      await identifyInactiveAccounts();
-      await refetchPending();
-      await refetchMetrics();
-    } catch (error) {
-      console.error('Error identifying inactive accounts:', error);
-    } finally {
-      setIsProcessing(false);
-    }
-  };
-  
-  // Format date
-  const formatDate = (date: string) => {
-    try {
-      return format(new Date(date), 'MMM d, yyyy HH:mm');
-    } catch (e) {
-      return 'Invalid date';
-    }
-  };
-  
-  // Get badge variant based on status
-  const getStatusBadgeVariant = (status: string) => {
-    switch (status) {
-      case 'active':
-        return 'default';
-      case 'warning':
-        return 'warning';
-      case 'inactive':
-        return 'secondary';
-      case 'grace_period':
-        return 'outline';
-      case 'anonymizing':
-        return 'destructive';
-      case 'anonymized':
-        return 'secondary';
-      default:
-        return 'secondary';
-    }
-  };
-  
   return (
-    <div className="space-y-8">
-      <section>
-        <h2 className="text-2xl font-bold tracking-tight mb-4">Data Retention Overview</h2>
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Active Users</CardTitle>
-              <Users className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              {metricsLoading ? (
-                <Skeleton className="h-7 w-16" />
-              ) : (
-                <div className="text-2xl font-bold">{metrics?.activeUsers || 0}</div>
-              )}
-            </CardContent>
-          </Card>
-          
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Warning Stage</CardTitle>
-              <Clock className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              {metricsLoading ? (
-                <Skeleton className="h-7 w-16" />
-              ) : (
-                <div className="text-2xl font-bold">{metrics?.warningUsers || 0}</div>
-              )}
-            </CardContent>
-          </Card>
-          
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Inactive Users</CardTitle>
-              <UserX className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              {metricsLoading ? (
-                <Skeleton className="h-7 w-16" />
-              ) : (
-                <div className="text-2xl font-bold">{metrics?.inactiveUsers || 0}</div>
-              )}
-            </CardContent>
-          </Card>
-          
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Anonymized</CardTitle>
-              <Archive className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              {metricsLoading ? (
-                <Skeleton className="h-7 w-16" />
-              ) : (
-                <div className="text-2xl font-bold">{metrics?.anonymizedUsers || 0}</div>
-              )}
-            </CardContent>
-          </Card>
-        </div>
-      </section>
-      
-      <section>
-        <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-4 gap-4">
-          <h2 className="text-2xl font-bold tracking-tight">Accounts Pending Anonymization</h2>
-          <div className="flex gap-2">
-            <Button 
-              onClick={handleIdentifyInactive}
-              disabled={isProcessing}
-              variant="outline"
-            >
-              <RefreshCw className="mr-2 h-4 w-4" />
-              Identify Inactive
-            </Button>
-            <Button 
-              onClick={handleAnonymization}
-              disabled={isProcessing || (pendingAccounts?.accounts.length || 0) === 0}
-              variant="destructive"
-            >
-              <Trash2 className="mr-2 h-4 w-4" />
-              Process Anonymization
-            </Button>
-          </div>
-        </div>
-        
-        <Card>
-          <CardHeader>
-            <div className="flex flex-col md:flex-row justify-between gap-4">
-              <div>
-                <CardTitle>Users to be Anonymized</CardTitle>
-                <CardDescription>
-                  Accounts that have exceeded the retention period and are pending anonymization
-                </CardDescription>
-              </div>
-              
-              <div className="w-full md:w-auto">
-                <Input
-                  placeholder="Search by email or ID..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="max-w-sm"
-                />
+    <HeadlessRetentionDashboard>
+      {({
+        metrics,
+        pendingAccounts,
+        filteredAccounts,
+        searchQuery,
+        setSearchQuery,
+        isProcessing,
+        metricsLoading,
+        metricsError,
+        pendingLoading,
+        pendingError,
+        handleAnonymization,
+        handleIdentifyInactive,
+        formatDate,
+        getStatusBadgeVariant,
+      }) => (
+        <div className="space-y-8">
+          <section>
+            <h2 className="text-2xl font-bold tracking-tight mb-4">Data Retention Overview</h2>
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">Active Users</CardTitle>
+                  <Users className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  {metricsLoading ? (
+                    <Skeleton className="h-7 w-16" />
+                  ) : (
+                    <div className="text-2xl font-bold">{metrics?.activeUsers || 0}</div>
+                  )}
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">Warning Stage</CardTitle>
+                  <Clock className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  {metricsLoading ? (
+                    <Skeleton className="h-7 w-16" />
+                  ) : (
+                    <div className="text-2xl font-bold">{metrics?.warningUsers || 0}</div>
+                  )}
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">Inactive Users</CardTitle>
+                  <UserX className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  {metricsLoading ? (
+                    <Skeleton className="h-7 w-16" />
+                  ) : (
+                    <div className="text-2xl font-bold">{metrics?.inactiveUsers || 0}</div>
+                  )}
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">Anonymized</CardTitle>
+                  <Archive className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  {metricsLoading ? (
+                    <Skeleton className="h-7 w-16" />
+                  ) : (
+                    <div className="text-2xl font-bold">{metrics?.anonymizedUsers || 0}</div>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          </section>
+
+          <section>
+            <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-4 gap-4">
+              <h2 className="text-2xl font-bold tracking-tight">Accounts Pending Anonymization</h2>
+              <div className="flex gap-2">
+                <Button onClick={handleIdentifyInactive} disabled={isProcessing} variant="outline">
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                  Identify Inactive
+                </Button>
+                <Button
+                  onClick={handleAnonymization}
+                  disabled={isProcessing || (pendingAccounts?.accounts.length || 0) === 0}
+                  variant="destructive"
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Process Anonymization
+                </Button>
               </div>
             </div>
-          </CardHeader>
-          <CardContent>
-            {pendingLoading ? (
-              <div className="space-y-4">
-                {Array.from({ length: 5 }).map((_, index) => (
-                  <div key={index} className="flex items-center gap-4">
-                    <Skeleton className="h-10 w-10 rounded-full" />
-                    <div className="space-y-2">
-                      <Skeleton className="h-4 w-[250px]" />
-                      <Skeleton className="h-3 w-[200px]" />
-                    </div>
+
+            <Card>
+              <CardHeader>
+                <div className="flex flex-col md:flex-row justify-between gap-4">
+                  <div>
+                    <CardTitle>Users to be Anonymized</CardTitle>
+                    <CardDescription>
+                      Accounts that have exceeded the retention period and are pending anonymization
+                    </CardDescription>
                   </div>
-                ))}
-              </div>
-            ) : pendingError ? (
-              <div className="p-4 text-destructive">
-                Error loading accounts pending anonymization
-              </div>
-            ) : filteredAccounts.length === 0 ? (
-              <div className="text-center py-8 text-muted-foreground">
-                {searchQuery
-                  ? "No matching accounts found"
-                  : "No accounts pending anonymization"}
-              </div>
-            ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Email</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Type</TableHead>
-                    <TableHead>Last Login</TableHead>
-                    <TableHead>Anonymize After</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredAccounts.map((account) => (
-                    <TableRow key={account.userId}>
-                      <TableCell className="font-medium">{account.email}</TableCell>
-                      <TableCell>
-                        <Badge variant={getStatusBadgeVariant(account.status)}>
-                          {account.status}
-                        </Badge>
-                      </TableCell>
-                      <TableCell>{account.retentionType}</TableCell>
-                      <TableCell>{formatDate(account.lastLoginAt)}</TableCell>
-                      <TableCell>{formatDate(account.anonymizeAt)}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            )}
-          </CardContent>
-        </Card>
-      </section>
-    </div>
+
+                  <div className="w-full md:w-auto">
+                    <Input
+                      placeholder="Search by email or ID..."
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      className="max-w-sm"
+                    />
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                {pendingLoading ? (
+                  <div className="space-y-4">
+                    {Array.from({ length: 5 }).map((_, index) => (
+                      <div key={index} className="flex items-center gap-4">
+                        <Skeleton className="h-10 w-10 rounded-full" />
+                        <div className="space-y-2">
+                          <Skeleton className="h-4 w-[250px]" />
+                          <Skeleton className="h-3 w-[200px]" />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : pendingError ? (
+                  <div className="p-4 text-destructive">Error loading accounts pending anonymization</div>
+                ) : filteredAccounts.length === 0 ? (
+                  <div className="text-center py-8 text-muted-foreground">
+                    {searchQuery ? 'No matching accounts found' : 'No accounts pending anonymization'}
+                  </div>
+                ) : (
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Email</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead>Type</TableHead>
+                        <TableHead>Last Login</TableHead>
+                        <TableHead>Anonymize After</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {filteredAccounts.map((account) => (
+                        <TableRow key={account.userId}>
+                          <TableCell className="font-medium">{account.email}</TableCell>
+                          <TableCell>
+                            <Badge variant={getStatusBadgeVariant(account.status)}>{account.status}</Badge>
+                          </TableCell>
+                          <TableCell>{account.retentionType}</TableCell>
+                          <TableCell>{formatDate(account.lastLoginAt)}</TableCell>
+                          <TableCell>{formatDate(account.anonymizeAt)}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                )}
+              </CardContent>
+            </Card>
+          </section>
+        </div>
+      )}
+    </HeadlessRetentionDashboard>
   );
-} 
+}

--- a/src/ui/styled/admin/RoleManagementPanel.tsx
+++ b/src/ui/styled/admin/RoleManagementPanel.tsx
@@ -1,207 +1,161 @@
 import React from 'react';
-import { User } from '@/types/user';
-import { useRBACStore } from '@/lib/stores/rbac.store';
-import { UserRoleSchema, RoleSchema } from '@/types/rbac';
+import {
+  RoleManagementPanel as HeadlessRoleManagementPanel,
+  RoleManagementPanelProps,
+} from '@/ui/headless/admin/RoleManagementPanel';
 
-/**
- * RoleManagementPanel Component
- *
- * Purpose:
- *   - Provides an admin-facing UI for listing users, assigning/removing roles, and viewing role permissions.
- *   - Designed to be modular, pluggable, and database-agnostic (uses RBAC store abstraction).
- *
- * Props:
- *   - users: User[]
- *     List of user objects to display and manage roles for.
- *   - (Planned) Optional feature toggles and custom actions for further configuration.
- *
- * Usage Example:
- *   import RoleManagementPanel from '@/ui/styled/admin/RoleManagementPanel';
- *   <RoleManagementPanel users={users} />
- *
- * Feature Toggling:
- *   - To enable/disable this panel, control its rendering in the parent admin/dashboard page.
- *   - Future: Accepts feature toggle props for finer control (see TODO in props).
- *
- * Backend Abstraction:
- *   - All role/permission logic is abstracted via the RBAC store (see '@/lib/stores/rbac.store').
- *   - Swapping database providers only requires updating the store implementation.
- *
- * Accessibility & Responsiveness:
- *   - Follows accessibility best practices (ARIA labels, keyboard navigation).
- *   - Responsive design for mobile and desktop.
- *
- * For more details, see the implementation plan and file structure guidelines.
- */
-
-export interface RoleManagementPanelProps {
-  users: User[];
-  // TODO: Add optional props for feature toggles, custom actions, etc.
-}
-
-const RoleManagementPanel: React.FC<RoleManagementPanelProps> = ({ users }) => {
-  // React 19 compatibility - Use individual selectors
-  const roles = useRBACStore(state => state.roles);
-  const userRoles = useRBACStore(state => state.userRoles);
-  const isLoading = useRBACStore(state => state.isLoading);
-  const error = useRBACStore(state => state.error);
-  const assignRole = useRBACStore(state => state.assignRole);
-  const removeRole = useRBACStore(state => state.removeRole);
-
-  // Helper to get role assignments for a user
-  const getUserRoleAssignments = (userId: string | number): UserRoleSchema[] =>
-    userRoles.filter((ur: UserRoleSchema) => ur.userId === String(userId));
-
-  // Helper to get roles not assigned to a user
-  const getAssignableRoles = (userId: string | number): RoleSchema[] => {
-    const assignedRoleIds = new Set(getUserRoleAssignments(userId).map((ur: UserRoleSchema) => ur.roleId));
-    return roles.filter((role: RoleSchema) => !assignedRoleIds.has(role.id));
-  };
-
-  const handleAssignRole = async (userId: string | number, roleId: string) => {
-    if (!isLoading) {
-      await assignRole(userId.toString(), roleId);
-    }
-  };
-
-  const handleRemoveRole = async (userId: string | number, roleId: string) => {
-    if (!isLoading) {
-      await removeRole(userId.toString(), roleId);
-    }
-  };
-
-  return (
-    <div className="rounded-md border p-4 w-full max-w-5xl mx-auto">
-      <h2 className="text-xl font-semibold mb-4">User Role Management</h2>
-      <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead>
-            <tr>
-              <th className="px-4 py-2 text-left">Name</th>
-              <th className="px-4 py-2 text-left">Email</th>
-              <th className="px-4 py-2 text-left">Roles</th>
-              <th className="px-4 py-2 text-left">Assign</th>
-              <th className="px-4 py-2 text-left">Remove</th>
-            </tr>
-          </thead>
-          <tbody>
-            {isLoading ? (
+const RoleManagementPanel: React.FC<RoleManagementPanelProps> = ({ users }) => (
+  <HeadlessRoleManagementPanel users={users}>
+    {({
+      roles,
+      userRoles,
+      isLoading,
+      error,
+      getUserRoleAssignments,
+      getAssignableRoles,
+      handleAssignRole,
+      handleRemoveRole,
+    }) => (
+      <div className="rounded-md border p-4 w-full max-w-5xl mx-auto">
+        <h2 className="text-xl font-semibold mb-4">User Role Management</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead>
               <tr>
-                <td colSpan={5} className="text-center py-4">Loading...</td>
+                <th className="px-4 py-2 text-left">Name</th>
+                <th className="px-4 py-2 text-left">Email</th>
+                <th className="px-4 py-2 text-left">Roles</th>
+                <th className="px-4 py-2 text-left">Assign</th>
+                <th className="px-4 py-2 text-left">Remove</th>
               </tr>
-            ) : error ? (
-              <tr>
-                <td colSpan={5} className="text-center text-red-500 py-4" role="alert">{error}</td>
-              </tr>
-            ) : users.length === 0 ? (
-              <tr>
-                <td colSpan={5} className="text-center py-4">No users found.</td>
-              </tr>
-            ) : (
-              users.map((user) => {
-                const assignedRoles = getUserRoleAssignments(user.id);
-                const assignableRoles = getAssignableRoles(user.id);
-                return (
-                  <tr key={user.id}>
-                    <td className="px-4 py-2">{user.fullName || user.username || user.email}</td>
-                    <td className="px-4 py-2">{user.email}</td>
-                    <td className="px-4 py-2">
-                      {assignedRoles.length === 0 ? (
-                        <span className="text-gray-400">None</span>
-                      ) : (
+            </thead>
+            <tbody>
+              {isLoading ? (
+                <tr>
+                  <td colSpan={5} className="text-center py-4">Loading...</td>
+                </tr>
+              ) : error ? (
+                <tr>
+                  <td colSpan={5} className="text-center text-red-500 py-4" role="alert">
+                    {error}
+                  </td>
+                </tr>
+              ) : users.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="text-center py-4">No users found.</td>
+                </tr>
+              ) : (
+                users.map((user) => {
+                  const assignedRoles = getUserRoleAssignments(user.id);
+                  const assignableRoles = getAssignableRoles(user.id);
+                  return (
+                    <tr key={user.id}>
+                      <td className="px-4 py-2">{user.fullName || user.username || user.email}</td>
+                      <td className="px-4 py-2">{user.email}</td>
+                      <td className="px-4 py-2">
+                        {assignedRoles.length === 0 ? (
+                          <span className="text-gray-400">None</span>
+                        ) : (
+                          <ul className="flex flex-wrap gap-2">
+                            {assignedRoles.map((ur) => {
+                              const role = roles.find((r) => r.id === ur.roleId);
+                              return role ? (
+                                <li key={ur.roleId} className="inline-flex items-center bg-gray-100 rounded px-2 py-1">
+                                  <span>{role.name}</span>
+                                </li>
+                              ) : null;
+                            })}
+                          </ul>
+                        )}
+                      </td>
+                      <td className="px-4 py-2">
+                        <select
+                          aria-label={`Assign role to ${user.fullName || user.email}`}
+                          className="border rounded px-2 py-1"
+                          disabled={isLoading || assignableRoles.length === 0}
+                          defaultValue=""
+                          onChange={(e) => {
+                            if (e.target.value) {
+                              handleAssignRole(user.id, e.target.value);
+                              e.target.value = '';
+                            }
+                          }}
+                        >
+                          <option value="" disabled>
+                            {assignableRoles.length === 0 ? 'No roles' : 'Select role'}
+                          </option>
+                          {assignableRoles.map((role) => (
+                            <option key={role.id} value={role.id}>
+                              {role.name}
+                            </option>
+                          ))}
+                        </select>
+                      </td>
+                      <td className="px-4 py-2">
                         <ul className="flex flex-wrap gap-2">
-                          {assignedRoles.map((ur: UserRoleSchema) => {
-                            const role = roles.find((r: RoleSchema) => r.id === ur.roleId);
-                            return role ? (
-                              <li key={ur.roleId} className="inline-flex items-center bg-gray-100 rounded px-2 py-1">
-                                <span>{role.name}</span>
-                              </li>
-                            ) : null;
-                          })}
+                          {assignedRoles.map((ur) => (
+                            <li key={ur.roleId}>
+                              <button
+                                aria-label={`Remove role ${roles.find((r) => r.id === ur.roleId)?.name || ur.roleId} from ${user.fullName || user.email}`}
+                                className="text-red-600 hover:underline disabled:opacity-50"
+                                disabled={isLoading}
+                                onClick={() => handleRemoveRole(user.id, ur.roleId)}
+                              >
+                                Remove
+                              </button>
+                            </li>
+                          ))}
                         </ul>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+        {/* Permissions Viewer Section */}
+        <div className="mt-8">
+          <h3 className="text-lg font-semibold mb-2">Roles & Permissions</h3>
+          {isLoading ? (
+            <div className="py-4 text-center">Loading roles...</div>
+          ) : error ? (
+            <div className="py-4 text-center text-red-500" role="alert">
+              {error}
+            </div>
+          ) : roles.length === 0 ? (
+            <div className="py-4 text-center text-gray-500">No roles defined.</div>
+          ) : (
+            <ul className="space-y-2">
+              {roles.map((role) => (
+                <li key={role.id} className="border rounded p-3 bg-gray-50">
+                  <details>
+                    <summary className="cursor-pointer font-bold text-base flex items-center">
+                      {role.name}
+                      {role.description && (
+                        <span className="ml-2 text-gray-500 font-normal text-sm">{role.description}</span>
                       )}
-                    </td>
-                    <td className="px-4 py-2">
-                      <select
-                        aria-label={`Assign role to ${user.fullName || user.email}`}
-                        className="border rounded px-2 py-1"
-                        disabled={isLoading || assignableRoles.length === 0}
-                        defaultValue=""
-                        onChange={e => {
-                          if (e.target.value) {
-                            handleAssignRole(user.id, e.target.value);
-                            e.target.value = '';
-                          }
-                        }}
-                      >
-                        <option value="" disabled>
-                          {assignableRoles.length === 0 ? 'No roles' : 'Select role'}
-                        </option>
-                        {assignableRoles.map((role: RoleSchema) => (
-                          <option key={role.id} value={role.id}>{role.name}</option>
-                        ))}
-                      </select>
-                    </td>
-                    <td className="px-4 py-2">
-                      <ul className="flex flex-wrap gap-2">
-                        {assignedRoles.map((ur: UserRoleSchema) => (
-                          <li key={ur.roleId}>
-                            <button
-                              aria-label={`Remove role ${roles.find((r: RoleSchema) => r.id === ur.roleId)?.name || ur.roleId} from ${user.fullName || user.email}`}
-                              className="text-red-600 hover:underline disabled:opacity-50"
-                              disabled={isLoading}
-                              onClick={() => handleRemoveRole(user.id, ur.roleId)}
-                            >
-                              Remove
-                            </button>
+                    </summary>
+                    <ul className="ml-6 mt-2 list-disc">
+                      {role.permissions.length === 0 ? (
+                        <li className="text-gray-400">No permissions</li>
+                      ) : (
+                        role.permissions.map((perm) => (
+                          <li key={perm} className="text-sm">
+                            {perm}
                           </li>
-                        ))}
-                      </ul>
-                    </td>
-                  </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
+                        ))
+                      )}
+                    </ul>
+                  </details>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </div>
-      {/* Permissions Viewer Section */}
-      <div className="mt-8">
-        <h3 className="text-lg font-semibold mb-2">Roles & Permissions</h3>
-        {isLoading ? (
-          <div className="py-4 text-center">Loading roles...</div>
-        ) : error ? (
-          <div className="py-4 text-center text-red-500" role="alert">{error}</div>
-        ) : roles.length === 0 ? (
-          <div className="py-4 text-center text-gray-500">No roles defined.</div>
-        ) : (
-          <ul className="space-y-2">
-            {roles.map((role: RoleSchema) => (
-              <li key={role.id} className="border rounded p-3 bg-gray-50">
-                <details>
-                  <summary className="cursor-pointer font-bold text-base flex items-center">
-                    {role.name}
-                    {role.description && (
-                      <span className="ml-2 text-gray-500 font-normal text-sm">{role.description}</span>
-                    )}
-                  </summary>
-                  <ul className="ml-6 mt-2 list-disc">
-                    {role.permissions.length === 0 ? (
-                      <li className="text-gray-400">No permissions</li>
-                    ) : (
-                      role.permissions.map((perm: string) => (
-                        <li key={perm} className="text-sm">{perm}</li>
-                      ))
-                    )}
-                  </ul>
-                </details>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-    </div>
-  );
-};
+    )}
+  </HeadlessRoleManagementPanel>
+);
 
-export default RoleManagementPanel; 
+export default RoleManagementPanel;

--- a/src/ui/styled/admin/audit-logs/AdminAuditLogs.tsx
+++ b/src/ui/styled/admin/audit-logs/AdminAuditLogs.tsx
@@ -1,33 +1,23 @@
 "use client";
 
 import { AuditLogViewer } from '@/ui/styled/audit/AuditLogViewer';
-import { useEffect, useState } from 'react';
-import { useToast } from '@/ui/primitives/use-toast';
+import {
+  AdminAuditLogs as HeadlessAdminAuditLogs,
+} from '@/ui/headless/admin/audit-logs/AdminAuditLogs';
 
 export function AdminAuditLogs() {
-  const { toast } = useToast();
-  const [isError, setIsError] = useState(false);
-  
-  useEffect(() => {
-    // Check if we're simulating an error for testing
-    if (typeof window !== 'undefined' && window.location.search.includes('simulateError=1')) {
-      setIsError(true);
-      toast({
-        title: 'Error',
-        description: 'Failed to fetch audit logs',
-        variant: 'destructive',
-      });
-    }
-  }, [toast]);
-
-  if (isError) {
-    return (
-      <div className="rounded-lg border border-destructive bg-destructive/10 p-4">
-        <h2 className="text-lg font-semibold text-destructive mb-2">Error</h2>
-        <p>Failed to fetch audit logs. Please try again later.</p>
-      </div>
-    );
-  }
-
-  return <AuditLogViewer isAdmin={true} />;
-} 
+  return (
+    <HeadlessAdminAuditLogs>
+      {({ isError }) =>
+        isError ? (
+          <div className="rounded-lg border border-destructive bg-destructive/10 p-4">
+            <h2 className="text-lg font-semibold text-destructive mb-2">Error</h2>
+            <p>Failed to fetch audit logs. Please try again later.</p>
+          </div>
+        ) : (
+          <AuditLogViewer isAdmin={true} />
+        )
+      }
+    </HeadlessAdminAuditLogs>
+  );
+}


### PR DESCRIPTION
## Summary
- refactor styled AdminDashboard to consume HeadlessAdminDashboard
- refactor styled AdminUsers to consume HeadlessAdminUsers
- refactor styled RetentionDashboard to consume HeadlessRetentionDashboard
- refactor styled RoleManagementPanel to consume HeadlessRoleManagementPanel
- refactor styled AdminAuditLogs to consume HeadlessAdminAuditLogs
- update integration tests to use new import paths

## Testing
- `npm run test:coverage` *(fails: React warnings and test errors)*