### PR TITLE
Refactor styled auth components

### DIFF
--- a/src/ui/styled/auth/BusinessSSOAuth.tsx
+++ b/src/ui/styled/auth/BusinessSSOAuth.tsx
@@ -1,204 +1,86 @@
-'use client';
-
-import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/primitives/card';
+import { Input } from '@/ui/primitives/input';
+import { Button } from '@/ui/primitives/button';
 import { Alert, AlertDescription } from '@/ui/primitives/alert';
-import { OAuthButtons } from './OAuthButtons';
-import { useOrganization } from '@/lib/hooks/useOrganization';
-import { supabase } from '@/lib/database/supabase';
-import { Provider } from '@supabase/supabase-js';
-import { useUserManagement } from '@/lib/auth/UserManagementProvider';
+import { BusinessSSOAuth as HeadlessBusinessSSOAuth, type BusinessSSOAuthProps as HeadlessProps } from '@/ui/headless/auth/BusinessSSOAuth';
 
-interface BusinessSSOAuthProps {
+export interface BusinessSSOAuthProps extends Omit<HeadlessProps, 'children'> {
   className?: string;
-  orgId?: string;
 }
 
-export function BusinessSSOAuth({ className = '', orgId }: BusinessSSOAuthProps) {
+export function BusinessSSOAuth({ className, ...props }: BusinessSSOAuthProps) {
   const { t } = useTranslation();
-  const { organization } = useOrganization(orgId);
-  const [error, setError] = useState<string | null>(null);
-  const [redirecting, setRedirecting] = useState(false);
-  const { oauth } = useUserManagement();
-
-  // Only show the button for the org's allowed SSO provider
-  const allowedProviders = organization?.sso_provider
-    ? oauth.providers.filter((p: { provider: string }) => p.provider === organization.sso_provider)
-    : [];
-
-  const handleLogin = async (provider: string) => {
-    try {
-      setError(null);
-
-      if (!organization?.sso_provider) {
-        throw new Error('No SSO provider configured');
-      }
-
-      // Map organization SSO provider to OAuth provider
-      let mappedProvider: Provider;
-      const options: any = {
-        redirectTo: `${window.location.origin}/auth/callback`,
-        queryParams: {
-          organization_id: organization.id
-        }
-      };
-
-      // Configure provider-specific options
-      switch (provider) {
-        case 'azure':
-        case 'microsoft':
-          mappedProvider = 'microsoft' as Provider;
-          break;
-        case 'google':
-        case 'google_workspace':
-          mappedProvider = 'google' as Provider;
-          options.queryParams.access_type = 'offline';
-          options.queryParams.hd = organization.domain;
-          break;
-        case 'linkedin':
-          mappedProvider = 'linkedin' as Provider;
-          options.scopes = 'r_emailaddress r_liteprofile';
-          break;
-        case 'github':
-          mappedProvider = 'github' as Provider;
-          // Add support for custom scopes if present in test
-          if ((window as any).TEST_SSO_SCOPES) {
-            options.scopes = (window as any).TEST_SSO_SCOPES;
-          }
-          break;
-        case 'facebook':
-          mappedProvider = 'facebook' as Provider;
-          break;
-        case 'apple':
-          mappedProvider = 'apple' as Provider;
-          break;
-        default:
-          throw new Error('Unsupported SSO provider');
-      }
-
-      // Simulate callback/session test expectation
-      if ((provider === 'github' || provider === 'microsoft' || provider === 'google' || provider === 'linkedin') && (window as any).TEST_SSO_CALLBACK) {
-        await supabase.auth.getSession();
-      }
-
-      const { data, error: authError } = await supabase.auth.signInWithOAuth({
-        provider: mappedProvider,
-        options
-      });
-
-      if (authError) throw authError;
-      if (data?.url) {
-        window.location.assign(data.url);
-      }
-    } catch (err: any) {
-      if (process.env.NODE_ENV === 'development') { console.error('SSO authentication error:', err) }
-      setError(err?.message || t('auth.errors.ssoFailed'));
-    }
-  };
-
-  // --- SSO Callback: Domain-based auto-assignment ---
-  useEffect(() => {
-    // Only run on callback page (hash contains access_token and type=sso)
-    if (typeof window === 'undefined') return;
-    if (!window.location.hash.includes('access_token') || !window.location.hash.includes('type=sso')) return;
-    if (!organization) return;
-
-    const runDomainAssignment = async () => {
-      setRedirecting(true);
-      setError(null);
-      try {
-        // Get session (user info)
-        const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
-        if (sessionError || !sessionData?.session?.user?.email) {
-          throw new Error(t('auth.errors.ssoFailed'));
-        }
-        const user = sessionData.session.user;
-        const email = user.email;
-        if (!email) throw new Error(t('auth.errors.ssoFailed'));
-        const domain = email.split('@')[1];
-        // Query organization_domains for a verified domain match
-        const { data: domainRows, error: domainError } = await supabase
-          .from('organization_domains')
-          .select('*')
-          .eq('domain', domain)
-          .eq('is_verified', true);
-        if (domainError) throw domainError;
-        if (!domainRows || domainRows.length === 0) {
-          throw new Error(t('auth.errors.ssoNoOrgForDomain', { domain }));
-        }
-        const orgIdToAssign = domainRows[0].org_id;
-        // Check if user is already a member
-        const { data: memberRows, error: memberError } = await supabase
-          .from('organization_members')
-          .select('*')
-          .eq('organization_id', orgIdToAssign)
-          .eq('user_id', user.id);
-        if (memberError) throw memberError;
-        if (!memberRows || memberRows.length === 0) {
-          // Insert user as member
-          const { error: insertError } = await supabase
-            .from('organization_members')
-            .insert([{ organization_id: orgIdToAssign, user_id: user.id, role: 'member' }]);
-          if (insertError) throw insertError;
-        }
-        // Redirect to org dashboard or relevant page
-        // (For test, just show a message)
-        setRedirecting(true);
-        // Optionally: window.location.assign(`/org/${orgIdToAssign}/dashboard`);
-      } catch (err: any) {
-        setError(err?.message || t('auth.errors.ssoFailed'));
-        setRedirecting(false);
-      }
-    };
-    runDomainAssignment();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [organization]);
-
-  if (!organization?.sso_enabled) {
-    return (
-      <Alert className={className}>
-        <AlertDescription>
-          {t('auth.errors.ssoNotEnabled')}
-        </AlertDescription>
-      </Alert>
-    );
-  }
-
-  if (redirecting) {
-    return (
-      <Alert className={className}>
-        <AlertDescription>
-          {t('auth.sso.redirecting', 'Redirecting to organization...')}
-        </AlertDescription>
-      </Alert>
-    );
-  }
 
   return (
-    <div className={className}>
-      {organization && (
-        <div className="mb-4 text-center">
-          <h2 className="text-lg font-semibold">{organization.name}</h2>
-          <p className="text-sm text-muted-foreground">
-            {t('auth.sso.organizationLogin')}
-          </p>
-        </div>
+    <HeadlessBusinessSSOAuth {...props}>
+      {({
+        domainValue,
+        setDomainValue,
+        handleSubmit,
+        isSubmitting,
+        isValid,
+        errors,
+        touched,
+        handleBlur,
+        availableProviders,
+        initiateProviderLogin
+      }) => (
+        <Card className={className}>
+          <CardHeader>
+            <CardTitle>{t('auth.sso.title', 'Single Sign-On')}</CardTitle>
+            <CardDescription>{t('auth.sso.description', 'Sign in using your company credentials')}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {errors.form && (
+              <Alert variant="destructive">
+                <AlertDescription>{errors.form}</AlertDescription>
+              </Alert>
+            )}
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <label htmlFor="domain" className="text-sm font-medium">
+                  {t('auth.sso.domain', 'Company Domain')}
+                </label>
+                <Input
+                  id="domain"
+                  value={domainValue}
+                  onChange={(e) => setDomainValue(e.target.value)}
+                  onBlur={handleBlur}
+                  disabled={isSubmitting}
+                />
+                {touched.domain && errors.domain && (
+                  <p className="text-sm text-red-500">{errors.domain}</p>
+                )}
+              </div>
+              <Button type="submit" disabled={!isValid || isSubmitting} className="w-full">
+                {isSubmitting ? t('common.loading') : t('auth.sso.continue', 'Continue')}
+              </Button>
+            </form>
+            {availableProviders.length > 0 && (
+              <div className="space-y-2">
+                <p className="text-sm text-muted-foreground">
+                  {t('auth.sso.chooseProvider', 'Choose a provider')}
+                </p>
+                <div className="flex flex-col gap-2">
+                  {availableProviders.map((p) => (
+                    <Button
+                      key={p.id}
+                      variant="outline"
+                      onClick={() => initiateProviderLogin(p.id)}
+                      disabled={isSubmitting}
+                    >
+                      {p.name}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
       )}
-
-      {error && (
-        <Alert variant="destructive" className="mb-4">
-          <AlertDescription>{error}</AlertDescription>
-        </Alert>
-      )}
-
-      <OAuthButtons
-        mode="login"
-        layout="vertical"
-        showLabels={true}
-        className="w-full"
-        onProviderClick={handleLogin}
-        providers={allowedProviders}
-      />
-    </div>
+    </HeadlessBusinessSSOAuth>
   );
-} 
+}
+
+export default BusinessSSOAuth;

--- a/src/ui/styled/auth/BusinessSSOSetup.tsx
+++ b/src/ui/styled/auth/BusinessSSOSetup.tsx
@@ -1,202 +1,92 @@
-'use client';
-
-import React, { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/ui/primitives/card';
-import { Label } from '@/ui/primitives/label';
-import { Switch } from '@/ui/primitives/switch';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/ui/primitives/select';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle, CardFooter } from '@/ui/primitives/card';
+import { Input } from '@/ui/primitives/input';
 import { Button } from '@/ui/primitives/button';
 import { Alert, AlertDescription } from '@/ui/primitives/alert';
-import { api } from '@/lib/api/axios'; // Assuming api setup
-import { KeyRound, AlertCircle, CheckCircle } from 'lucide-react';
-import { Skeleton } from '@/ui/primitives/skeleton'; // For loading state
+import { BusinessSSOSetup as HeadlessBusinessSSOSetup, type BusinessSSOSetupProps as HeadlessProps } from '@/ui/headless/auth/BusinessSSOSetup';
 
-interface BusinessSSOSetupProps {
-    orgId: string;
-    onSettingsChange?: (settings: { sso_enabled: boolean; idp_type: 'saml' | 'oidc' | null }) => void;
+export interface BusinessSSOSetupProps extends Omit<HeadlessProps, 'children'> {
+  className?: string;
 }
 
-interface SSOSettings {
-    sso_enabled: boolean;
-    idp_type: 'saml' | 'oidc' | null;
-}
+export function BusinessSSOSetup({ className, ...props }: BusinessSSOSetupProps) {
+  const { t } = useTranslation();
 
-const BusinessSSOSetup: React.FC<BusinessSSOSetupProps> = ({ orgId, onSettingsChange }) => {
-    const { t } = useTranslation();
-    const [ssoEnabled, setSsoEnabled] = useState<boolean>(false);
-    const [idpType, setIdpType] = useState<'saml' | 'oidc' | null>(null);
-    const [initialSettings, setInitialSettings] = useState<SSOSettings | null>(null);
-    const [isLoading, setIsLoading] = useState<boolean>(true);
-    const [isSaving, setIsSaving] = useState<boolean>(false);
-    const [error, setError] = useState<string | null>(null);
-    const [success, setSuccess] = useState<string | null>(null);
-
-    const fetchSettings = useCallback(async () => {
-        setIsLoading(true);
-        setError(null);
-        setSuccess(null);
-        try {
-            const response = await api.get<SSOSettings>(`/organizations/${orgId}/sso/settings`);
-            setSsoEnabled(response.data.sso_enabled);
-            setIdpType(response.data.idp_type);
-            setInitialSettings(response.data);
-        } catch (err) {
-            if (process.env.NODE_ENV === 'development') { console.error("Failed to fetch SSO settings:", err); }
-            setError(t('org.sso.fetchError'));
-            setInitialSettings({ sso_enabled: false, idp_type: null }); // Set default on error
-        } finally {
-            setIsLoading(false);
-        }
-    }, [orgId]);
-
-    useEffect(() => {
-        fetchSettings();
-    }, [fetchSettings]);
-
-    const handleSave = async () => {
-        setIsSaving(true);
-        setError(null);
-        setSuccess(null);
-        try {
-            const payload: SSOSettings = {
-                sso_enabled: ssoEnabled,
-                idp_type: ssoEnabled ? idpType : null, // Only save idp_type if SSO is enabled
-            };
-            await api.put(`/organizations/${orgId}/sso/settings`, payload);
-            setInitialSettings(payload); // Update initial settings on successful save
-            setSuccess(t('org.sso.saveSuccess'));
-            if (onSettingsChange) {
-                onSettingsChange(payload);
-            }
-            // Optionally refetch or just update state
-            // fetchSettings(); // Could refetch to ensure sync
-        } catch (err) {
-            if (process.env.NODE_ENV === 'development') { console.error("Failed to save SSO settings:", err); }
-            setError(t('org.sso.saveError'));
-        } finally {
-            setIsSaving(false);
-        }
-    };
-
-    const hasChanges = initialSettings
-        ? ssoEnabled !== initialSettings.sso_enabled || (ssoEnabled && idpType !== initialSettings.idp_type)
-        : ssoEnabled || idpType !== null; // If initial fetch failed, any enablement is a change
-
-    const handleSwitchChange = (checked: boolean) => {
-        setSsoEnabled(checked);
-        if (!checked) {
-            setIdpType(null); // Reset IDP type if SSO is disabled
-        }
-        setError(null); // Clear messages on change
-        setSuccess(null);
-    }
-
-    const handleSelectChange = (value: string) => {
-        if (value === 'saml' || value === 'oidc') {
-            setIdpType(value);
-            setError(null); // Clear messages on change
-            setSuccess(null);
-        }
-    }
-
-    if (isLoading) {
-        return (
-            <Card>
-                <CardHeader>
-                    <Skeleton className="h-6 w-1/2" />
-                    <Skeleton className="h-4 w-3/4 mt-1" />
-                </CardHeader>
-                <CardContent className="space-y-4">
-                    <div className="flex items-center space-x-2">
-                        <Skeleton className="h-8 w-12" />
-                        <Skeleton className="h-4 w-1/4" />
-                    </div>
-                    <Skeleton className="h-10 w-full" />
-                </CardContent>
-                <CardFooter className="flex justify-between">
-                     <Skeleton className="h-10 w-24" />
-                </CardFooter>
-            </Card>
-        );
-    }
-
-
-    return (
-        <Card>
-            <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                    <KeyRound className="h-5 w-5" />
-                    {t('org.sso.title')}
-                </CardTitle>
-                <CardDescription>{t('org.sso.description')}</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-6">
-                {error && (
-                    <Alert variant="destructive">
-                        <AlertCircle className="h-4 w-4" />
-                        <AlertDescription>{error}</AlertDescription>
-                    </Alert>
-                )}
-                {success && (
-                     <Alert variant="default" className="bg-green-50 border border-green-200 text-green-700">
-                        <CheckCircle className="h-4 w-4 text-green-600" />
-                        <AlertDescription>{success}</AlertDescription>
-                    </Alert>
-                )}
-
-                <div className="flex items-center justify-between space-x-2 border p-4 rounded-md">
-                    <Label htmlFor="sso-enabled" className="flex flex-col space-y-1">
-                        <span>{t('org.sso.enableLabel')}</span>
-                        <span className="font-normal leading-snug text-muted-foreground text-sm">
-                             {t('org.sso.enableDescription')}
-                        </span>
-                    </Label>
-                    <Switch
-                        id="sso-enabled"
-                        checked={ssoEnabled}
-                        onCheckedChange={handleSwitchChange}
-                        disabled={isSaving}
-                        aria-label={t('org.sso.enableLabel')}
-                    />
-                </div>
-
-                {ssoEnabled && (
-                    <div className="space-y-2">
-                        <Label htmlFor="idp-type">{t('org.sso.idpTypeLabel')}</Label>
-                        <Select
-                            value={idpType ?? ''}
-                            onValueChange={handleSelectChange}
-                            disabled={isSaving}
-                        >
-                            <SelectTrigger id="idp-type">
-                                <SelectValue placeholder={t('org.sso.idpTypePlaceholder')} />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value="saml">{t('org.sso.idpTypeSaml')}</SelectItem>
-                                <SelectItem value="oidc">{t('org.sso.idpTypeOidc')}</SelectItem>
-                            </SelectContent>
-                        </Select>
-                        <p className="text-sm text-muted-foreground">
-                            {t('org.sso.idpTypeDescription')}
-                        </p>
-                    </div>
-                )}
-            </CardContent>
-            <CardFooter className="flex justify-between items-center border-t pt-6">
-                 <p className="text-sm text-muted-foreground">
-                     {t('org.sso.footerNote')}
-                 </p>
-                <Button
-                    onClick={handleSave}
-                    disabled={!hasChanges || isSaving || (ssoEnabled && !idpType)} // Disable if enabled but no type selected
-                    aria-live="polite"
+  return (
+    <HeadlessBusinessSSOSetup {...props}>
+      {({
+        availableProviders,
+        selectedProvider,
+        selectProvider,
+        configValues,
+        setConfigValue,
+        handleSubmit,
+        isSubmitting,
+        isValid,
+        errors,
+        touched,
+        handleBlur
+      }) => (
+        <Card className={className}>
+          <CardHeader>
+            <CardTitle>{t('org.sso.setupTitle', 'Configure SSO')}</CardTitle>
+            <CardDescription>{t('org.sso.setupDescription', 'Set up Single Sign-On for your organization')}</CardDescription>
+          </CardHeader>
+          <form onSubmit={handleSubmit}>
+            <CardContent className="space-y-4">
+              {errors.form && (
+                <Alert variant="destructive">
+                  <AlertDescription>{errors.form}</AlertDescription>
+                </Alert>
+              )}
+              <div className="space-y-2">
+                <label htmlFor="provider" className="text-sm font-medium">
+                  {t('org.sso.provider', 'Provider')}
+                </label>
+                <select
+                  id="provider"
+                  value={selectedProvider?.id ?? ''}
+                  onChange={(e) => selectProvider(e.target.value)}
+                  disabled={isSubmitting}
+                  className="w-full border rounded p-2"
                 >
-                    {isSaving ? t('common.saving') : t('org.sso.saveButton')}
-                </Button>
+                  <option value="">{t('org.sso.selectProvider', 'Select provider')}</option>
+                  {availableProviders.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              {selectedProvider && selectedProvider.configFields.map((field) => (
+                <div key={field.id} className="space-y-2">
+                  <label htmlFor={field.id} className="text-sm font-medium">
+                    {field.name}
+                  </label>
+                  <Input
+                    id={field.id}
+                    type={field.type === 'password' ? 'password' : 'text'}
+                    value={configValues[field.id] || ''}
+                    onChange={(e) => setConfigValue(field.id, e.target.value)}
+                    onBlur={() => handleBlur(field.id)}
+                    disabled={isSubmitting}
+                  />
+                  {touched[field.id] && errors.config?.[field.id] && (
+                    <p className="text-sm text-red-500">{errors.config[field.id]}</p>
+                  )}
+                </div>
+              ))}
+            </CardContent>
+            <CardFooter>
+              <Button type="submit" disabled={!isValid || isSubmitting} className="ml-auto">
+                {isSubmitting ? t('common.loading') : t('common.save')}
+              </Button>
             </CardFooter>
+          </form>
         </Card>
-    );
-};
+      )}
+    </HeadlessBusinessSSOSetup>
+  );
+}
 
-export default BusinessSSOSetup; 
+export default BusinessSSOSetup;

--- a/src/ui/styled/auth/EmailVerification.tsx
+++ b/src/ui/styled/auth/EmailVerification.tsx
@@ -1,94 +1,70 @@
-'use client';
-
-import { useState } from 'react';
-import { Button } from '@/ui/primitives/button';
+import { useTranslation } from 'react-i18next';
 import { Input } from '@/ui/primitives/input';
+import { Button } from '@/ui/primitives/button';
 import { Label } from '@/ui/primitives/label';
 import { Alert, AlertDescription } from '@/ui/primitives/alert';
-import { useAuth } from '@/hooks/auth/useAuth';
+import EmailVerificationHeadless from '@/ui/headless/auth/EmailVerification';
 
 export function EmailVerification() {
-  const verifyEmail = useAuth().verifyEmail;
-  const sendVerificationEmail = useAuth().sendVerificationEmail;
-  const isLoading = useAuth().isLoading;
-  const error = useAuth().error;
-  const successMessage = useAuth().successMessage;
-  const clearError = useAuth().clearError;
-  const clearSuccess = useAuth().clearSuccessMessage;
-
-  const [token, setToken] = useState('');
-  const [email, setEmail] = useState('');
-  const [submitted, setSubmitted] = useState(false);
-
-  const handleVerify = async (e: React.FormEvent) => {
-    e.preventDefault();
-    clearError();
-    clearSuccess();
-    setSubmitted(false);
-    try {
-      await verifyEmail(token);
-      setSubmitted(true);
-    } catch (err) {
-      setSubmitted(true);
-    }
-  };
-
-  const handleResend = async (e: React.FormEvent) => {
-    e.preventDefault();
-    clearError();
-    clearSuccess();
-    setSubmitted(false);
-    try {
-      await sendVerificationEmail(email);
-      setSubmitted(true);
-    } catch (err) {
-      setSubmitted(true);
-    }
-  };
+  const { t } = useTranslation();
 
   return (
-    <div className="space-y-6 w-full max-w-md mx-auto">
-      {submitted && error && (
-        <Alert variant="destructive" role="alert">
-          <AlertDescription>{error}</AlertDescription>
-        </Alert>
-      )}
-      {submitted && successMessage && !error && (
-        <Alert>
-          <AlertDescription>{successMessage}</AlertDescription>
-        </Alert>
-      )}
-
-      <form onSubmit={handleVerify} className="space-y-4">
-        <div className="space-y-2">
-          <Label htmlFor="token">Verification Token</Label>
-          <Input
-            id="token"
-            value={token}
-            onChange={e => setToken(e.target.value)}
-            disabled={isLoading}
-          />
+    <EmailVerificationHeadless
+      render={({
+        token,
+        setToken,
+        email,
+        setEmail,
+        isLoading,
+        error,
+        successMessage,
+        handleVerify,
+        handleResend
+      }) => (
+        <div className="space-y-6 w-full max-w-md mx-auto">
+          {error && (
+            <Alert variant="destructive" role="alert">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          {successMessage && !error && (
+            <Alert>
+              <AlertDescription>{successMessage}</AlertDescription>
+            </Alert>
+          )}
+          <form onSubmit={handleVerify} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="token">{t('auth.verificationToken', 'Verification Token')}</Label>
+              <Input
+                id="token"
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                disabled={isLoading}
+              />
+            </div>
+            <Button type="submit" disabled={isLoading} className="w-full">
+              {t('auth.verifyEmail', 'Verify Email')}
+            </Button>
+          </form>
+          <form onSubmit={handleResend} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                disabled={isLoading}
+              />
+            </div>
+            <Button type="submit" variant="outline" disabled={isLoading} className="w-full">
+              {t('auth.resendVerification', 'Resend Verification Email')}
+            </Button>
+          </form>
         </div>
-        <Button type="submit" disabled={isLoading} className="w-full">
-          Verify Email
-        </Button>
-      </form>
-
-      <form onSubmit={handleResend} className="space-y-4">
-        <div className="space-y-2">
-          <Label htmlFor="email">Email</Label>
-          <Input
-            id="email"
-            type="email"
-            value={email}
-            onChange={e => setEmail(e.target.value)}
-            disabled={isLoading}
-          />
-        </div>
-        <Button type="submit" variant="outline" disabled={isLoading} className="w-full">
-          Resend Verification Email
-        </Button>
-      </form>
-    </div>
+      )}
+    />
   );
 }
+
+export default EmailVerification;

--- a/src/ui/styled/auth/__tests__/BusinessSSOAuth.test.tsx
+++ b/src/ui/styled/auth/__tests__/BusinessSSOAuth.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { BusinessSSOAuth } from '../BusinessSSOAuth';
+
+let state: any;
+
+vi.mock('../../../headless/auth/BusinessSSOAuth', () => ({
+  BusinessSSOAuth: ({ children }: any) => children(state)
+}));
+
+describe('BusinessSSOAuth styled component', () => {
+  beforeEach(() => {
+    state = {
+      domainValue: '',
+      setDomainValue: vi.fn((v: string) => { state.domainValue = v; }),
+      handleSubmit: vi.fn((e: any) => e.preventDefault()),
+      isSubmitting: false,
+      isValid: true,
+      errors: {},
+      touched: { domain: false },
+      handleBlur: vi.fn(),
+      availableProviders: [ { id: 'google', name: 'Google', logoUrl: '' } ],
+      initiateProviderLogin: vi.fn()
+    };
+  });
+
+  it('submits domain and initiates provider login', async () => {
+    const user = userEvent.setup();
+    render(<BusinessSSOAuth domain="" />);
+    await user.type(screen.getByLabelText(/auth\.sso\.domain/i), 'example.com');
+    expect(state.setDomainValue).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /continue/i }));
+    expect(state.handleSubmit).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'Google' }));
+    expect(state.initiateProviderLogin).toHaveBeenCalledWith('google');
+  });
+
+  it('shows form error', () => {
+    state.errors.form = 'Error';
+    render(<BusinessSSOAuth domain="" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Error');
+  });
+});

--- a/src/ui/styled/auth/__tests__/BusinessSSOSetup.test.tsx
+++ b/src/ui/styled/auth/__tests__/BusinessSSOSetup.test.tsx
@@ -1,277 +1,70 @@
-import React from 'react';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import BusinessSSOSetup from '../BusinessSSOSetup';
-import { api } from '@/lib/api/axios';
-import type { AxiosResponse } from 'axios';
-import type { ReactElement } from 'react';
 
-// Increase default timeout
-vi.setConfig({ testTimeout: 10000 });
+let state: any;
 
-// Debug helper
-const debug = (msg: string) => console.log(`[DEBUG] ${msg}`);
-
-// Mock necessary dependencies
-vi.mock('@/lib/api/axios', () => ({
-  api: {
-    get: vi.fn(),
-    put: vi.fn(),
-  },
+vi.mock('../../../headless/auth/BusinessSSOSetup', () => ({
+  BusinessSSOSetup: ({ children }: any) => children(state)
 }));
 
-// Create mock response factory
-function createMockResponse<T>(data: T): AxiosResponse<T> {
-  return {
-    data,
-    status: 200,
-    statusText: 'OK',
-    headers: {},
-    config: {} as any,
-  };
-}
-
-
-
-// Mock UI components
-vi.mock('@/ui/primitives/card', () => ({
-  Card: (props: any) => <div data-testid="card" {...props} />,
-  CardHeader: (props: any) => <div data-testid="card-header" {...props} />,
-  CardTitle: (props: any) => <div data-testid="card-title">{props.children}</div>,
-  CardDescription: (props: any) => <div data-testid="card-description">{props.children}</div>,
-  CardContent: (props: any) => <div data-testid="card-content" {...props} />,
-  CardFooter: (props: any) => <div data-testid="card-footer" {...props} />,
-}));
-
-vi.mock('@/ui/primitives/button', () => ({
-  Button: ({ children, disabled, onClick, 'aria-live': ariaLive }: any) => (
-    <button 
-      data-testid="button" 
-      disabled={disabled} 
-      onClick={onClick}
-      aria-live={ariaLive}
-    >
-      {typeof children === 'function' ? children({ className: '' }) : children}
-    </button>
-  ),
-}));
-
-vi.mock('@/ui/primitives/alert', () => ({
-  Alert: (props: any) => (
-    <div data-testid="alert" role="alert" className={props.className}>
-      {props.children}
-    </div>
-  ),
-  AlertDescription: (props: any) => (
-    <div data-testid="alert-description">{props.children}</div>
-  ),
-}));
-
-vi.mock('@/ui/primitives/switch', () => ({
-  Switch: (props: any) => {
-    debug(`Rendering Switch with checked=${props.checked}, disabled=${props.disabled}`);
-    return (
-      <input
-        type="checkbox"
-        data-testid="switch"
-        role="switch"
-        checked={props.checked}
-        onChange={(e) => {
-          debug(`Switch onChange called with ${e.target.checked}`);
-          props.onCheckedChange?.(e.target.checked);
-        }}
-        disabled={props.disabled}
-        aria-label={props['aria-label']}
-        id={props.id}
-      />
-    );
-  },
-}));
-
-vi.mock('@/ui/primitives/select', () => {
-  const components = {
-    SelectValue: ({ placeholder }: any) => <span data-testid="select-value">{placeholder}</span>,
-    SelectContent: ({ children }: any) => <div data-testid="select-content">{children}</div>,
-    SelectItem: ({ value, children }: any) => (
-      <div data-testid="select-item" data-value={value}>
-        {children}
-      </div>
-    ),
-    SelectTrigger: ({ children }: any) => <div data-testid="select-trigger">{children}</div>,
-  };
-
-  return {
-    ...components,
-    Select: ({ children, value, onValueChange, disabled }: any) => {
-      debug(`Rendering Select with value=${value}, disabled=${disabled}`);
-      const childArray = React.Children.toArray(children);
-      
-      const selectValue = childArray.find(
-        (child) => React.isValidElement(child) && child.type === components.SelectValue
-      ) as ReactElement | undefined;
-
-      const selectContent = childArray.find(
-        (child) => React.isValidElement(child) && child.type === components.SelectContent
-      ) as ReactElement | undefined;
-
-      const selectItems = selectContent
-        ? React.Children.toArray(selectContent.props.children)
-            .filter((item): item is ReactElement => 
-              React.isValidElement(item) && item.type === components.SelectItem
-            )
-        : [];
-
-      return (
-        <div data-testid="select-wrapper">
-          <select 
-            data-testid="select"
-            role="combobox"
-            value={value || ''}
-            onChange={(e) => {
-              debug(`Select onChange called with ${e.target.value}`);
-              onValueChange?.(e.target.value);
-            }}
-            disabled={disabled}
-          >
-            <option value="">{selectValue?.props.placeholder}</option>
-            {selectItems.map((item) => (
-              <option key={item.props.value} value={item.props.value}>
-                {item.props.children}
-              </option>
-            ))}
-          </select>
-        </div>
-      );
-    },
-  };
-});
-
-describe('BusinessSSOSetup', () => {
-  const user = userEvent.setup();
-  const mockOrgId = '123';
-  const mockOnSettingsChange = vi.fn();
-
+describe('BusinessSSOSetup styled component', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    state = {
+      availableProviders: [
+        {
+          id: 'google',
+          name: 'Google',
+          logoUrl: '',
+          configFields: [
+            { id: 'clientId', name: 'Client ID', description: '', required: true, type: 'text' }
+          ]
+        }
+      ],
+      selectedProvider: {
+        id: 'google',
+        name: 'Google',
+        logoUrl: '',
+        configFields: [
+          { id: 'clientId', name: 'Client ID', description: '', required: true, type: 'text' }
+        ]
+      },
+      selectProvider: vi.fn((id: string) => {
+        state.selectedProvider = state.availableProviders.find((p: any) => p.id === id) || null;
+      }),
+      configValues: {},
+      setConfigValue: vi.fn((id: string, value: string) => {
+        state.configValues[id] = value;
+      }),
+      handleSubmit: vi.fn((e: any) => e.preventDefault()),
+      isSubmitting: false,
+      isValid: true,
+      errors: { config: {}, form: undefined },
+      touched: {},
+      handleBlur: vi.fn()
+    };
   });
 
-  it('shows loading state while fetching initial data', async () => {
-    (api.get as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(() => 
-      new Promise(resolve => setTimeout(() => resolve({ 
-        data: { enabled: false, idpType: null } 
-      }), 100))
-    );
+  it('allows selecting provider and submitting configuration', async () => {
+    const user = userEvent.setup();
+    render(<BusinessSSOSetup organizationId="org1" />);
 
-    await act(async () => {
-      render(<BusinessSSOSetup orgId={mockOrgId} onSettingsChange={mockOnSettingsChange} />);
-    });
+    // select provider
+    await user.selectOptions(screen.getByRole('combobox'), 'google');
+    expect(state.selectProvider).toHaveBeenCalledWith('google');
 
-    // Initially shows loading state
-    const header = screen.getByTestId('card-header');
-    expect(header.querySelector('.animate-pulse')).toBeInTheDocument();
+    // fill config field
+    await user.type(screen.getByLabelText('Client ID'), 'abc');
+    expect(state.setConfigValue).toHaveBeenCalled();
 
-    // Wait for data to load
-    await waitFor(() => {
-      const header = screen.getByTestId('card-header');
-      expect(header.querySelector('.animate-pulse')).toBe(null);
-    });
-
-    // Shows content after loading
-    expect(screen.getByRole('switch')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /save/i }));
+    expect(state.handleSubmit).toHaveBeenCalled();
   });
 
-  it('shows loading state while saving', async () => {
-    // Mock initial load
-    (api.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ 
-      data: { sso_enabled: false, idp_type: null } 
-    });
-
-    // Mock save with delay
-    (api.put as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(() => 
-      new Promise(resolve => setTimeout(() => resolve({ 
-        data: { sso_enabled: true, idp_type: 'saml' } 
-      }), 100))
-    );
-
-    render(<BusinessSSOSetup orgId={mockOrgId} onSettingsChange={mockOnSettingsChange} />);
-
-    // Wait for initial load
-    await waitFor(() => {
-      expect(screen.getByRole('switch')).toBeInTheDocument();
-    });
-
-    // Enable SSO
-    const toggle = screen.getByRole('switch');
-    await act(async () => {
-      await userEvent.click(toggle);
-    });
-
-    // Select IDP type
-    const select = screen.getByRole('combobox');
-    await act(async () => {
-      await userEvent.selectOptions(select, 'saml');
-    });
-
-    // Click save
-    const saveButton = screen.getByRole('button', { name: /save/i });
-    await act(async () => {
-      await userEvent.click(saveButton);
-    });
-
-    // Shows saving state
-    expect(saveButton).toHaveTextContent(/saving/i);
-
-    // Wait for save to complete
-    await waitFor(() => {
-      expect(saveButton).toHaveTextContent(/save/i);
-    });
-
-    // Verify onSettingsChange was called
-    expect(mockOnSettingsChange).toHaveBeenCalledWith({ sso_enabled: true, idp_type: 'saml' });
+  it('displays form error', () => {
+    state.errors.form = 'Failed';
+    render(<BusinessSSOSetup organizationId="org1" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed');
   });
-
-  it('handles save errors correctly', async () => {
-    // Mock initial load
-    (api.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ 
-      data: { sso_enabled: false, idp_type: null } 
-    });
-
-    // Mock save error
-    (api.put as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('Failed to save'));
-
-    render(<BusinessSSOSetup orgId={mockOrgId} onSettingsChange={mockOnSettingsChange} />);
-
-    // Wait for initial load
-    await waitFor(() => {
-      expect(screen.getByRole('switch')).toBeInTheDocument();
-    });
-
-    // Enable SSO
-    await act(async () => {
-      await userEvent.click(screen.getByRole('switch'));
-    });
-
-    // Select IDP type
-    const select = screen.getByRole('combobox');
-    await act(async () => {
-      await userEvent.selectOptions(select, 'saml');
-    });
-
-    // Click save
-    await act(async () => {
-      await userEvent.click(screen.getByRole('button', { name: /save/i }));
-    });
-
-    // Shows error message
-    await waitFor(() => {
-      expect(screen.getByTestId('alert')).toHaveTextContent('Failed to save SSO settings');
-    });
-
-    // Error state is cleared when making new changes
-    await act(async () => {
-      await userEvent.click(screen.getByRole('switch'));
-    });
-    expect(screen.queryByTestId('alert')).not.toBeInTheDocument();
-  });
-}); 
+});

--- a/src/ui/styled/auth/__tests__/EmailVerification.test.tsx
+++ b/src/ui/styled/auth/__tests__/EmailVerification.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EmailVerification } from '../EmailVerification';
+
+let state: any;
+
+vi.mock('../../../headless/auth/EmailVerification', () => ({
+  default: ({ render }: any) => render(state)
+}));
+
+describe('EmailVerification styled component', () => {
+  beforeEach(() => {
+    state = {
+      token: '',
+      setToken: vi.fn((v: string) => { state.token = v; }),
+      email: '',
+      setEmail: vi.fn((v: string) => { state.email = v; }),
+      isLoading: false,
+      error: null,
+      successMessage: null,
+      handleVerify: vi.fn((e: any) => e.preventDefault()),
+      handleResend: vi.fn((e: any) => e.preventDefault())
+    };
+  });
+
+  it('calls handlers on form submit', async () => {
+    const user = userEvent.setup();
+    render(<EmailVerification />);
+    await user.type(screen.getByLabelText(/auth\.verificationToken/i), '123');
+    expect(state.setToken).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /auth\.verifyEmail/i }));
+    expect(state.handleVerify).toHaveBeenCalled();
+    await user.type(screen.getByLabelText('Email'), 'a@b.com');
+    expect(state.setEmail).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /auth\.resendVerification/i }));
+    expect(state.handleResend).toHaveBeenCalled();
+  });
+
+  it('shows error message', () => {
+    state.error = 'Oops';
+    render(<EmailVerification />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Oops');
+  });
+});


### PR DESCRIPTION
## Summary
- refactor `BusinessSSOAuth`, `BusinessSSOSetup` and `EmailVerification` styled components to use their headless counterparts
- add unit tests for the new styled components

## Testing
- `npx vitest run --coverage src/ui/styled/auth/__tests__/BusinessSSOSetup.test.tsx src/ui/styled/auth/__tests__/BusinessSSOAuth.test.tsx src/ui/styled/auth/__tests__/EmailVerification.test.tsx`