### PR TITLE
Add headless team management components

### DIFF
--- a/src/ui/headless/team/InviteMemberForm.tsx
+++ b/src/ui/headless/team/InviteMemberForm.tsx
@@ -1,0 +1,59 @@
+import { useState, FormEvent } from 'react';
+import { z } from 'zod';
+import { useTeamInvite } from '@/hooks/team/useTeamInvite';
+
+export interface InviteMemberFormRenderProps {
+  email: string;
+  role: string;
+  setEmail: (v: string) => void;
+  setRole: (v: string) => void;
+  handleSubmit: (e: FormEvent) => void;
+  isSubmitting: boolean;
+  error: string | null;
+  successMessage: string | null;
+}
+
+export interface InviteMemberFormProps {
+  teamId: string;
+  onInviteSent?: () => void;
+  children: (props: InviteMemberFormRenderProps) => React.ReactNode;
+}
+
+const inviteSchema = z.object({
+  email: z.string().email('Invalid email'),
+  role: z.string().min(1)
+});
+
+export function InviteMemberForm({ teamId, onInviteSent, children }: InviteMemberFormProps) {
+  const { inviteToTeam, isLoading, error, successMessage } = useTeamInvite();
+  const [email, setEmail] = useState('');
+  const [role, setRole] = useState('member');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      inviteSchema.parse({ email, role });
+      await inviteToTeam(teamId, { email, role });
+      setEmail('');
+      setRole('member');
+      onInviteSent?.();
+    } catch (err) {
+      // ignore, hook will expose error
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return children({
+    email,
+    role,
+    setEmail,
+    setRole,
+    handleSubmit,
+    isSubmitting: isLoading || submitting,
+    error,
+    successMessage
+  });
+}

--- a/src/ui/headless/team/InviteMemberModal.tsx
+++ b/src/ui/headless/team/InviteMemberModal.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { InviteMemberForm, InviteMemberFormRenderProps } from './InviteMemberForm';
+
+export interface SeatUsage {
+  used: number;
+  total: number;
+}
+
+export interface InviteMemberModalRenderProps {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  seatUsage: SeatUsage;
+  formProps: InviteMemberFormRenderProps;
+}
+
+export interface InviteMemberModalProps {
+  teamId: string;
+  seatUsage: SeatUsage;
+  children: (props: InviteMemberModalRenderProps) => React.ReactNode;
+}
+
+export function InviteMemberModal({ teamId, seatUsage, children }: InviteMemberModalProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <InviteMemberForm teamId={teamId} onInviteSent={() => setIsOpen(false)}>
+      {(formProps) =>
+        children({
+          isOpen,
+          open: () => setIsOpen(true),
+          close: () => setIsOpen(false),
+          seatUsage,
+          formProps
+        })
+      }
+    </InviteMemberForm>
+  );
+}

--- a/src/ui/headless/team/RemoveMemberDialog.tsx
+++ b/src/ui/headless/team/RemoveMemberDialog.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { useTeamMembers } from '@/hooks/team/useTeamMembers';
+
+export interface RemoveMemberDialogRenderProps {
+  confirmText: string;
+  setConfirmText: (v: string) => void;
+  confirm: () => Promise<void>;
+  cancel: () => void;
+  isProcessing: boolean;
+  isOpen: boolean;
+  memberId: string;
+}
+
+export interface RemoveMemberDialogProps {
+  teamId: string;
+  memberId: string;
+  isOpen: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onRemoved?: () => void;
+  children: (props: RemoveMemberDialogRenderProps) => React.ReactNode;
+}
+
+export function RemoveMemberDialog({
+  teamId,
+  memberId,
+  isOpen: controlled,
+  onOpenChange,
+  onRemoved,
+  children
+}: RemoveMemberDialogProps) {
+  const { removeTeamMember, isLoading } = useTeamMembers(teamId);
+  const [confirmText, setConfirmText] = useState('');
+  const [internal, setInternal] = useState(false);
+  const open = controlled ?? internal;
+  const setOpen = onOpenChange ?? setInternal;
+
+  const confirm = async () => {
+    if (confirmText.toLowerCase() !== 'remove') return;
+    await removeTeamMember(memberId);
+    setOpen(false);
+    onRemoved?.();
+  };
+
+  return children({
+    confirmText,
+    setConfirmText,
+    confirm,
+    cancel: () => setOpen(false),
+    isProcessing: isLoading,
+    isOpen: open,
+    memberId
+  });
+}

