### PR TITLE
Refactor onboarding components using headless pattern

### DIFF
--- a/src/ui/headless/onboarding/FeatureTour.tsx
+++ b/src/ui/headless/onboarding/FeatureTour.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { useOnboarding } from '@/hooks/user/useOnboarding';
+
+export interface TourStep {
+  title: string;
+  description: string;
+  element: string;
+}
+
+export interface FeatureTourProps {
+  steps: TourStep[];
+  render: (props: {
+    currentStep: TourStep;
+    currentStepIndex: number;
+    isOpen: boolean;
+    setIsOpen: (open: boolean) => void;
+    handleNext: () => void;
+    handlePrevious: () => void;
+  }) => React.ReactNode;
+}
+
+export function FeatureTour({ steps, render }: FeatureTourProps) {
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [isOpen, setIsOpen] = useState(true);
+  const { completeStep } = useOnboarding();
+
+  const handleNext = () => {
+    if (currentStepIndex < steps.length - 1) {
+      setCurrentStepIndex(currentStepIndex + 1);
+    } else {
+      completeStep('features');
+      setIsOpen(false);
+    }
+  };
+
+  const handlePrevious = () => {
+    if (currentStepIndex > 0) {
+      setCurrentStepIndex(currentStepIndex - 1);
+    }
+  };
+
+  return (
+    <>
+      {render({
+        currentStep: steps[currentStepIndex],
+        currentStepIndex,
+        isOpen,
+        setIsOpen,
+        handleNext,
+        handlePrevious,
+      })}
+    </>
+  );
+}
+
+export default FeatureTour;

--- a/src/ui/headless/onboarding/ProgressTracker.tsx
+++ b/src/ui/headless/onboarding/ProgressTracker.tsx
@@ -1,0 +1,20 @@
+import { useOnboarding } from '@/hooks/user/useOnboarding';
+
+interface OnboardingStep {
+  id: string;
+  title: string;
+  description: string;
+  completed: boolean;
+  order: number;
+}
+
+export interface ProgressTrackerProps {
+  render: (props: { steps: OnboardingStep[]; progress: number }) => React.ReactNode;
+}
+
+export function ProgressTracker({ render }: ProgressTrackerProps) {
+  const { steps, progress } = useOnboarding();
+  return <>{render({ steps, progress })}</>;
+}
+
+export default ProgressTracker;

--- a/src/ui/headless/onboarding/SetupWizard.tsx
+++ b/src/ui/headless/onboarding/SetupWizard.tsx
@@ -1,0 +1,56 @@
+import { ReactNode, useState } from 'react';
+import { useOnboarding } from '@/hooks/user/useOnboarding';
+
+export interface SetupStep {
+  id: string;
+  title: string;
+  component: ReactNode;
+}
+
+export interface SetupWizardProps {
+  steps: SetupStep[];
+  render: (props: {
+    currentStep: SetupStep;
+    currentStepIndex: number;
+    progress: number;
+    handleNext: () => void;
+    handlePrevious: () => void;
+    setCurrentStepIndex: (index: number) => void;
+  }) => React.ReactNode;
+}
+
+export function SetupWizard({ steps, render }: SetupWizardProps) {
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const { completeStep } = useOnboarding();
+
+  const handleNext = () => {
+    if (currentStepIndex < steps.length - 1) {
+      setCurrentStepIndex(currentStepIndex + 1);
+    } else {
+      completeStep('settings');
+    }
+  };
+
+  const handlePrevious = () => {
+    if (currentStepIndex > 0) {
+      setCurrentStepIndex(currentStepIndex - 1);
+    }
+  };
+
+  const progress = ((currentStepIndex + 1) / steps.length) * 100;
+
+  return (
+    <>
+      {render({
+        currentStep: steps[currentStepIndex],
+        currentStepIndex,
+        progress,
+        handleNext,
+        handlePrevious,
+        setCurrentStepIndex,
+      })}
+    </>
+  );
+}
+
+export default SetupWizard;

