### PR TITLE
Refactor some profile components to headless pattern

### DIFF
--- a/src/ui/styled/profile/DataExport.tsx
+++ b/src/ui/styled/profile/DataExport.tsx
@@ -1,60 +1,36 @@
-import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/ui/primitives/card';
+import { Button } from '@/ui/primitives/button';
+import { Alert, AlertDescription } from '@/ui/primitives/alert';
+import { DataExport as DataExportHeadless } from '@/ui/headless/settings/DataExport';
 
-const DataExport: React.FC = () => {
-  const [downloading, setDownloading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState<string | null>(null);
-
-  const handleExport = async () => {
-    setDownloading(true);
-    setError(null);
-    setSuccess(null);
-    try {
-      const res = await fetch('/api/profile/export');
-      if (!res.ok) throw new Error(await res.text());
-      const blob = await res.blob();
-      // Extract filename from Content-Disposition header
-      const disposition = res.headers.get('Content-Disposition');
-      let filename = 'Personal_Data_Export.json';
-      if (disposition) {
-        const match = disposition.match(/filename="(.+?)"/);
-        if (match) filename = match[1];
-      }
-      // Trigger download
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      window.URL.revokeObjectURL(url);
-      setSuccess('Your data export has been downloaded successfully.');
-    } catch (e) {
-      setError('Failed to export your data.');
-    } finally {
-      setDownloading(false);
-    }
-  };
+export default function DataExport() {
+  const { t } = useTranslation();
 
   return (
-    <div className="rounded border p-4 max-w-lg mx-auto bg-white shadow mt-6">
-      <h3 className="text-lg font-semibold mb-2">Export Your Data</h3>
-      <p className="text-sm text-gray-600 mb-4">
-        Download a copy of your profile information, account settings, and activity log. This export is provided in JSON format for your records or compliance needs.
-      </p>
-      <button
-        className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
-        onClick={handleExport}
-        disabled={downloading}
-        {...(downloading ? { role: "status" } : {})}
-      >
-        {downloading ? 'Generating export...' : 'Download My Data'}
-      </button>
-      {success && <div className="text-green-600 text-sm mt-2" role="alert">{success}</div>}
-      {error && <div className="text-red-600 text-sm mt-2" role="alert">{error}</div>}
-    </div>
+    <DataExportHeadless
+      render={({ isLoading, error, handleExport }) => (
+        <Card className="rounded border p-4 max-w-lg mx-auto bg-white shadow mt-6">
+          <CardHeader>
+            <CardTitle>{t('profile.dataExport.title', 'Export Your Data')}</CardTitle>
+            <CardDescription>
+              {t('profile.dataExport.description', 'Download a copy of your profile information, account settings, and activity log.')}
+            </CardDescription>
+          </CardHeader>
+          {error && (
+            <CardContent>
+              <Alert variant="destructive" role="alert">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            </CardContent>
+          )}
+          <CardFooter>
+            <Button onClick={handleExport} disabled={isLoading} {...(isLoading ? { role: 'status' } : {})}>
+              {isLoading ? t('profile.dataExport.generating', 'Generating export...') : t('profile.dataExport.button', 'Download My Data')}
+            </Button>
+          </CardFooter>
+        </Card>
+      )}
+    />
   );
-};
-
-export default DataExport;
+}

--- a/src/ui/styled/profile/NotificationPreferences.tsx
+++ b/src/ui/styled/profile/NotificationPreferences.tsx
@@ -1,121 +1,98 @@
-import React, { useEffect, useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { NotificationPreferences as HeadlessNotificationPreferences } from '@/ui/headless/shared/NotificationPreferences';
 
-interface NotificationPrefs {
-  email?: boolean;
-  push?: boolean;
-  marketing?: boolean;
-}
-
-const defaultPrefs: NotificationPrefs = {
-  email: true,
-  push: true,
-  marketing: false,
-};
-
-const NotificationPreferences: React.FC = () => {
-  const [prefs, setPrefs] = useState<NotificationPrefs>(defaultPrefs);
-  const [loading, setLoading] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState<string | null>(null);
-
-  useEffect(() => {
-    setLoading(true);
-    setError(null);
-    fetch('/api/profile/notifications')
-      .then(async (res) => {
-        if (!res.ok) throw new Error(await res.text());
-        return res.json();
-      })
-      .then((data) => {
-        setPrefs({ ...defaultPrefs, ...data.notifications });
-      })
-      .catch(() => setError('Failed to load notification preferences.'))
-      .finally(() => setLoading(false));
-  }, []);
-
-  const handleChange = (key: keyof NotificationPrefs) => (e: React.ChangeEvent<HTMLInputElement>) => {
-    setPrefs((prev) => ({ ...prev, [key]: e.target.checked }));
-  };
-
-  const handleSave = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setSaving(true);
-    setError(null);
-    setSuccess(null);
-    try {
-      const res = await fetch('/api/profile/notifications', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(prefs),
-      });
-      if (!res.ok) throw new Error(await res.text());
-      setSuccess('Notification preferences saved successfully.');
-    } catch {
-      setError('Failed to save notification preferences.');
-    } finally {
-      setSaving(false);
-    }
-  };
+export default function NotificationPreferences() {
+  const { t } = useTranslation();
 
   return (
-    <div className="rounded border p-4 max-w-lg mx-auto bg-white shadow mt-6">
-      <h3 className="text-lg font-semibold mb-2">Notification Preferences</h3>
-      {loading ? (
-        <div className="text-gray-500" role="status">Loading preferences...</div>
-      ) : (
-        <form onSubmit={handleSave} className="space-y-4">
-          <div>
-            <label className="flex items-center">
-              <input
-                type="checkbox"
-                checked={!!prefs.email}
-                onChange={handleChange('email')}
-                className="mr-2"
-              />
-              Email Notifications
-            </label>
-            <div className="text-xs text-gray-500 ml-6">Security alerts, account activity, important updates</div>
-          </div>
-          <div>
-            <label className="flex items-center">
-              <input
-                type="checkbox"
-                checked={!!prefs.push}
-                onChange={handleChange('push')}
-                className="mr-2"
-              />
-              Push Notifications
-            </label>
-            <div className="text-xs text-gray-500 ml-6">Browser/device notifications (requires permission)</div>
-          </div>
-          <div>
-            <label className="flex items-center">
-              <input
-                type="checkbox"
-                checked={!!prefs.marketing}
-                onChange={handleChange('marketing')}
-                className="mr-2"
-              />
-              Product & Marketing Updates
-            </label>
-            <div className="text-xs text-gray-500 ml-6">Tips, tutorials, new features, and offers</div>
-          </div>
-          <div className="flex items-center space-x-4 mt-4">
-            <button
-              type="submit"
-              className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
-              disabled={saving}
-            >
-              {saving ? 'Saving...' : 'Save Preferences'}
-            </button>
-            {success && <span className="text-green-600 text-sm" role="alert">{success}</span>}
-            {error && <span className="text-red-600 text-sm" role="alert">{error}</span>}
-          </div>
-        </form>
-      )}
-    </div>
-  );
-};
+    <HeadlessNotificationPreferences
+      render={({ preferences, isLoading, error, update }) => {
+        const [form, setForm] = useState(
+          preferences?.notifications || { email: true, push: true, marketing: false }
+        );
 
-export default NotificationPreferences;
+        useEffect(() => {
+          if (preferences) {
+            setForm(preferences.notifications);
+          }
+        }, [preferences]);
+
+        const handleChange = (key: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement>) => {
+          setForm({ ...form, [key]: e.target.checked });
+        };
+
+        const handleSave = async (e: React.FormEvent) => {
+          e.preventDefault();
+          await update({ notifications: form });
+        };
+
+        return (
+          <div className="rounded border p-4 max-w-lg mx-auto bg-white shadow mt-6">
+            <h3 className="text-lg font-semibold mb-2">
+              {t('profile.notifications.title', 'Notification Preferences')}
+            </h3>
+            {isLoading ? (
+              <div className="text-gray-500" role="status">{t('common.loading')}</div>
+            ) : (
+              <form onSubmit={handleSave} className="space-y-4">
+                <div>
+                  <label className="flex items-center">
+                    <input
+                      type="checkbox"
+                      checked={!!form.email}
+                      onChange={handleChange('email')}
+                      className="mr-2"
+                    />
+                    {t('profile.notifications.email', 'Email Notifications')}
+                  </label>
+                  <div className="text-xs text-gray-500 ml-6">
+                    {t('profile.notifications.emailHelp', 'Security alerts, account activity, important updates')}
+                  </div>
+                </div>
+                <div>
+                  <label className="flex items-center">
+                    <input
+                      type="checkbox"
+                      checked={!!form.push}
+                      onChange={handleChange('push')}
+                      className="mr-2"
+                    />
+                    {t('profile.notifications.push', 'Push Notifications')}
+                  </label>
+                  <div className="text-xs text-gray-500 ml-6">
+                    {t('profile.notifications.pushHelp', 'Browser/device notifications (requires permission)')}
+                  </div>
+                </div>
+                <div>
+                  <label className="flex items-center">
+                    <input
+                      type="checkbox"
+                      checked={!!form.marketing}
+                      onChange={handleChange('marketing')}
+                      className="mr-2"
+                    />
+                    {t('profile.notifications.marketing', 'Product & Marketing Updates')}
+                  </label>
+                  <div className="text-xs text-gray-500 ml-6">
+                    {t('profile.notifications.marketingHelp', 'Tips, tutorials, new features, and offers')}
+                  </div>
+                </div>
+                <div className="flex items-center space-x-4 mt-4">
+                  <button
+                    type="submit"
+                    className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
+                    disabled={isLoading}
+                  >
+                    {t('common.save', 'Save Preferences')}
+                  </button>
+                  {error && <span className="text-red-600 text-sm" role="alert">{error}</span>}
+                </div>
+              </form>
+            )}
+          </div>
+        );
+      }}
+    />
+  );
+}