--- a/src/ui/headless/team/TeamInviteDialog.tsx
+++ b/src/ui/headless/team/TeamInviteDialog.tsx
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+import { useTeamInvitations } from '@/hooks/team/useTeamInvitations';
+import { InvitationStatus, TeamInvitation } from '@/core/team/models';
+
+export interface TeamInviteDialogRenderProps {
+  invitations: (TeamInvitation & { isExpired: boolean })[];
+  resend: (id: string) => Promise<void>;
+  cancel: (id: string) => Promise<void>;
+  refresh: () => Promise<void>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export interface TeamInviteDialogProps {
+  teamId: string;
+  children: (props: TeamInviteDialogRenderProps) => React.ReactNode;
+}
+
+export function TeamInviteDialog({ teamId, children }: TeamInviteDialogProps) {
+  const {
+    teamInvitations,
+    fetchTeamInvitations,
+    resendInvitation,
+    cancelInvitation,
+    isLoading,
+    error
+  } = useTeamInvitations(teamId);
+
+  useEffect(() => {
+    if (teamId) {
+      fetchTeamInvitations(teamId);
+    }
+  }, [teamId, fetchTeamInvitations]);
+
+  const invitationsWithExpiry = teamInvitations.map((inv) => ({
+    ...inv,
+    isExpired: inv.status === InvitationStatus.EXPIRED || (inv.expiresAt && new Date(inv.expiresAt) < new Date())
+  }));
+
+  return children({
+    invitations: invitationsWithExpiry,
+    resend: resendInvitation,
+    cancel: cancelInvitation,
+    refresh: () => fetchTeamInvitations(teamId),
+    isLoading,
+    error
+  });
+}

--- a/src/ui/headless/team/TeamManagement.tsx
+++ b/src/ui/headless/team/TeamManagement.tsx
@@ -1,0 +1,60 @@
+import { useEffect } from 'react';
+import { useTeams } from '@/hooks/team/useTeams';
+import { useTeamMembers } from '@/hooks/team/useTeamMembers';
+import { useTeamInvitations } from '@/hooks/team/useTeamInvitations';
+import { Team, TeamMember, TeamInvitation } from '@/core/team/models';
+
+export interface TeamManagementRenderProps {
+  team: Team | null;
+  members: TeamMember[];
+  invitations: TeamInvitation[];
+  refreshMembers: () => Promise<void>;
+  refreshInvitations: () => Promise<void>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export interface TeamManagementProps {
+  teamId: string;
+  children: (props: TeamManagementRenderProps) => React.ReactNode;
+}
+
+export function TeamManagement({ teamId, children }: TeamManagementProps) {
+  const {
+    fetchTeam,
+    currentTeam,
+    isLoading: teamsLoading,
+    error: teamsError
+  } = useTeams();
+  const {
+    members,
+    fetchTeamMembers,
+    isLoading: membersLoading,
+    error: membersError
+  } = useTeamMembers(teamId);
+  const {
+    teamInvitations,
+    fetchTeamInvitations,
+    isLoading: invitesLoading,
+    error: invitesError
+  } = useTeamInvitations(teamId);
+
+  useEffect(() => {
+    fetchTeam(teamId);
+    fetchTeamMembers();
+    fetchTeamInvitations(teamId);
+  }, [teamId, fetchTeam, fetchTeamMembers, fetchTeamInvitations]);
+
+  const isLoading = teamsLoading || membersLoading || invitesLoading;
+  const error = teamsError || membersError || invitesError || null;
+
+  return children({
+    team: currentTeam,
+    members,
+    invitations: teamInvitations,
+    refreshMembers: fetchTeamMembers,
+    refreshInvitations: () => fetchTeamInvitations(teamId),
+    isLoading,
+    error
+  });
+}

--- a/src/ui/headless/team/TeamMembersList.tsx
+++ b/src/ui/headless/team/TeamMembersList.tsx
@@ -1,0 +1,70 @@
+import { useState, useMemo } from 'react';
+import { useTeamMembers } from '@/hooks/team/useTeamMembers';
+import { TeamMember } from '@/core/team/models';
+
+export interface TeamMembersListRenderProps {
+  members: TeamMember[];
+  updateRole: (userId: string, role: string) => Promise<void>;
+  removeMember: (userId: string) => Promise<void>;
+  refresh: () => Promise<void>;
+  isLoading: boolean;
+  error: string | null;
+  filter: string;
+  setFilter: (v: string) => void;
+  sortBy: 'name' | 'role' | 'status';
+  setSortBy: (v: 'name' | 'role' | 'status') => void;
+}
+
+export interface TeamMembersListProps {
+  teamId: string;
+  onUpdateRole?: (userId: string, role: string) => Promise<void>;
+  onRemove?: (userId: string) => Promise<void>;
+  children: (props: TeamMembersListRenderProps) => React.ReactNode;
+}
+
+export function TeamMembersList({ teamId, onUpdateRole, onRemove, children }: TeamMembersListProps) {
+  const {
+    members,
+    updateTeamMember,
+    removeTeamMember,
+    fetchTeamMembers,
+    isLoading,
+    error
+  } = useTeamMembers(teamId);
+  const [filter, setFilter] = useState('');
+  const [sortBy, setSortBy] = useState<'name' | 'role' | 'status'>('name');
+
+  const filtered = useMemo(() => {
+    const data = members.filter((m) =>
+      m.userId.toLowerCase().includes(filter.toLowerCase())
+    );
+    return data.sort((a, b) => {
+      if (sortBy === 'role') return a.role.localeCompare(b.role);
+      if (sortBy === 'status') return Number(a.isActive) - Number(b.isActive);
+      return a.userId.localeCompare(b.userId);
+    });
+  }, [members, filter, sortBy]);
+
+  const updateRole = async (userId: string, role: string) => {
+    if (onUpdateRole) await onUpdateRole(userId, role);
+    else await updateTeamMember(userId, { role });
+  };
+
+  const removeMember = async (userId: string) => {
+    if (onRemove) await onRemove(userId);
+    else await removeTeamMember(userId);
+  };
+
+  return children({
+    members: filtered,
+    updateRole,
+    removeMember,
+    refresh: fetchTeamMembers,
+    isLoading,
+    error,
+    filter,
+    setFilter,
+    sortBy,
+    setSortBy
+  });
+}

--- a/src/ui/headless/team/__tests__/InviteMemberForm.test.tsx
+++ b/src/ui/headless/team/__tests__/InviteMemberForm.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { InviteMemberForm } from '../InviteMemberForm';
+import { useTeamInvite } from '@/hooks/team/useTeamInvite';
+
+vi.mock('@/hooks/team/useTeamInvite', () => ({
+  useTeamInvite: vi.fn()
+}));
+
+describe('InviteMemberForm', () => {
+  const mockInvite = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useTeamInvite as unknown as vi.Mock).mockReturnValue({
+      inviteToTeam: mockInvite,
+      isLoading: false,
+      error: null,
+      successMessage: null
+    });
+  });
+
+  it('calls inviteToTeam with form values', async () => {
+    let props: any;
+    render(
+      <InviteMemberForm teamId="1">
+        {(p) => {
+          props = p;
+          return <div />;
+        }}
+      </InviteMemberForm>
+    );
+
+    act(() => {
+      props.setEmail('test@example.com');
+      props.setRole('admin');
+    });
+
+    await act(async () => {
+      await props.handleSubmit({ preventDefault() {} } as any);
+    });
+
+    expect(mockInvite).toHaveBeenCalledWith('1', {
+      email: 'test@example.com',
+      role: 'admin'
+    });
+  });
+});