--- a/src/ui/headless/onboarding/WelcomeScreen.tsx
+++ b/src/ui/headless/onboarding/WelcomeScreen.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+import { useOnboarding } from '@/hooks/user/useOnboarding';
+
+interface OnboardingStep {
+  id: string;
+  title: string;
+  description: string;
+  completed: boolean;
+  order: number;
+}
+
+export interface WelcomeScreenProps {
+  render: (props: {
+    steps: OnboardingStep[];
+    currentStep?: OnboardingStep;
+    progress: number;
+    handleNext: () => void;
+  }) => React.ReactNode;
+}
+
+export function WelcomeScreen({ render }: WelcomeScreenProps) {
+  const {
+    steps,
+    currentStepId,
+    progress,
+    setCurrentStep,
+    completeStep,
+    setHasSeenWelcome,
+  } = useOnboarding();
+
+  useEffect(() => {
+    setHasSeenWelcome(true);
+  }, [setHasSeenWelcome]);
+
+  const currentStep = steps.find((step) => step.id === currentStepId);
+
+  const handleNext = () => {
+    if (currentStep) {
+      completeStep(currentStep.id);
+      const nextStep = steps.find((step) => step.order === currentStep.order + 1);
+      if (nextStep) {
+        setCurrentStep(nextStep.id);
+      }
+    }
+  };
+
+  return <>{render({ steps, currentStep, progress, handleNext })}</>;
+}
+
+export default WelcomeScreen;

--- a/src/ui/styled/onboarding/FeatureTour.tsx
+++ b/src/ui/styled/onboarding/FeatureTour.tsx
@@ -1,13 +1,6 @@
-import { useState } from 'react';
 import { Button } from '../ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog';
