### PR TITLE
Refactor styled components to use headless versions

### DIFF
--- a/src/ui/styled/dashboard/Dashboard.tsx
+++ b/src/ui/styled/dashboard/Dashboard.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { Dashboard as HeadlessDashboard } from '../../headless/dashboard/Dashboard';
+import React from "react";
+// Already uses the headless dashboard implementation
+import { Dashboard as HeadlessDashboard } from "../../headless/dashboard/Dashboard";
 
 export const Dashboard: React.FC = () => (
   <HeadlessDashboard>
@@ -24,8 +25,12 @@ export const Dashboard: React.FC = () => (
             onSubmit={(e) => {
               e.preventDefault();
               const form = e.target as HTMLFormElement;
-              const title = (form.elements.namedItem('title') as HTMLInputElement).value;
-              const description = (form.elements.namedItem('description') as HTMLInputElement).value;
+              const title = (
+                form.elements.namedItem("title") as HTMLInputElement
+              ).value;
+              const description = (
+                form.elements.namedItem("description") as HTMLInputElement
+              ).value;
 
               if (currentItem) {
                 handleUpdate(currentItem.id, title, description);
@@ -36,11 +41,19 @@ export const Dashboard: React.FC = () => (
           >
             <div>
               <label htmlFor="title">Title</label>
-              <input id="title" name="title" defaultValue={currentItem?.title || ''} />
+              <input
+                id="title"
+                name="title"
+                defaultValue={currentItem?.title || ""}
+              />
             </div>
             <div>
               <label htmlFor="description">Description</label>
-              <input id="description" name="description" defaultValue={currentItem?.description || ''} />
+              <input
+                id="description"
+                name="description"
+                defaultValue={currentItem?.description || ""}
+              />
             </div>
             <button type="submit">Save</button>
           </form>
@@ -64,7 +77,7 @@ export const Dashboard: React.FC = () => (
                 <button
                   onClick={() => {
                     /* istanbul ignore next */
-                    if (window.confirm('Are you sure?')) {
+                    if (window.confirm("Are you sure?")) {
                       handleDelete(item.id);
                     }
                   }}

--- a/src/ui/styled/gdpr/AccountDeletion.tsx
+++ b/src/ui/styled/gdpr/AccountDeletion.tsx
@@ -1,8 +1,15 @@
-'use client';
+"use client";
 
-import React, { useState } from 'react';
-import { Button } from '@/ui/primitives/button';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/ui/primitives/card';
+import { useTranslation } from "react-i18next";
+import { Trash2, Loader2, AlertTriangle } from "lucide-react";
+import { Button } from "@/ui/primitives/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/ui/primitives/card";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -13,103 +20,86 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogTrigger,
-} from "@/ui/primitives/alert-dialog"
-import { useToast } from "@/ui/primitives/use-toast";
-import { Trash2, Loader2, AlertTriangle } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
-import { api } from '@/lib/api/axios';
-import { useAuth } from '@/hooks/auth/use-auth';
+} from "@/ui/primitives/alert-dialog";
+import { AccountDeletion as HeadlessAccountDeletion } from "../../headless/account/AccountDeletion";
 
 export function AccountDeletion() {
   const { t } = useTranslation();
-  const { toast } = useToast();
-  const { logout } = useAuth();
-  const [isLoading, setIsLoading] = useState(false);
-  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
-
-  const handleDelete = async () => {
-    setIsLoading(true);
-    try {
-      // In a real implementation, might need to pass password confirmation here
-      const response = await api.post('/api/gdpr/delete');
-
-      toast({
-        title: t('gdpr.delete.successTitle'),
-        description: response.data.message || t('gdpr.delete.successDescription'),
-      });
-
-      // Wait a bit for toast to show, then log out
-      setTimeout(() => {
-          logout();
-          // Optionally redirect to home page or login page
-          // window.location.href = '/';
-      }, 2000);
-
-    } catch (error: any) {
-      if (process.env.NODE_ENV === 'development') { console.error("Account deletion error:", error); }
-      toast({
-        variant: "destructive",
-        title: t('common.error'),
-        description: error.response?.data?.error || t('gdpr.delete.errorDescription'),
-      });
-      setIsLoading(false); // Only set loading false on error, on success user is signed out
-    }
-     // Keep dialog open on error 
-    // setIsConfirmOpen(false); // Close dialog on success is handled by sign out
-  };
 
   return (
-    <Card className="border-destructive/50">
-      <CardHeader>
-        <CardTitle className="text-destructive">{t('gdpr.delete.title')}</CardTitle>
-        <CardDescription>{t('gdpr.delete.description')}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <AlertDialog open={isConfirmOpen} onOpenChange={setIsConfirmOpen}>
-          <AlertDialogTrigger asChild>
-            <Button variant="destructive" disabled={isLoading}>
-              {isLoading ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <Trash2 className="mr-2 h-4 w-4" />
-              )}
-              {isLoading ? t('common.loading') : t('gdpr.delete.buttonText')}
-            </Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>
-                <AlertTriangle className="inline-block mr-2 h-5 w-5 text-destructive" />
-                {t('gdpr.delete.confirmTitle')}
-              </AlertDialogTitle>
-              <AlertDialogDescription>
-                 {t('gdpr.delete.confirmDescription1')} 
-                 <strong className="text-destructive">{t('gdpr.delete.confirmDescription2')}</strong>
-                 {t('gdpr.delete.confirmDescription3')}
-                 {/* Add input for password confirmation here in real implementation */}
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel disabled={isLoading}>{t('common.cancel')}</AlertDialogCancel>
-              <AlertDialogAction 
-                onClick={handleDelete} 
-                disabled={isLoading}
-                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-               >
-                {isLoading ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : (
-                   t('gdpr.delete.confirmButton')
+    <HeadlessAccountDeletion
+      render={({
+        isDialogOpen,
+        setIsDialogOpen,
+        isLoading,
+        error,
+        localError,
+        handleDeleteAccount,
+      }) => (
+        <Card className="border-destructive/50">
+          <CardHeader>
+            <CardTitle className="text-destructive">
+              {t("gdpr.delete.title")}
+            </CardTitle>
+            <CardDescription>{t("gdpr.delete.description")}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+              <AlertDialogTrigger asChild>
+                <Button variant="destructive" disabled={isLoading}>
+                  {isLoading ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="mr-2 h-4 w-4" />
+                  )}
+                  {isLoading
+                    ? t("common.loading")
+                    : t("gdpr.delete.buttonText")}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>
+                    <AlertTriangle className="inline-block mr-2 h-5 w-5 text-destructive" />
+                    {t("gdpr.delete.confirmTitle")}
+                  </AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {t("gdpr.delete.confirmDescription1")}
+                    <strong className="text-destructive">
+                      {t("gdpr.delete.confirmDescription2")}
+                    </strong>
+                    {t("gdpr.delete.confirmDescription3")}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                {(error || localError) && (
+                  <p className="text-destructive text-sm" role="alert">
+                    {error || localError}
+                  </p>
                 )}
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
-
-        <p className="text-xs text-muted-foreground mt-3">
-            {t('gdpr.delete.helpText')}
-        </p>
-      </CardContent>
-    </Card>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={isLoading}>
+                    {t("common.cancel")}
+                  </AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={handleDeleteAccount}
+                    disabled={isLoading}
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  >
+                    {isLoading ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      t("gdpr.delete.confirmButton")
+                    )}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+            <p className="text-xs text-muted-foreground mt-3">
+              {t("gdpr.delete.helpText")}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+    />
   );
-} 
+}

--- a/src/ui/styled/gdpr/ConsentManagement.tsx
+++ b/src/ui/styled/gdpr/ConsentManagement.tsx
@@ -1,15 +1,23 @@
-'use client';
+"use client";
 
-import { Checkbox } from '@/ui/primitives/checkbox';
-import { Button } from '@/ui/primitives/button';
-import { Label } from '@/ui/primitives/label';
-import { Alert, AlertDescription } from '@/ui/primitives/alert';
-import { ConsentManagement as HeadlessConsentManagement } from '../../headless/gdpr/ConsentManagement';
+import { Checkbox } from "@/ui/primitives/checkbox";
+import { Button } from "@/ui/primitives/button";
+import { Label } from "@/ui/primitives/label";
+import { Alert, AlertDescription } from "@/ui/primitives/alert";
+// This component already follows the headless pattern, so no refactoring needed.
+import { ConsentManagement as HeadlessConsentManagement } from "../../headless/gdpr/ConsentManagement";
 
 export function ConsentManagement() {
   return (
     <HeadlessConsentManagement
-      render={({ marketing, setMarketing, isLoading, error, submitted, handleSave }) => (
+      render={({
+        marketing,
+        setMarketing,
+        isLoading,
+        error,
+        submitted,
+        handleSave,
+      }) => (
         <div className="space-y-4 w-full max-w-md mx-auto">
           {submitted && error && (
             <Alert variant="destructive" role="alert">
@@ -25,11 +33,13 @@ export function ConsentManagement() {
             <Checkbox
               id="marketing-consent"
               checked={marketing}
-              onCheckedChange={val => setMarketing(val === true)}
+              onCheckedChange={(val) => setMarketing(val === true)}
             />
             <Label htmlFor="marketing-consent">Allow marketing emails</Label>
           </div>
-          <Button onClick={handleSave} disabled={isLoading}>Save</Button>
+          <Button onClick={handleSave} disabled={isLoading}>
+            Save
+          </Button>
         </div>
       )}
     />

--- a/src/ui/styled/gdpr/DataExport.tsx
+++ b/src/ui/styled/gdpr/DataExport.tsx
@@ -1,171 +1,141 @@
-'use client';
+"use client";
 
-import React, { useState } from 'react';
-import { Button } from '@/ui/primitives/button';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from '@/ui/primitives/card';
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Download, Loader2, AlertCircle, CheckCircle2 } from "lucide-react";
+import { Button } from "@/ui/primitives/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardFooter,
+} from "@/ui/primitives/card";
+import { Alert, AlertDescription } from "@/ui/primitives/alert";
+import { RadioGroup, RadioGroupItem } from "@/ui/primitives/radio-group";
+import { Label } from "@/ui/primitives/label";
+import { Progress } from "@/ui/primitives/progress";
 import { useToast } from "@/ui/primitives/use-toast";
-import { Download, Loader2, AlertCircle, CheckCircle2 } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
-import { api } from '@/lib/api/axios';
-import { RadioGroup, RadioGroupItem } from '@/ui/primitives/radio-group';
-import { Label } from '@/ui/primitives/label';
-import { Alert, AlertDescription } from '@/ui/primitives/alert';
-import { useIsMobile } from '@/lib/utils/responsive';
-import { Progress } from '@/ui/primitives/progress';
-
-// Define export formats
-enum ExportFormat {
-  JSON = 'json',
-  CSV = 'csv'
-}
+import { useIsMobile } from "@/lib/utils/responsive";
+import {
+  DataExport as HeadlessDataExport,
+  ExportFormat,
+} from "../../headless/settings/DataExport";
 
 export function DataExport() {
   const { t } = useTranslation();
   const { toast } = useToast();
-  const [isLoading, setIsLoading] = useState(false);
-  const [format, setFormat] = useState<ExportFormat>(ExportFormat.JSON);
-  const [exportProgress, setExportProgress] = useState(0);
-  const [showSuccess, setShowSuccess] = useState(false);
   const isMobile = useIsMobile();
-
-  const handleExport = async () => {
-    setIsLoading(true);
-    setExportProgress(0);
-    setShowSuccess(false);
-    
-    // Simulate progress for better UX feedback
-    const progressInterval = setInterval(() => {
-      setExportProgress(prev => {
-        // Randomly increase progress up to 90% (the actual completion will push to 100%)
-        const increase = Math.random() * 10;
-        const newValue = Math.min(prev + increase, 90);
-        return newValue;
-      });
-    }, 500);
-
-    try {
-      const response = await api.get(`/api/gdpr/export?format=${format}`, {
-        responseType: 'blob',
-      });
-
-      // Create a URL for the blob
-      const url = window.URL.createObjectURL(new Blob([response.data]));
-      const link = document.createElement('a');
-      link.href = url;
-
-      // Extract filename from content-disposition header if available
-      const contentDisposition = response.headers['content-disposition'];
-      let filename = `user_data_export.${format}`;
-      if (contentDisposition) {
-        const filenameMatch = contentDisposition.match(/filename="?(.+)"?/i);
-        if (filenameMatch && filenameMatch.length > 1) {
-          filename = filenameMatch[1];
-        }
-      }
-      link.setAttribute('download', filename);
-
-      // Append to html link element page
-      document.body.appendChild(link);
-
-      // Start download
-      link.click();
-
-      // Clean up and remove the link
-      link.parentNode?.removeChild(link);
-      window.URL.revokeObjectURL(url);
-
-      // Complete progress and show success
-      setExportProgress(100);
-      setShowSuccess(true);
-      
-      toast({
-        title: t('gdpr.export.successTitle'),
-        description: t('gdpr.export.successDescription'),
-      });
-    } catch (error: any) {
-      if (process.env.NODE_ENV === 'development') { console.error("Data export error:", error); }
-      toast({
-        variant: "destructive",
-        title: t('common.error'),
-        description: error.response?.data?.error || t('gdpr.export.errorDescription'),
-      });
-    } finally {
-      clearInterval(progressInterval);
-      setIsLoading(false);
-    }
-  };
+  const [progress, setProgress] = useState(0);
+  const [showSuccess, setShowSuccess] = useState(false);
 
   return (
-    <Card className="w-full max-w-md mx-auto">
-      <CardHeader>
-        <CardTitle>{t('gdpr.export.title')}</CardTitle>
-        <CardDescription>{t('gdpr.export.description')}</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-6">
-        {/* Format Selection */}
-        <div className="space-y-3">
-          <h3 className="text-sm font-medium">{t('gdpr.export.format')}</h3>
-          <RadioGroup
-            value={format}
-            onValueChange={(value) => setFormat(value as ExportFormat)}
-            className={isMobile ? "grid grid-cols-1 gap-2" : "grid grid-cols-2 gap-2"}
+    <HeadlessDataExport
+      onComplete={() => setShowSuccess(true)}
+      render={({
+        selectedFormat,
+        setSelectedFormat,
+        isLoading,
+        error,
+        handleExport,
+      }) => (
+        <Card className="w-full max-w-md mx-auto">
+          <CardHeader>
+            <CardTitle>{t("gdpr.export.title")}</CardTitle>
+            <CardDescription>{t("gdpr.export.description")}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {error && (
+              <Alert variant="destructive" role="alert">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+            {showSuccess && (
+              <Alert
+                className="bg-green-50 border-green-200 flex items-center gap-2"
+                role="alert"
+              >
+                <CheckCircle2 className="h-4 w-4 text-green-600" />
+                <AlertDescription className="text-green-800 text-sm">
+                  {t("gdpr.export.successDescription")}
+                </AlertDescription>
+              </Alert>
+            )}
+            <div className="space-y-3">
+              <h3 className="text-sm font-medium">{t("gdpr.export.format")}</h3>
+              <RadioGroup
+                value={selectedFormat}
+                onValueChange={(val) => setSelectedFormat(val as ExportFormat)}
+                className={
+                  isMobile ? "grid grid-cols-1 gap-2" : "grid grid-cols-2 gap-2"
+                }
+              >
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value={ExportFormat.JSON} id="json" />
+                  <Label htmlFor="json" className="cursor-pointer">
+                    JSON
+                  </Label>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value={ExportFormat.CSV} id="csv" />
+                  <Label htmlFor="csv" className="cursor-pointer">
+                    CSV
+                  </Label>
+                </div>
+              </RadioGroup>
+            </div>
+            {isLoading && (
+              <div className="space-y-2">
+                <div className="flex justify-between text-xs text-muted-foreground">
+                  <span>{t("gdpr.export.preparing")}</span>
+                  <span>{Math.round(progress)}%</span>
+                </div>
+                <Progress value={progress} className="h-2" />
+              </div>
+            )}
+            <p className="text-xs text-muted-foreground">
+              {t("gdpr.export.helpText")}
+            </p>
+          </CardContent>
+          <CardFooter
+            className={
+              isMobile ? "flex-col space-y-4" : "flex-row justify-between"
+            }
           >
-            <div className="flex items-center space-x-2">
-              <RadioGroupItem value={ExportFormat.JSON} id="json" />
-              <Label htmlFor="json" className="cursor-pointer">JSON</Label>
+            <Button
+              onClick={async () => {
+                setShowSuccess(false);
+                setProgress(0);
+                const interval = setInterval(() => {
+                  setProgress((p) => Math.min(p + Math.random() * 10, 90));
+                }, 500);
+                await handleExport();
+                clearInterval(interval);
+                setProgress(100);
+                toast({
+                  title: t("gdpr.export.successTitle"),
+                  description: t("gdpr.export.successDescription"),
+                });
+              }}
+              disabled={isLoading}
+              className={isMobile ? "w-full" : ""}
+              {...(isLoading ? { role: "status" } : {})}
+            >
+              {isLoading ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Download className="mr-2 h-4 w-4" />
+              )}
+              {isLoading ? t("common.loading") : t("gdpr.export.buttonText")}
+            </Button>
+            <div className="flex items-center text-xs text-muted-foreground gap-1">
+              <AlertCircle className="h-3 w-3" />
+              <span>{t("gdpr.export.dataPrivacyNote")}</span>
             </div>
-            <div className="flex items-center space-x-2">
-              <RadioGroupItem value={ExportFormat.CSV} id="csv" />
-              <Label htmlFor="csv" className="cursor-pointer">CSV</Label>
-            </div>
-          </RadioGroup>
-        </div>
-        
-        {/* Progress Indicator */}
-        {isLoading && (
-          <div className="space-y-2">
-            <div className="flex justify-between text-xs text-muted-foreground">
-              <span>{t('gdpr.export.preparing')}</span>
-              <span>{Math.round(exportProgress)}%</span>
-            </div>
-            <Progress value={exportProgress} className="h-2" />
-          </div>
-        )}
-        
-        {/* Success Message */}
-        {showSuccess && (
-          <Alert className="bg-green-50 border-green-200 flex items-center gap-2">
-            <CheckCircle2 className="h-4 w-4 text-green-600" />
-            <AlertDescription className="text-green-800 text-sm">
-              {t('gdpr.export.successDescription')}
-            </AlertDescription>
-          </Alert>
-        )}
-        
-        <p className="text-xs text-muted-foreground">
-          {t('gdpr.export.helpText')}
-        </p>
-      </CardContent>
-      <CardFooter className={isMobile ? "flex-col space-y-4" : "flex-row justify-between"}>
-        <Button 
-          onClick={handleExport} 
-          disabled={isLoading} 
-          className={isMobile ? "w-full" : ""}
-          {...(isLoading ? { role: "status" } : {})}
-        >
-          {isLoading ? (
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-          ) : (
-            <Download className="mr-2 h-4 w-4" />
-          )}
-          {isLoading ? t('common.loading') : t('gdpr.export.buttonText')}
-        </Button>
-        
-        <div className="flex items-center text-xs text-muted-foreground gap-1">
-          <AlertCircle className="h-3 w-3" />
-          <span>{t('gdpr.export.dataPrivacyNote')}</span>
-        </div>
-      </CardFooter>
-    </Card>
+          </CardFooter>
+        </Card>
+      )}
+    />
   );
-} 
+}

--- a/src/ui/styled/layout/Features.tsx
+++ b/src/ui/styled/layout/Features.tsx
@@ -1,39 +1,59 @@
-import { ReactNode } from 'react';
-import { cn } from '@/lib/utils';
-import { Box, Layers, Zap } from 'lucide-react';
-import { Features as HeadlessFeatures, FeatureItem, FeaturesProps as HeadlessProps } from '../../headless/layout/Features';
+import { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { Box, Layers, Zap } from "lucide-react";
+// Already uses headless implementation
+import {
+  Features as HeadlessFeatures,
+  FeatureItem,
+  FeaturesProps as HeadlessProps,
+} from "../../headless/layout/Features";
 
-export interface FeaturesProps extends Omit<HeadlessProps, 'children'> {
+export interface FeaturesProps extends Omit<HeadlessProps, "children"> {
   className?: string;
 }
 
 const defaultFeatures: FeatureItem[] = [
   {
-    name: 'Modular Components',
-    description: 'Build your application with reusable, production-ready components.',
+    name: "Modular Components",
+    description:
+      "Build your application with reusable, production-ready components.",
     icon: Box,
   },
   {
-    name: 'Flexible Architecture',
-    description: 'Designed to scale with your needs, from simple apps to complex systems.',
+    name: "Flexible Architecture",
+    description:
+      "Designed to scale with your needs, from simple apps to complex systems.",
     icon: Layers,
   },
   {
-    name: 'Lightning Fast',
-    description: 'Optimized for performance with modern web technologies.',
+    name: "Lightning Fast",
+    description: "Optimized for performance with modern web technologies.",
     icon: Zap,
   },
 ];
 
-export function Features({ title, description, features, className }: FeaturesProps) {
+export function Features({
+  title,
+  description,
+  features,
+  className,
+}: FeaturesProps) {
   return (
-    <HeadlessFeatures title={title} description={description} features={features ?? defaultFeatures}>
+    <HeadlessFeatures
+      title={title}
+      description={description}
+      features={features ?? defaultFeatures}
+    >
       {({ title, description, features }) => (
-        <div className={cn('py-24 sm:py-32', className)}>
+        <div className={cn("py-24 sm:py-32", className)}>
           <div className="mx-auto max-w-7xl px-6 lg:px-8">
             <div className="mx-auto max-w-2xl text-center">
-              <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">{title}</h2>
-              <p className="mt-6 text-lg leading-8 text-muted-foreground">{description}</p>
+              <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
+                {title}
+              </h2>
+              <p className="mt-6 text-lg leading-8 text-muted-foreground">
+                {description}
+              </p>
             </div>
             <div className="mx-auto mt-16 max-w-2xl sm:mt-20 lg:mt-24 lg:max-w-none">
               <dl className="grid max-w-xl grid-cols-1 gap-x-8 gap-y-16 lg:max-w-none lg:grid-cols-3">
@@ -46,7 +66,10 @@ export function Features({ title, description, features, className }: FeaturesPr
                         target="_blank"
                         rel="noopener noreferrer"
                       >
-                        <feature.icon className="h-5 w-5 flex-none text-primary" aria-hidden="true" />
+                        <feature.icon
+                          className="h-5 w-5 flex-none text-primary"
+                          aria-hidden="true"
+                        />
                         {feature.name}
                       </a>
                     ) : feature.onClick ? (
@@ -55,12 +78,18 @@ export function Features({ title, description, features, className }: FeaturesPr
                         onClick={feature.onClick}
                         className="flex items-center gap-x-3 text-lg font-semibold leading-7 hover:text-primary focus:text-primary transition-colors bg-transparent border-none p-0 m-0 cursor-pointer"
                       >
-                        <feature.icon className="h-5 w-5 flex-none text-primary" aria-hidden="true" />
+                        <feature.icon
+                          className="h-5 w-5 flex-none text-primary"
+                          aria-hidden="true"
+                        />
                         {feature.name}
                       </button>
                     ) : (
                       <dt className="flex items-center gap-x-3 text-lg font-semibold leading-7">
-                        <feature.icon className="h-5 w-5 flex-none text-primary" aria-hidden="true" />
+                        <feature.icon
+                          className="h-5 w-5 flex-none text-primary"
+                          aria-hidden="true"
+                        />
                         {feature.name}
                       </dt>
                     )}

--- a/src/ui/styled/layout/Footer.tsx
+++ b/src/ui/styled/layout/Footer.tsx
@@ -1,9 +1,13 @@
-import { useTranslation } from 'react-i18next';
-import { Footer as HeadlessFooter, FooterProps as HeadlessProps } from '../../headless/layout/Footer';
+import { useTranslation } from "react-i18next";
+// Already refactored to use headless Footer
+import {
+  Footer as HeadlessFooter,
+  FooterProps as HeadlessProps,
+} from "../../headless/layout/Footer";
 
-interface FooterProps extends Omit<HeadlessProps, 'children'> {}
+interface FooterProps extends Omit<HeadlessProps, "children"> {}
 
-export function Footer({ position = 'static' }: FooterProps) {
+export function Footer({ position = "static" }: FooterProps) {
   const { t } = useTranslation();
   return (
     <HeadlessFooter position={position}>
@@ -11,15 +15,21 @@ export function Footer({ position = 'static' }: FooterProps) {
         <footer className={footerClasses}>
           <div className="container mx-auto flex flex-col items-center justify-between gap-4 md:h-16 md:flex-row">
             <p className="text-sm text-muted-foreground">
-              &copy; {year} User Management. {t('common.allRightsReserved')}
+              &copy; {year} User Management. {t("common.allRightsReserved")}
             </p>
 
             <nav className="flex items-center gap-4 text-sm">
-              <a href="#" className="text-muted-foreground underline-offset-4 hover:underline">
-                {t('common.privacy')}
+              <a
+                href="#"
+                className="text-muted-foreground underline-offset-4 hover:underline"
+              >
+                {t("common.privacy")}
               </a>
-              <a href="#" className="text-muted-foreground underline-offset-4 hover:underline">
-                {t('common.terms')}
+              <a
+                href="#"
+                className="text-muted-foreground underline-offset-4 hover:underline"
+              >
+                {t("common.terms")}
               </a>
             </nav>
           </div>

--- a/src/ui/styled/layout/Header.tsx
+++ b/src/ui/styled/layout/Header.tsx
@@ -1,228 +1,190 @@
-import { useState, useEffect } from "react";
-import { Link, useNavigate, useLocation } from "react-router-dom";
-import { Button } from "@/ui/primitives/button";
-import { useAuth } from '@/hooks/auth/useAuth';
-import { LanguageSelector } from "@/ui/styled/settings/LanguageSelector";
+import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { useUserManagement } from "@/lib/auth/UserManagementProvider";
 import { Menu, X, User, LogOut, Settings, Home } from "lucide-react";
-import { 
-  DropdownMenu, 
-  DropdownMenuContent, 
-  DropdownMenuItem, 
-  DropdownMenuSeparator, 
-  DropdownMenuTrigger 
+import { Button } from "@/ui/primitives/button";
+import { LanguageSelector } from "@/ui/styled/settings/LanguageSelector";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
 } from "@/ui/primitives/dropdown-menu";
-import { getPlatformClasses } from "@/hooks/utils/usePlatformStyles";
-import { useIsMobile } from "@/lib/utils/responsive";
+import {
+  Header as HeadlessHeader,
+  NavItem,
+} from "../../headless/layout/Header";
 
 interface HeaderProps {
-  type?: 'fixed' | 'static' | 'sticky';
+  type?: "fixed" | "static" | "sticky";
 }
 
-export function Header({ type = 'fixed' }: HeaderProps) {
+export function Header({ type = "fixed" }: HeaderProps) {
   const { t } = useTranslation();
-  const user = useAuth().user;
-  const logout = useAuth().logout;
-  const isLoading = useAuth().isLoading;
-  
-  const { isNative, platform } = useUserManagement();
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const navigate = useNavigate();
-  const location = useLocation();
-  const isMobile = useIsMobile();
 
-  // Close mobile menu on location change
-  useEffect(() => {
-    setMobileMenuOpen(false);
-  }, [location]);
-
-  // Prevent body scrolling when mobile menu is open
-  useEffect(() => {
-    if (mobileMenuOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = '';
-    }
-    return () => {
-      document.body.style.overflow = '';
-    };
-  }, [mobileMenuOpen]);
-
-  const handleLogout = async () => {
-    try {
-      await logout();
-      navigate('/login');
-    } catch (error) {
-      if (process.env.NODE_ENV === 'development') { console.error("Logout failed:", error) }
-      navigate('/login');
-    }
-  };
-
-  const headerClasses = getPlatformClasses({
-    base: `w-full z-40 ${type === 'fixed' ? 'fixed top-0' : type === 'sticky' ? 'sticky top-0' : ''} bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 ${mobileMenuOpen ? 'shadow-md' : 'border-b'} transition-all duration-100`,
-    mobile: 'py-2 px-3',
-    web: 'py-3 px-4',
-    ios: 'pt-safe',
-  }, { platform, isNative });
-
-  if (isNative && platform !== 'web') {
-    return (
-      <header className={headerClasses}>
-        <div className="flex items-center justify-between">
-          <Link to="/" className="flex items-center space-x-2">
-            <span className="font-bold text-xl">User Management</span>
-          </Link>
-          
-          <div className="flex items-center space-x-3">
-            <LanguageSelector minimal={true} />
-            
-            {user ? (
-              <Button variant="ghost" size="icon" onClick={handleLogout} disabled={isLoading}>
-                <LogOut className="h-5 w-5" />
-              </Button>
-            ) : (
-              <Link to="/login">
-                <Button size="sm">{t('auth.login')}</Button>
-              </Link>
-            )}
-          </div>
-        </div>
-      </header>
-    );
-  }
-
-  const mainNavItems = [
-    { to: "/", label: t('common.home'), icon: <Home className="h-4 w-4 mr-2" /> },
-    { to: "/settings", label: t('settings.title'), icon: <Settings className="h-4 w-4 mr-2" /> },
-    { to: "/profile", label: t('profile.title'), icon: <User className="h-4 w-4 mr-2" /> },
+  const navItems: NavItem[] = [
+    {
+      to: "/",
+      label: t("common.home"),
+      icon: <Home className="h-4 w-4 mr-2" />,
+    },
+    {
+      to: "/settings",
+      label: t("settings.title"),
+      icon: <Settings className="h-4 w-4 mr-2" />,
+    },
+    {
+      to: "/profile",
+      label: t("profile.title"),
+      icon: <User className="h-4 w-4 mr-2" />,
+    },
   ];
 
   return (
-    <header className={headerClasses}>
-      <div className="container mx-auto flex items-center justify-between">
-        <Link to="/" className="flex items-center space-x-2 relative z-20">
-          <span className="font-bold text-xl">User Management</span>
-        </Link>
-        
-        <div className="hidden md:flex items-center space-x-6">
-          <nav className="flex items-center space-x-4">
-            {mainNavItems.slice(1).map(item => (
-              <Link
-                key={item.to}
-                to={item.to}
-                className="text-sm font-medium transition-colors hover:text-primary"
-              >
-                {item.label}
-              </Link>
-            ))}
-          </nav>
-          
-          <div className="flex items-center space-x-4">
-            <LanguageSelector />
-            
-            {user ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="icon" disabled={isLoading} aria-label={t('profile.menu')}>
-                    <User className="h-5 w-5" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem asChild>
-                    <Link to="/profile" className="flex items-center">
-                      <User className="mr-2 h-4 w-4" />
-                      {t('profile.title')}
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
-                    <Link to="/settings" className="flex items-center">
-                      <Settings className="mr-2 h-4 w-4" />
-                      {t('settings.title')}
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={handleLogout} disabled={isLoading}>
-                    <LogOut className="mr-2 h-4 w-4" />
-                    {t('auth.logout')}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ) : (
-              <Link to="/login">
-                <Button disabled={isLoading}>{t('auth.login')}</Button>
-              </Link>
-            )}
-          </div>
-        </div>
-        
-        <div className="md:hidden flex items-center gap-3">
-          <LanguageSelector minimal={true} />
-          <Button 
-            variant="ghost" 
-            size="icon"
-            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-            disabled={isLoading}
-            aria-label={mobileMenuOpen ? t('common.close') : t('common.menu')}
-            className="relative z-20"
-          >
-            {mobileMenuOpen ? (
-              <X className="h-6 w-6 transition-transform duration-300" />
-            ) : (
-              <Menu className="h-6 w-6 transition-transform duration-300" />
-            )}
-          </Button>
-        </div>
-      </div>
-      
-      {/* Mobile Menu - Full Screen Overlay */}
-      <div 
-        className={`fixed inset-0 z-10 bg-background transition-transform duration-300 ease-in-out pt-16 ${
-          mobileMenuOpen ? 'translate-y-0' : 'translate-y-full'
-        } md:hidden`}
-      >
-        <div className="container mx-auto py-6 h-full overflow-y-auto">
-          <nav className="flex flex-col space-y-6">
-            {mainNavItems.map(item => (
-              <Link 
-                key={item.to}
-                to={item.to} 
-                className="px-2 py-3 text-lg font-medium flex items-center transition-colors hover:text-primary border-b border-border/30"
-                onClick={() => setMobileMenuOpen(false)}
-              >
-                {item.icon}
-                {item.label}
-              </Link>
-            ))}
-            
-            {user ? (
-              <Button 
-                variant="ghost" 
-                className="justify-start px-2 py-6 h-auto text-lg"
-                onClick={() => {
-                  setMobileMenuOpen(false);
-                  handleLogout();
-                }}
+    <HeadlessHeader type={type} navItems={navItems}>
+      {({
+        mobileMenuOpen,
+        setMobileMenuOpen,
+        handleLogout,
+        isLoading,
+        user,
+        isMobile,
+        headerClasses,
+        navItems,
+      }) => (
+        <header className={headerClasses}>
+          <div className="container mx-auto flex items-center justify-between">
+            <Link to="/" className="flex items-center space-x-2 relative z-20">
+              <span className="font-bold text-xl">User Management</span>
+            </Link>
+
+            <div className="hidden md:flex items-center space-x-6">
+              <nav className="flex items-center space-x-4">
+                {navItems.slice(1).map((item) => (
+                  <Link
+                    key={item.to}
+                    to={item.to}
+                    className="text-sm font-medium transition-colors hover:text-primary"
+                  >
+                    {item.label}
+                  </Link>
+                ))}
+              </nav>
+
+              <div className="flex items-center space-x-4">
+                <LanguageSelector />
+                {user ? (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        disabled={isLoading}
+                        aria-label={t("profile.menu")}
+                      >
+                        <User className="h-5 w-5" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem asChild>
+                        <Link to="/profile" className="flex items-center">
+                          <User className="mr-2 h-4 w-4" />
+                          {t("profile.title")}
+                        </Link>
+                      </DropdownMenuItem>
+                      <DropdownMenuItem asChild>
+                        <Link to="/settings" className="flex items-center">
+                          <Settings className="mr-2 h-4 w-4" />
+                          {t("settings.title")}
+                        </Link>
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onClick={handleLogout}
+                        disabled={isLoading}
+                      >
+                        <LogOut className="mr-2 h-4 w-4" />
+                        {t("auth.logout")}
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                ) : (
+                  <Link to="/login">
+                    <Button disabled={isLoading}>{t("auth.login")}</Button>
+                  </Link>
+                )}
+              </div>
+            </div>
+
+            <div className="md:hidden flex items-center gap-3">
+              <LanguageSelector minimal={true} />
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
                 disabled={isLoading}
+                aria-label={
+                  mobileMenuOpen ? t("common.close") : t("common.menu")
+                }
+                className="relative z-20"
               >
-                <LogOut className="mr-2 h-5 w-5" />
-                {t('auth.logout')}
+                {mobileMenuOpen ? (
+                  <X className="h-6 w-6 transition-transform duration-300" />
+                ) : (
+                  <Menu className="h-6 w-6 transition-transform duration-300" />
+                )}
               </Button>
-            ) : (
-              <Link to="/login" onClick={() => setMobileMenuOpen(false)}>
-                <Button 
-                  variant="default" 
-                  size="lg" 
-                  disabled={isLoading}
-                  className="w-full mt-4"
-                >
-                  {t('auth.login')}
-                </Button>
-              </Link>
-            )}
-          </nav>
-        </div>
-      </div>
-    </header>
+            </div>
+          </div>
+
+          <div
+            className={`fixed inset-0 z-10 bg-background transition-transform duration-300 ease-in-out pt-16 ${
+              mobileMenuOpen ? "translate-y-0" : "translate-y-full"
+            } md:hidden`}
+          >
+            <div className="container mx-auto py-6 h-full overflow-y-auto">
+              <nav className="flex flex-col space-y-6">
+                {navItems.map((item) => (
+                  <Link
+                    key={item.to}
+                    to={item.to}
+                    className="px-2 py-3 text-lg font-medium flex items-center transition-colors hover:text-primary border-b border-border/30"
+                    onClick={() => setMobileMenuOpen(false)}
+                  >
+                    {item.icon}
+                    {item.label}
+                  </Link>
+                ))}
+                {user ? (
+                  <Button
+                    variant="ghost"
+                    className="justify-start px-2 py-6 h-auto text-lg"
+                    onClick={() => {
+                      setMobileMenuOpen(false);
+                      handleLogout();
+                    }}
+                    disabled={isLoading}
+                  >
+                    <LogOut className="mr-2 h-5 w-5" />
+                    {t("auth.logout")}
+                  </Button>
+                ) : (
+                  <Link to="/login" onClick={() => setMobileMenuOpen(false)}>
+                    <Button
+                      variant="default"
+                      size="lg"
+                      disabled={isLoading}
+                      className="w-full mt-4"
+                    >
+                      {t("auth.login")}
+                    </Button>
+                  </Link>
+                )}
+              </nav>
+            </div>
+          </div>
+        </header>
+      )}
+    </HeadlessHeader>
   );
 }

--- a/src/ui/styled/layout/Hero.tsx
+++ b/src/ui/styled/layout/Hero.tsx
@@ -1,34 +1,37 @@
-import { ReactNode } from 'react';
-import { cn } from '@/lib/utils';
+import { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { Hero as HeadlessHero } from "../../headless/layout/Hero";
 
 interface HeroProps {
   title?: ReactNode;
   description?: ReactNode;
-  children?: ReactNode; // For custom CTAs/buttons
+  children?: ReactNode;
   className?: string;
 }
 
 export function Hero({ title, description, children, className }: HeroProps) {
   return (
-    <div className={cn('relative overflow-hidden', className)}>
-      <div className="container relative z-10 mx-auto px-4 py-32 sm:px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <h1 className="text-4xl font-bold tracking-tight sm:text-6xl">
-            {title ?? (<>
-              Build Better Apps{' '}
-              <span className="text-primary">Faster</span>
-            </>)}
-          </h1>
-          <p className="mt-6 text-lg leading-8 text-muted-foreground">
-            {description ?? 'A complete solution for building modern web applications. Start with our production-ready components and focus on what matters most - your business logic.'}
-          </p>
-          <div className="mt-10 flex items-center justify-center gap-x-6">
-            {children}
+    <HeadlessHero
+      title={title}
+      description={description}
+      render={({ title, description, children }) => (
+        <div className={cn("relative overflow-hidden", className)}>
+          <div className="container relative z-10 mx-auto px-4 py-32 sm:px-6 lg:px-8">
+            <div className="mx-auto max-w-2xl text-center">
+              <h1 className="text-4xl font-bold tracking-tight sm:text-6xl">
+                {title}
+              </h1>
+              <p className="mt-6 text-lg leading-8 text-muted-foreground">
+                {description}
+              </p>
+              <div className="mt-10 flex items-center justify-center gap-x-6">
+                {children}
+              </div>
+            </div>
           </div>
+          <div className="absolute inset-0 -z-10 bg-[linear-gradient(to_right,#4f4f4f2e_1px,transparent_1px),linear-gradient(to_bottom,#4f4f4f2e_1px,transparent_1px)] bg-[size:14px_24px]"></div>
         </div>
-      </div>
-      
-      <div className="absolute inset-0 -z-10 bg-[linear-gradient(to_right,#4f4f4f2e_1px,transparent_1px),linear-gradient(to_bottom,#4f4f4f2e_1px,transparent_1px)] bg-[size:14px_24px]"></div>
-    </div>
+      )}
+    />
   );
 }

--- a/src/ui/styled/layout/Layout.tsx
+++ b/src/ui/styled/layout/Layout.tsx
@@ -1,18 +1,21 @@
-import { Outlet } from 'react-router-dom';
-import { Toaster } from '@/ui/primitives/toaster';
-import { ThemeProvider } from '@/ui/primitives/theme-provider';
+import { Outlet } from "react-router-dom";
+import { Layout as HeadlessLayout } from "../../headless/layout/Layout";
 
 export function Layout() {
   return (
-    <ThemeProvider defaultTheme="system" storageKey="user-mgmt-theme">
-      <div className="min-h-screen bg-background font-sans antialiased">
-        <div className="relative flex min-h-screen flex-col">
-          <div className="flex-1">
-            <Outlet />
+    <HeadlessLayout>
+      {({ ThemeProvider, Toaster }) => (
+        <ThemeProvider defaultTheme="system" storageKey="user-mgmt-theme">
+          <div className="min-h-screen bg-background font-sans antialiased">
+            <div className="relative flex min-h-screen flex-col">
+              <div className="flex-1">
+                <Outlet />
+              </div>
+            </div>
+            <Toaster />
           </div>
-        </div>
-        <Toaster />
-      </div>
-    </ThemeProvider>
+        </ThemeProvider>
+      )}
+    </HeadlessLayout>
   );
-} 
+}

--- a/src/ui/styled/layout/UserLayout.tsx
+++ b/src/ui/styled/layout/UserLayout.tsx
@@ -1,12 +1,14 @@
-import { SessionPolicyEnforcer } from '@/ui/styled/session/SessionPolicyEnforcer';
+import { Outlet } from "react-router-dom";
+import { UserLayout as HeadlessUserLayout } from "../../headless/layout/UserLayout";
 
-<UserContext>
-  <ThemeProvider>
-    <Toaster />
-    <AuthGuard>
-      <SessionPolicyEnforcer>
-        {/* Existing layout content */}
-      </SessionPolicyEnforcer>
-    </AuthGuard>
-  </ThemeProvider>
-</UserContext> 
+export function UserLayout() {
+  return (
+    <HeadlessUserLayout>
+      {({ SessionPolicyEnforcer }) => (
+        <SessionPolicyEnforcer>
+          <Outlet />
+        </SessionPolicyEnforcer>
+      )}
+    </HeadlessUserLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- rewrite GDPR account deletion and export UIs to use headless components
- convert layout elements (header, hero, layout, user layout) to render headless components
- document existing headless usage in dashboard, features, footer and consent management

## Testing
- `npx vitest run --coverage` *(fails: JavaScript heap out of memory)*