--- a/src/ui/headless/team/__tests__/InviteMemberModal.test.tsx
+++ b/src/ui/headless/team/__tests__/InviteMemberModal.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { InviteMemberModal } from '../InviteMemberModal';
+import { useTeamInvite } from '@/hooks/team/useTeamInvite';
+
+vi.mock('@/hooks/team/useTeamInvite', () => ({
+  useTeamInvite: vi.fn()
+}));
+
+describe('InviteMemberModal', () => {
+  const mockInvite = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useTeamInvite as unknown as vi.Mock).mockReturnValue({
+      inviteToTeam: mockInvite,
+      isLoading: false,
+      error: null,
+      successMessage: null
+    });
+  });
+
+  it('closes on successful invite', async () => {
+    let props: any;
+    render(
+      <InviteMemberModal teamId="1" seatUsage={{ used: 0, total: 1 }}>
+        {(p) => {
+          props = p;
+          return <div />;
+        }}
+      </InviteMemberModal>
+    );
+
+    act(() => props.open());
+    expect(props.isOpen).toBe(true);
+
+    act(() => {
+      props.formProps.setEmail('a@b.com');
+    });
+
+    await act(async () => {
+      await props.formProps.handleSubmit({ preventDefault() {} } as any);
+    });
+
+    expect(props.isOpen).toBe(false);
+  });
+});