-import { useOnboarding } from '@/lib/hooks/useOnboarding';
-
-interface TourStep {
-  title: string;
-  description: string;
-  element: string;
-}
+import FeatureTourHeadless, { TourStep } from '@/ui/headless/onboarding/FeatureTour';
 
 const tourSteps: TourStep[] = [
   {
@@ -28,58 +21,47 @@ const tourSteps: TourStep[] = [
 ];
 
 export function FeatureTour() {
-  const [currentStep, setCurrentStep] = useState(0);
-  const [isOpen, setIsOpen] = useState(true);
-  const { completeStep } = useOnboarding();
-
-  const handleNext = () => {
-    if (currentStep < tourSteps.length - 1) {
-      setCurrentStep(currentStep + 1);
-    } else {
-      completeStep('features');
-      setIsOpen(false);
-    }
-  };
-
-  const handlePrevious = () => {
-    if (currentStep > 0) {
-      setCurrentStep(currentStep - 1);
-    }
-  };
-
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>{tourSteps[currentStep].title}</DialogTitle>
-        </DialogHeader>
-        
-        <div className="p-4">
-          <p className="text-muted-foreground">
-            {tourSteps[currentStep].description}
-          </p>
-        </div>
+    <FeatureTourHeadless
+      steps={tourSteps}
+      render={({
+        currentStep,
+        currentStepIndex,
+        isOpen,
+        setIsOpen,
+        handleNext,
+        handlePrevious,
+      }) => (
+        <Dialog open={isOpen} onOpenChange={setIsOpen}>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>{currentStep.title}</DialogTitle>
+            </DialogHeader>
 
-        <DialogFooter className="flex justify-between">
-          <div className="flex space-x-2">
-            <Button
-              variant="outline"
-              onClick={handlePrevious}
-              disabled={currentStep === 0}
-            >
-              Previous
-            </Button>
-            <Button
-              onClick={handleNext}
-            >
-              {currentStep === tourSteps.length - 1 ? 'Finish' : 'Next'}
-            </Button>
-          </div>
-          <Button variant="ghost" onClick={() => setIsOpen(false)}>
-            Skip Tour
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+            <div className="p-4">
+              <p className="text-muted-foreground">{currentStep.description}</p>
+            </div>
+
+            <DialogFooter className="flex justify-between">
+              <div className="flex space-x-2">
+                <Button
+                  variant="outline"
+                  onClick={handlePrevious}
+                  disabled={currentStepIndex === 0}
+                >
+                  Previous
+                </Button>
+                <Button onClick={handleNext}>
+                  {currentStepIndex === tourSteps.length - 1 ? 'Finish' : 'Next'}
+                </Button>
+              </div>
+              <Button variant="ghost" onClick={() => setIsOpen(false)}>
+                Skip Tour
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
+    />
   );
 }

--- a/src/ui/styled/onboarding/ProgressTracker.tsx
+++ b/src/ui/styled/onboarding/ProgressTracker.tsx
@@ -1,48 +1,47 @@
-import { useOnboarding } from '@/lib/hooks/useOnboarding';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Progress } from '../ui/progress';
 import { CheckCircle2, Circle } from 'lucide-react';
+import ProgressTrackerHeadless from '@/ui/headless/onboarding/ProgressTracker';
 
 export function ProgressTracker() {
-  const { steps, progress } = useOnboarding();
-
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Setup Progress</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-6">
-        <Progress value={progress} className="w-full" />
-        
-        <div className="space-y-4">
-          {steps.map((step) => (
-            <div
-              key={step.id}
-              className="flex items-center space-x-3"
-            >
-              {step.completed ? (
-                <CheckCircle2 className="h-5 w-5 text-primary" />
-              ) : (
-                <Circle className="h-5 w-5 text-muted-foreground" />
-              )}
-              <div>
-                <p className="font-medium">{step.title}</p>
-                <p className="text-sm text-muted-foreground">
-                  {step.description}
-                </p>
-              </div>
-            </div>
-          ))}
-        </div>
+    <ProgressTrackerHeadless
+      render={({ steps, progress }) => (
+        <Card>
+          <CardHeader>
+            <CardTitle>Setup Progress</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <Progress value={progress} className="w-full" />
 
-        <div className="text-center text-sm text-muted-foreground">
-          {progress === 100 ? (
-            'All steps completed!'
-          ) : (
-            `${Math.round(progress)}% complete`
-          )}
-        </div>
-      </CardContent>
-    </Card>
+            <div className="space-y-4">
+              {steps.map((step) => (
+                <div key={step.id} className="flex items-center space-x-3">
+                  {step.completed ? (
+                    <CheckCircle2 className="h-5 w-5 text-primary" />
+                  ) : (
+                    <Circle className="h-5 w-5 text-muted-foreground" />
+                  )}
+                  <div>
+                    <p className="font-medium">{step.title}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {step.description}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="text-center text-sm text-muted-foreground">
+              {progress === 100 ? (
+                'All steps completed!'
+              ) : (
+                `${Math.round(progress)}% complete`
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    />
   );
 }

--- a/src/ui/styled/onboarding/SetupWizard.tsx
+++ b/src/ui/styled/onboarding/SetupWizard.tsx
@@ -1,22 +1,12 @@
-import { useState } from 'react';
-import { useOnboarding } from '@/lib/hooks/useOnboarding';
 import { Button } from '../ui/button';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '../ui/card';
 import { Progress } from '../ui/progress';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import { Checkbox } from '../ui/checkbox';
-
-interface SetupStep {
-  id: string;
-  title: string;
-  component: React.ReactNode;
-}
+import SetupWizardHeadless, { SetupStep } from '@/ui/headless/onboarding/SetupWizard';
 
 export function SetupWizard() {
-  const [currentStepIndex, setCurrentStepIndex] = useState(0);
-  const { completeStep } = useOnboarding();
-
   const steps: SetupStep[] = [
     {
       id: 'preferences',
@@ -76,39 +66,41 @@ export function SetupWizard() {
     },
   ];
 
-  const handleNext = () => {
-    if (currentStepIndex < steps.length - 1) {
-      setCurrentStepIndex(currentStepIndex + 1);
-    } else {
-      completeStep('settings');
-    }
-  };
-
-  const progress = ((currentStepIndex + 1) / steps.length) * 100;
-
   return (
-    <Card className="max-w-lg mx-auto">
-      <CardHeader>
-        <CardTitle>{steps[currentStepIndex].title}</CardTitle>
-      </CardHeader>
-      
-      <CardContent>
-        <Progress value={progress} className="mb-6" />
-        {steps[currentStepIndex].component}
-      </CardContent>
+    <SetupWizardHeadless
+      steps={steps}
+      render={({
+        currentStep,
+        currentStepIndex,
+        progress,
+        handleNext,
+        handlePrevious,
+        setCurrentStepIndex,
+      }) => (
+        <Card className="max-w-lg mx-auto">
+          <CardHeader>
+            <CardTitle>{currentStep.title}</CardTitle>
+          </CardHeader>
 
-      <CardFooter className="flex justify-between">
-        <Button
-          variant="outline"
-          onClick={() => setCurrentStepIndex(Math.max(0, currentStepIndex - 1))}
-          disabled={currentStepIndex === 0}
-        >
-          Previous
-        </Button>
-        <Button onClick={handleNext}>
-          {currentStepIndex === steps.length - 1 ? 'Finish' : 'Next'}
-        </Button>
-      </CardFooter>
-    </Card>
+          <CardContent>
+            <Progress value={progress} className="mb-6" />
+            {currentStep.component}
+          </CardContent>
+
+          <CardFooter className="flex justify-between">
+            <Button
+              variant="outline"
+              onClick={handlePrevious}
+              disabled={currentStepIndex === 0}
+            >
+              Previous
+            </Button>
+            <Button onClick={handleNext}>
+              {currentStepIndex === steps.length - 1 ? 'Finish' : 'Next'}
+            </Button>
+          </CardFooter>
+        </Card>
+      )}
+    />
   );
 }

--- a/src/ui/styled/onboarding/WelcomeScreen.tsx
+++ b/src/ui/styled/onboarding/WelcomeScreen.tsx
@@ -1,73 +1,60 @@
-import { useEffect } from 'react';
-import { useOnboarding } from '@/lib/hooks/useOnboarding';
 import { Button } from '../ui/button';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '../ui/card';
 import { Progress } from '../ui/progress';
 import { ArrowRight, Rocket } from 'lucide-react';
+import WelcomeScreenHeadless from '@/ui/headless/onboarding/WelcomeScreen';
 
 export function WelcomeScreen() {
-  const { steps, currentStepId, progress, setCurrentStep, completeStep, setHasSeenWelcome } = useOnboarding();
-
-  useEffect(() => {
-    setHasSeenWelcome(true);
-  }, [setHasSeenWelcome]);
-
-  const currentStep = steps.find((step) => step.id === currentStepId);
-
-  const handleNext = () => {
-    if (currentStep) {
-      completeStep(currentStep.id);
-      const nextStep = steps.find((step) => step.order === currentStep.order + 1);
-      if (nextStep) {
-        setCurrentStep(nextStep.id);
-      }
-    }
-  };
-
   return (
-    <Card className="max-w-lg mx-auto">
-      <CardHeader>
-        <div className="flex items-center space-x-2">
-          <Rocket className="h-6 w-6 text-primary" />
-          <CardTitle>{currentStep?.title}</CardTitle>
-        </div>
-      </CardHeader>
-      
-      <CardContent className="space-y-4">
-        <Progress value={progress} className="w-full" />
-        
-        <p className="text-muted-foreground">
-          {currentStep?.description}
-        </p>
-
-        <div className="grid gap-4">
-          {steps.map((step) => (
-            <div
-              key={step.id}
-              className={`flex items-center space-x-2 p-2 rounded ${
-                step.completed ? 'bg-primary/10' : ''
-              }`}
-            >
-              <div className={`h-2 w-2 rounded-full ${
-                step.completed ? 'bg-primary' : 'bg-muted'
-              }`} />
-              <span className={step.completed ? 'text-primary' : ''}>
-                {step.title}
-              </span>
+    <WelcomeScreenHeadless
+      render={({ steps, currentStep, progress, handleNext }) => (
+        <Card className="max-w-lg mx-auto">
+          <CardHeader>
+            <div className="flex items-center space-x-2">
+              <Rocket className="h-6 w-6 text-primary" />
+              <CardTitle>{currentStep?.title}</CardTitle>
             </div>
-          ))}
-        </div>
-      </CardContent>
+          </CardHeader>
 
-      <CardFooter className="flex justify-between">
-        <Button variant="ghost" onClick={() => {}}>
-          Skip Tour
-        </Button>
-        <Button onClick={handleNext}>
-          Next Step
-          <ArrowRight className="ml-2 h-4 w-4" />
-        </Button>
-      </CardFooter>
-    </Card>
+          <CardContent className="space-y-4">
+            <Progress value={progress} className="w-full" />
+
+            <p className="text-muted-foreground">
+              {currentStep?.description}
+            </p>
+
+            <div className="grid gap-4">
+              {steps.map((step) => (
+                <div
+                  key={step.id}
+                  className={`flex items-center space-x-2 p-2 rounded ${
+                    step.completed ? 'bg-primary/10' : ''
+                  }`}
+                >
+                  <div
+                    className={`h-2 w-2 rounded-full ${
+                      step.completed ? 'bg-primary' : 'bg-muted'
+                    }`}
+                  />
+                  <span className={step.completed ? 'text-primary' : ''}>
+                    {step.title}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+
+          <CardFooter className="flex justify-between">
+            <Button variant="ghost" onClick={() => {}}>
+              Skip Tour
+            </Button>
+            <Button onClick={handleNext}>
+              Next Step
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Button>
+          </CardFooter>
+        </Card>
+      )}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- create headless onboarding components (FeatureTour, ProgressTracker, SetupWizard, WelcomeScreen)
- refactor existing styled onboarding components to use the new headless components

## Testing
- `npx vitest run --coverage` *(fails: out of memory)*