### PR TITLE
Refactor AddressCard to use headless version

### DIFF
--- a/src/ui/styled/company/AddressCard.tsx
+++ b/src/ui/styled/company/AddressCard.tsx
@@ -2,6 +2,7 @@ import { CompanyAddress } from '@/types/company';
 import { Card, CardContent } from '@/ui/primitives/card';
 import { Button } from '@/ui/primitives/button';
 import { Edit, Trash2 } from 'lucide-react';
+import { AddressCard as AddressCardHeadless } from '@/ui/headless/company/AddressCard';
 
 interface AddressCardProps {
   address: CompanyAddress;
@@ -11,42 +12,49 @@ interface AddressCardProps {
 
 export function AddressCard({ address, onEdit, onDelete }: AddressCardProps) {
   return (
-    <Card className="w-full">
-      <CardContent className="pt-6">
-        <div className="flex justify-between items-start">
-          <div className="space-y-1">
-            <p className="font-medium">{address.street_address}</p>
-            {address.street_address2 && (
-              <p className="text-sm text-muted-foreground">{address.street_address2}</p>
-            )}
-            <p className="text-sm text-muted-foreground">
-              {address.city}, {address.state} {address.postal_code}
-            </p>
-            <p className="text-sm text-muted-foreground">{address.country}</p>
-            {address.is_default && (
-              <p className="text-sm text-primary">Default Address</p>
-            )}
-          </div>
-          <div className="flex gap-2">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => onEdit(address)}
-              aria-label="Edit address"
-            >
-              <Edit className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => onDelete(address)}
-              aria-label="Delete address"
-            >
-              <Trash2 className="h-4 w-4" />
-            </Button>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+    <AddressCardHeadless
+      address={address}
+      onEdit={onEdit}
+      onDelete={onDelete}
+      render={({ address, onEdit, onDelete }) => (
+        <Card className="w-full">
+          <CardContent className="pt-6">
+            <div className="flex justify-between items-start">
+              <div className="space-y-1">
+                <p className="font-medium">{address.street_line1}</p>
+                {address.street_line2 && (
+                  <p className="text-sm text-muted-foreground">{address.street_line2}</p>
+                )}
+                <p className="text-sm text-muted-foreground">
+                  {address.city}, {address.state} {address.postal_code}
+                </p>
+                <p className="text-sm text-muted-foreground">{address.country}</p>
+                {address.is_primary && (
+                  <p className="text-sm text-primary">Default Address</p>
+                )}
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={onEdit}
+                  aria-label="Edit address"
+                >
+                  <Edit className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={onDelete}
+                  aria-label="Delete address"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    />
   );
-} 
+}

--- a/src/ui/styled/company/__tests__/AddressCard.test.tsx
+++ b/src/ui/styled/company/__tests__/AddressCard.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AddressCard } from '../AddressCard';
+import { CompanyAddress } from '@/types/company';
+
+describe('AddressCard styled component', () => {
+  const address: CompanyAddress = {
+    id: '1',
+    company_id: 'c1',
+    type: 'billing',
+    street_line1: '123 Main St',
+    street_line2: 'Suite 4',
+    city: 'Metropolis',
+    state: 'NY',
+    postal_code: '12345',
+    country: 'USA',
+    is_primary: true,
+    validated: true,
+    created_at: '',
+    updated_at: '',
+  };
+
+  it('renders address info and triggers callbacks', async () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    const user = userEvent.setup();
+    render(<AddressCard address={address} onEdit={onEdit} onDelete={onDelete} />);
+    expect(screen.getByText('123 Main St')).toBeInTheDocument();
+    expect(screen.getByText('Suite 4')).toBeInTheDocument();
+    await user.click(screen.getByLabelText('Edit address'));
+    expect(onEdit).toHaveBeenCalledWith(address);
+    await user.click(screen.getByLabelText('Delete address'));
+    expect(onDelete).toHaveBeenCalledWith(address);
+  });
+});


### PR DESCRIPTION
## Summary
- refactor `AddressCard` styled component to rely on headless `AddressCard`
- add unit test for styled `AddressCard`

## Testing
- `npx vitest run --coverage src/ui/styled/company/__tests__/AddressCard.test.tsx`