--- a/src/ui/headless/team/__tests__/RemoveMemberDialog.test.tsx
+++ b/src/ui/headless/team/__tests__/RemoveMemberDialog.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { RemoveMemberDialog } from '../RemoveMemberDialog';
+import { useTeamMembers } from '@/hooks/team/useTeamMembers';
+
+vi.mock('@/hooks/team/useTeamMembers', () => ({
+  useTeamMembers: vi.fn()
+}));
+
+describe('RemoveMemberDialog', () => {
+  const mockRemove = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useTeamMembers as unknown as vi.Mock).mockReturnValue({
+      removeTeamMember: mockRemove,
+      isLoading: false
+    });
+  });
+
+  it('calls removeTeamMember when confirmed', async () => {
+    let props: any;
+    render(
+      <RemoveMemberDialog teamId="1" memberId="u1" isOpen={true}>
+        {(p) => {
+          props = p;
+          return <div />;
+        }}
+      </RemoveMemberDialog>
+    );
+
+    act(() => props.setConfirmText('remove'));
+    await act(async () => {
+      await props.confirm();
+    });
+
+    expect(mockRemove).toHaveBeenCalledWith('u1');
+  });
+});

--- a/src/ui/headless/team/__tests__/TeamInviteDialog.test.tsx
+++ b/src/ui/headless/team/__tests__/TeamInviteDialog.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { TeamInviteDialog } from '../TeamInviteDialog';
+import { useTeamInvitations } from '@/hooks/team/useTeamInvitations';
+
+vi.mock('@/hooks/team/useTeamInvitations', () => ({
+  useTeamInvitations: vi.fn()
+}));
+
+describe('TeamInviteDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useTeamInvitations as unknown as vi.Mock).mockReturnValue({
+      teamInvitations: [],
+      fetchTeamInvitations: vi.fn(),
+      resendInvitation: vi.fn(),
+      cancelInvitation: vi.fn(),
+      isLoading: false,
+      error: null
+    });
+  });
+
+  it('renders with invitations prop', () => {
+    let props: any;
+    render(
+      <TeamInviteDialog teamId="1">
+        {(p) => {
+          props = p;
+          return <div />;
+        }}
+      </TeamInviteDialog>
+    );
+
+    expect(Array.isArray(props.invitations)).toBe(true);
+  });
+});