--- a/src/ui/styled/profile/Profile.jsx
+++ b/src/ui/styled/profile/Profile.jsx
@@ -1,236 +1,137 @@
-import React from 'react';
 import { useState, useEffect } from 'react';
-import { supabase } from '@/lib/database/supabase';
+import { Button } from '@/ui/primitives/button';
+import { Input } from '@/ui/primitives/input';
+import { Alert, AlertDescription } from '@/ui/primitives/alert';
 import DataExport from './DataExport';
 import CompanyDataExport from './CompanyDataExport';
 import NotificationPreferences from './NotificationPreferences';
 import ActivityLog from './ActivityLog';
+import ProfileHeadless from '@/ui/headless/user/Profile';
 
-export default function Profile({ user }) {
-  const [loading, setLoading] = useState(true);
-  const [profile, setProfile] = useState(null);
-  const [error, setError] = useState(null);
-  const [uploading, setUploading] = useState(false);
-
-  useEffect(() => {
-    if (user) {
-      fetchProfile();
-    }
-  }, [user]);
-
-  async function fetchProfile() {
-    try {
-      setLoading(true);
-      setError(null);
-      const { data, error } = await supabase
-        .from('profiles')
-        .select('*')
-        .eq('id', user.id)
-        .single();
-
-      if (error) throw error;
-      setProfile(data);
-    } catch (error) {
-      setError('Failed to fetch profile');
-      console.error('Error fetching profile:', error);
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function updateProfile(updates) {
-    try {
-      setLoading(true);
-      setError(null);
-      const { error } = await supabase
-        .from('profiles')
-        .update(updates)
-        .eq('id', user.id);
-
-      if (error) throw error;
-      await fetchProfile();
-    } catch (error) {
-      setError('Failed to update profile');
-      console.error('Error updating profile:', error);
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function uploadAvatar(event) {
-    try {
-      setUploading(true);
-      setError(null);
-
-      if (!event.target.files || event.target.files.length === 0) {
-        throw new Error('You must select an image to upload.');
-      }
-
-      const file = event.target.files[0];
-      const fileExt = file.name.split('.').pop();
-      const filePath = `${user.id}-${Math.random()}.${fileExt}`;
-
-      const { error: uploadError } = await supabase.storage
-        .from('avatars')
-        .upload(filePath, file);
-
-      if (uploadError) throw uploadError;
-
-      const { data: { publicUrl } } = supabase.storage
-        .from('avatars')
-        .getPublicUrl(filePath);
-
-      await updateProfile({ avatar_url: publicUrl });
-    } catch (error) {
-      setError('Error uploading avatar');
-      console.error('Error uploading avatar:', error);
-    } finally {
-      setUploading(false);
-    }
-  }
-
-  if (loading) return <div>Loading...</div>;
-  if (!profile) return <div>No profile found</div>;
-
+export default function Profile() {
   return (
-    <div className="profile">
-      <h2>Profile</h2>
-      {error && <div className="error-message">{error}</div>}
-      <div className="avatar">
-        <img src={profile.avatar_url || 'https://example.com/avatar.jpg'} alt="Avatar" />
-        <div className="avatar-upload">
-          <label htmlFor="avatar-upload">
-            Upload Avatar
-            <input
-              id="avatar-upload"
-              type="file"
-              accept="image/*"
-              onChange={uploadAvatar}
-              disabled={uploading}
-            />
-          </label>
-        </div>
-      </div>
-      <form onSubmit={(e) => {
-        e.preventDefault();
-        updateProfile({
-          full_name: profile.full_name,
-          website: profile.website,
-          avatar_url: profile.avatar_url
-        });
-      }}>
-        <div>
-          <label>
-            Full Name:
-            <input
-              type="text"
-              value={profile.full_name || ''}
-              onChange={(e) => setProfile({ ...profile, full_name: e.target.value })}
-            />
-          </label>
-        </div>
-        <div>
-          <label>
-            Website:
-            <input
-              type="url"
-              value={profile.website || ''}
-              onChange={(e) => setProfile({ ...profile, website: e.target.value })}
-            />
-          </label>
-        </div>
-        <div>
-          <label>
-            Avatar URL:
-            <input
-              type="url"
-              value={profile.avatar_url || ''}
-              onChange={(e) => setProfile({ ...profile, avatar_url: e.target.value })}
-            />
-          </label>
-        </div>
-        <div className="button-container">
-          <button type="submit" disabled={loading}>
-            Update Profile
-          </button>
-        </div>
-      </form>
-      <hr style={{margin: '2rem 0'}} />
-      {/* Data Export Section */}
-      <DataExport />
-      {/* Company Data Export Section (admin only) */}
-      <CompanyDataExport />
-      <hr style={{margin: '2rem 0'}} />
-      {/* Notification Preferences Section */}
-      <NotificationPreferences />
-      <hr style={{margin: '2rem 0'}} />
-      {/* Activity Log Section */}
-      {user && <ActivityLog />}
-      <style jsx>{`
-        .profile {
-          max-width: 500px;
-          margin: 0 auto;
-          padding: 20px;
-        }
-        .avatar {
-          margin: 20px 0;
-          text-align: center;
-        }
-        .avatar img {
-          width: 150px;
-          height: 150px;
-          border-radius: 50%;
-          object-fit: cover;
-        }
-        .avatar-upload {
-          margin-top: 10px;
-        }
-        .avatar-upload input[type="file"] {
-          display: none;
-        }
-        .avatar-upload label {
-          cursor: pointer;
-          padding: 8px 16px;
-          background-color: #3b82f6;
-          color: white;
-          border-radius: 4px;
-          display: inline-block;
-        }
-        label {
-          display: block;
-          margin: 10px 0;
-        }
-        input {
-          width: 100%;
-          padding: 8px;
-          margin-top: 5px;
-          border: 1px solid #ddd;
-          border-radius: 4px;
-        }
-        .button-container {
-          margin-top: 20px;
-          text-align: center;
-        }
-        button {
-          padding: 8px 16px;
-          background-color: #3b82f6;
-          color: white;
-          border: none;
-          border-radius: 4px;
-          cursor: pointer;
-        }
-        button:disabled {
-          background-color: #9ca3af;
-          cursor: not-allowed;
-        }
-        .error-message {
-          margin: 10px 0;
-          padding: 10px;
-          background-color: #fee2e2;
-          color: #b91c1c;
-          border-radius: 4px;
-        }
-      `}</style>
-    </div>
+    <ProfileHeadless>
+      {({ profile, isLoading, error, successMessage, uploadingAvatar, updateProfile, uploadAvatar }) => {
+        const [form, setForm] = useState({ fullName: '', website: '', avatarUrl: '' });
+
+        useEffect(() => {
+          if (profile) {
+            setForm({
+              fullName: profile.fullName || '',
+              website: profile.website || '',
+              avatarUrl: profile.profilePictureUrl || ''
+            });
+          }
+        }, [profile]);
+
+        const handleSubmit = async (e) => {
+          e.preventDefault();
+          await updateProfile({ fullName: form.fullName, website: form.website });
+        };
+
+        const handleFile = (e) => {
+          const file = e.target.files?.[0];
+          if (file) uploadAvatar(file);
+        };
+
+        if (isLoading && !profile) return <div>Loading...</div>;
+        if (!profile) return <div>No profile found</div>;
+
+        return (
+          <div className="profile">
+            <h2>Profile</h2>
+            {error && (
+              <Alert variant="destructive" role="alert" className="error-message">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+            {successMessage && (
+              <Alert role="alert">
+                <AlertDescription>{successMessage}</AlertDescription>
+              </Alert>
+            )}
+            <div className="avatar">
+              <img src={form.avatarUrl || 'https://example.com/avatar.jpg'} alt="Avatar" />
+              <div className="avatar-upload">
+                <label htmlFor="avatar-upload">
+                  Upload Avatar
+                  <input id="avatar-upload" type="file" accept="image/*" onChange={handleFile} disabled={uploadingAvatar} />
+                </label>
+              </div>
+            </div>
+            <form onSubmit={handleSubmit}>
+              <div>
+                <label>
+                  Full Name:
+                  <Input type="text" value={form.fullName} onChange={(e) => setForm({ ...form, fullName: e.target.value })} />
+                </label>
+              </div>
+              <div>
+                <label>
+                  Website:
+                  <Input type="url" value={form.website} onChange={(e) => setForm({ ...form, website: e.target.value })} />
+                </label>
+              </div>
+              <div className="button-container">
+                <Button type="submit" disabled={isLoading}>Update Profile</Button>
+              </div>
+            </form>
+            <hr style={{ margin: '2rem 0' }} />
+            <DataExport />
+            <CompanyDataExport />
+            <hr style={{ margin: '2rem 0' }} />
+            <NotificationPreferences />
+            <hr style={{ margin: '2rem 0' }} />
+            <ActivityLog />
+            <style jsx>{`
+              .profile {
+                max-width: 500px;
+                margin: 0 auto;
+                padding: 20px;
+              }
+              .avatar {
+                margin: 20px 0;
+                text-align: center;
+              }
+              .avatar img {
+                width: 150px;
+                height: 150px;
+                border-radius: 50%;
+                object-fit: cover;
+              }
+              .avatar-upload {
+                margin-top: 10px;
+              }
+              .avatar-upload input[type='file'] {
+                display: none;
+              }
+              .avatar-upload label {
+                cursor: pointer;
+                padding: 8px 16px;
+                background-color: #3b82f6;
+                color: white;
+                border-radius: 4px;
+                display: inline-block;
+              }
+              label {
+                display: block;
+                margin: 10px 0;
+              }
+              input {
+                width: 100%;
+                padding: 8px;
+                margin-top: 5px;
+                border: 1px solid #ddd;
+                border-radius: 4px;
+              }
+              .button-container {
+                margin-top: 20px;
+                text-align: center;
+              }
+            `}</style>
+          </div>
+        );
+      }}
+    </ProfileHeadless>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- refactor `DataExport`, `NotificationPreferences`, and `Profile` styled components to rely on their headless counterparts via render props
- keep only UI code in these styled components
- no changes to `CorporateProfileSection` and `PrivacySettings` as there are no existing headless components for these parts

## Testing
- `npm run test:coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*