--- a/src/ui/headless/team/__tests__/TeamManagement.test.tsx
+++ b/src/ui/headless/team/__tests__/TeamManagement.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { TeamManagement } from '../TeamManagement';
+import { useTeams } from '@/hooks/team/useTeams';
+import { useTeamMembers } from '@/hooks/team/useTeamMembers';
+import { useTeamInvitations } from '@/hooks/team/useTeamInvitations';
+
+vi.mock('@/hooks/team/useTeams', () => ({ useTeams: vi.fn() }));
+vi.mock('@/hooks/team/useTeamMembers', () => ({ useTeamMembers: vi.fn() }));
+vi.mock('@/hooks/team/useTeamInvitations', () => ({ useTeamInvitations: vi.fn() }));
+
+describe('TeamManagement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useTeams as unknown as vi.Mock).mockReturnValue({
+      fetchTeam: vi.fn(),
+      currentTeam: { id: '1', name: 'Test' },
+      isLoading: false,
+      error: null
+    });
+    (useTeamMembers as unknown as vi.Mock).mockReturnValue({
+      members: [],
+      fetchTeamMembers: vi.fn(),
+      isLoading: false,
+      error: null
+    });
+    (useTeamInvitations as unknown as vi.Mock).mockReturnValue({
+      teamInvitations: [],
+      fetchTeamInvitations: vi.fn(),
+      isLoading: false,
+      error: null
+    });
+  });
+
+  it('provides team data to children', () => {
+    let props: any;
+    render(
+      <TeamManagement teamId="1">
+        {(p) => {
+          props = p;
+          return <div />;
+        }}
+      </TeamManagement>
+    );
+
+    expect(props.team).toEqual({ id: '1', name: 'Test' });
+  });
+});

--- a/src/ui/headless/team/__tests__/TeamMembersList.test.tsx
+++ b/src/ui/headless/team/__tests__/TeamMembersList.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { TeamMembersList } from '../TeamMembersList';
+import { useTeamMembers } from '@/hooks/team/useTeamMembers';
+
+vi.mock('@/hooks/team/useTeamMembers', () => ({
+  useTeamMembers: vi.fn()
+}));
+
+describe('TeamMembersList', () => {
+  const mockUpdate = vi.fn();
+  const mockRemove = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useTeamMembers as unknown as vi.Mock).mockReturnValue({
+      members: [
+        { userId: 'u1', role: 'member', isActive: true, joinedAt: '', updatedAt: '', teamId: 't1' }
+      ],
+      updateTeamMember: mockUpdate,
+      removeTeamMember: mockRemove,
+      fetchTeamMembers: vi.fn(),
+      isLoading: false,
+      error: null
+    });
+  });
+
+  it('calls updateTeamMember', async () => {
+    let props: any;
+    render(
+      <TeamMembersList teamId="1">
+        {(p) => {
+          props = p;
+          return <div />;
+        }}
+      </TeamMembersList>
+    );
+
+    await act(async () => {
+      await props.updateRole('u1', 'admin');
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith('u1', { role: 'admin' });
+  });
+
+  it('calls removeTeamMember', async () => {
+    let props: any;
+    render(
+      <TeamMembersList teamId="1">
+        {(p) => {
+          props = p;
+          return <div />;
+        }}
+      </TeamMembersList>
+    );
+
+    await act(async () => {
+      await props.removeMember('u1');
+    });
+
+    expect(mockRemove).toHaveBeenCalledWith('u1');
+  });
+});


### PR DESCRIPTION
## Summary
- add headless InviteMemberForm with email validation
- add InviteMemberModal wrapper with open/close handling
- add RemoveMemberDialog with confirmation logic
- add TeamInviteDialog for pending invitations
- add TeamManagement orchestration component
- add TeamMembersList for displaying and managing members
- provide basic tests for new headless components

## Testing
- `npx vitest run --coverage src/ui/headless/team/__tests__/InviteMemberForm.test.tsx src/ui/headless/team/__tests__/InviteMemberModal.test.tsx src/ui/headless/team/__tests__/RemoveMemberDialog.test.tsx src/ui/headless/team/__tests__/TeamInviteDialog.test.tsx src/ui/headless/team/__tests__/TeamManagement.test.tsx src/ui/headless/team/__tests__/TeamMembersList.test.tsx`