### PR TITLE
Add headless settings components

### DIFF
--- a/src/hooks/user/useDataExport.ts
+++ b/src/hooks/user/useDataExport.ts
@@ -1,0 +1,78 @@
+import { useState, useCallback } from 'react';
+import { useAuth } from '@/hooks/auth/useAuth';
+import {
+  isUserRateLimited,
+  createUserDataExport,
+  processUserDataExport,
+  checkUserExportStatus
+} from '@/lib/exports/export.service';
+import type { ExportOptions, DataExportResponse, ExportStatus } from '@/lib/exports/types';
+
+/**
+ * Hook for initiating and tracking personal data exports
+ */
+export function useDataExport() {
+  const { user } = useAuth();
+  const [status, setStatus] = useState<DataExportResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  /**
+   * Request a new data export for the current user
+   */
+  const requestExport = useCallback(async (options?: Partial<ExportOptions>) => {
+    if (!user?.id) {
+      setError('User not authenticated');
+      return null;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const rateLimited = await isUserRateLimited(user.id);
+      if (rateLimited) {
+        setError('You have requested a data export recently. Please try again later.');
+        return null;
+      }
+
+      const record = await createUserDataExport(user.id, options);
+      if (!record) throw new Error('Failed to start data export');
+
+      if (!record.isLargeDataset) {
+        await processUserDataExport(record.id, user.id);
+      }
+
+      const res = await checkUserExportStatus(record.id);
+      setStatus(res);
+      return res;
+    } catch (err: any) {
+      setError(err.message || 'Failed to export data');
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [user]);
+
+  /**
+   * Refresh the status of the current export
+   */
+  const refreshStatus = useCallback(async () => {
+    if (!status || !user?.id) return null;
+    setIsLoading(true);
+    try {
+      const res = await checkUserExportStatus(status.id);
+      setStatus(res);
+      return res;
+    } catch (err: any) {
+      setError(err.message || 'Failed to check export status');
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [status, user]);
+
+  return { status, isLoading, error, requestExport, refreshStatus };
+}
+
+export default useDataExport;

--- a/src/ui/headless/profile/NotificationPreferences.tsx
+++ b/src/ui/headless/profile/NotificationPreferences.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import { usePreferencesStore } from '@/lib/stores/preferences.store';
+import { NotificationChannel, NotificationCategory } from '@/core/notification/models';
+
+export interface CategoryPreferences {
+  email: boolean;
+  push: boolean;
+  inApp: boolean;
+}
+
+export type NotificationPreferencesState = Record<NotificationCategory, CategoryPreferences>;
+
+export interface NotificationPreferencesProps {
+  /** Automatically save changes when toggles change */
+  autoSave?: boolean;
+  /** Optional save handler. If not provided, preferences store update is used */
+  onSave?: (prefs: NotificationPreferencesState) => Promise<void>;
+  /** Render prop function */
+  render: (props: {
+    preferences: NotificationPreferencesState;
+    isLoading: boolean;
+    error: string | null;
+    toggle: (category: NotificationCategory, channel: NotificationChannel) => void;
+    save: () => Promise<void>;
+  }) => React.ReactNode;
+}
+
+/**
+ * Headless component for managing notification preferences
+ */
+export function NotificationPreferences({ autoSave = true, onSave, render }: NotificationPreferencesProps) {
+  const { preferences, fetchPreferences, updatePreferences, isLoading, error } = usePreferencesStore();
+
+  const defaultState: NotificationPreferencesState = {
+    [NotificationCategory.SECURITY]: { email: true, push: true, inApp: true },
+    [NotificationCategory.TEAM]: { email: true, push: true, inApp: true },
+    [NotificationCategory.BILLING]: { email: true, push: true, inApp: true }
+  } as NotificationPreferencesState;
+
+  const [prefs, setPrefs] = useState<NotificationPreferencesState>(defaultState);
+
+  useEffect(() => { fetchPreferences(); }, [fetchPreferences]);
+
+  useEffect(() => {
+    if (preferences?.notifications) {
+      const { email = true, push = true } = preferences.notifications as any;
+      setPrefs({
+        [NotificationCategory.SECURITY]: { email, push, inApp: true },
+        [NotificationCategory.TEAM]: { email, push, inApp: true },
+        [NotificationCategory.BILLING]: { email, push, inApp: true }
+      });
+    }
+  }, [preferences]);
+
+  const save = async () => {
+    if (onSave) {
+      await onSave(prefs);
+    } else {
+      const firstCat = prefs[NotificationCategory.SECURITY];
+      await updatePreferences({ notifications: { email: firstCat.email, push: firstCat.push } as any });
+    }
+  };
+
+  const toggle = (category: NotificationCategory, channel: NotificationChannel) => {
+    setPrefs(prev => {
+      const next = { ...prev };
+      const cat = { ...next[category] };
+      if (channel === NotificationChannel.EMAIL) cat.email = !cat.email;
+      if (channel === NotificationChannel.PUSH) cat.push = !cat.push;
+      if (channel === NotificationChannel.IN_APP) cat.inApp = !cat.inApp;
+      next[category] = cat;
+      return next;
+    });
+    if (autoSave) {
+      save();
+    }
+  };
+
+  return <>{render({ preferences: prefs, isLoading, error, toggle, save })}</>;
+}
+
+export default NotificationPreferences;

--- a/src/ui/headless/profile/PrivacySettings.tsx
+++ b/src/ui/headless/profile/PrivacySettings.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import { useProfile } from '@/hooks/user/useProfile';
+
+export interface PrivacySettingsProps {
+  /** Automatically save changes when toggled */
+  autoSave?: boolean;
+  /** Render prop for custom UI */
+  render: (props: {
+    visibility: 'public' | 'private' | 'contacts';
+    setVisibility: (v: 'public' | 'private' | 'contacts') => void;
+    showEmail: boolean;
+    toggleShowEmail: () => void;
+    showPhone: boolean;
+    toggleShowPhone: () => void;
+    isLoading: boolean;
+    error: string | null;
+    save: () => Promise<void>;
+  }) => React.ReactNode;
+}
+
+/**
+ * Headless component for managing privacy settings
+ */
+export function PrivacySettings({ autoSave = true, render }: PrivacySettingsProps) {
+  const { profile, updatePrivacySettings, isLoading } = useProfile();
+  const [visibility, setVisibility] = useState<'public' | 'private' | 'contacts'>('private');
+  const [showEmail, setShowEmail] = useState(false);
+  const [showPhone, setShowPhone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (profile) {
+      setVisibility(profile.privacySettings.profileVisibility);
+      setShowEmail(profile.privacySettings.showEmail);
+      setShowPhone(profile.privacySettings.showPhone);
+    }
+  }, [profile]);
+
+  const save = async () => {
+    if (!profile) return;
+    setError(null);
+    try {
+      await updatePrivacySettings({
+        profileVisibility: visibility,
+        showEmail,
+        showPhone
+      });
+    } catch (err: any) {
+      setError(err.message || 'Failed to update privacy settings');
+    }
+  };
+
+  const setVis = (v: 'public' | 'private' | 'contacts') => {
+    setVisibility(v);
+    if (autoSave) save();
+  };
+  const toggleEmail = () => {
+    setShowEmail(v => !v);
+    if (autoSave) save();
+  };
+  const togglePhone = () => {
+    setShowPhone(v => !v);
+    if (autoSave) save();
+  };
+
+  return (
+    <>{render({
+      visibility,
+      setVisibility: setVis,
+      showEmail,
+      toggleShowEmail: toggleEmail,
+      showPhone,
+      toggleShowPhone: togglePhone,
+      isLoading,
+      error,
+      save
+    })}</>
+  );
+}
+
+export default PrivacySettings;

--- a/src/ui/headless/profile/Profile.tsx
+++ b/src/ui/headless/profile/Profile.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { useUserProfile } from '@/hooks/user/useUserProfile';
+import { UserProfile, ProfileUpdatePayload } from '@/core/user/models';
+import { UserType } from '@/types/user-type';
+
+export interface ProfileProps {
+  userId?: string;
+  render: (props: {
+    profile: UserProfile | null;
+    isLoading: boolean;
+    isEditing: boolean;
+    userType: UserType | null;
+    toggleEdit: () => void;
+    save: (data: ProfileUpdatePayload) => Promise<void>;
+    error: string | null;
+  }) => React.ReactNode;
+}
+
+/**
+ * Headless profile component providing profile data and edit logic
+ */
+export function Profile({ userId, render }: ProfileProps) {
+  const {
+    profile,
+    isLoading,
+    error,
+    updateProfile
+  } = useUserProfile();
+
+  const [isEditing, setIsEditing] = useState(false);
+
+  const toggleEdit = () => setIsEditing((e) => !e);
+
+  const save = async (data: ProfileUpdatePayload) => {
+    const id = userId || profile?.id;
+    if (!id) return;
+    await updateProfile(id, data);
+    setIsEditing(false);
+  };
+
+  const userType = profile?.userType ?? null;
+
+  return (
+    <>{render({ profile, isLoading, isEditing, userType, toggleEdit, save, error })}</>
+  );
+}
+
+export default Profile;

--- a/src/ui/headless/settings/DataExport.tsx
+++ b/src/ui/headless/settings/DataExport.tsx
@@ -1,53 +1,77 @@
 /**
  * Headless Data Export Component
  *
- * Exposes export options state and export trigger without UI.
+ * Provides behavior for initiating personal data exports without UI.
  */
 import { useState } from 'react';
-import { ExportFormat, ExportCategory, downloadDataExport } from '@/lib/utils/data-export';
+import { ExportFormat, ExportCategory } from '@/lib/utils/data-export';
+import { ExportStatus } from '@/lib/exports/types';
+import useDataExport from '@/hooks/user/useDataExport';
 
 export interface DataExportProps {
-  onComplete?: () => void;
+  /** Called when an export is completed and a download URL is available */
+  onComplete?: (downloadUrl: string) => void;
+  /** Render prop for custom UI */
   render: (props: {
     selectedFormat: ExportFormat;
     setSelectedFormat: (f: ExportFormat) => void;
     selectedCategories: ExportCategory[];
     setSelectedCategories: (c: ExportCategory[]) => void;
-    includeTimestamp: boolean;
-    setIncludeTimestamp: (v: boolean) => void;
-    anonymize: boolean;
-    setAnonymize: (v: boolean) => void;
-    prettify: boolean;
-    setPrettify: (v: boolean) => void;
+    progress: number;
+    status: ExportStatus | null;
+    downloadUrl: string | null;
     isLoading: boolean;
     error: string | null;
-    handleExport: () => Promise<void>;
+    initiateExport: () => Promise<void>;
+    checkStatus: () => Promise<void>;
   }) => React.ReactNode;
 }
 
 export function DataExport({ onComplete, render }: DataExportProps) {
   const [selectedFormat, setSelectedFormat] = useState<ExportFormat>(ExportFormat.JSON);
   const [selectedCategories, setSelectedCategories] = useState<ExportCategory[]>([ExportCategory.ALL]);
-  const [includeTimestamp, setIncludeTimestamp] = useState(true);
-  const [anonymize, setAnonymize] = useState(false);
-  const [prettify, setPrettify] = useState(true);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState(0);
+  const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
 
-  const handleExport = async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      await downloadDataExport({ selectedFormat, selectedCategories, includeTimestamp, anonymize, prettify });
-      onComplete?.();
-    } catch (err: any) {
-      setError(err.message);
-    } finally {
-      setIsLoading(false);
+  const { status, isLoading, error, requestExport, refreshStatus } = useDataExport();
+
+  const initiateExport = async () => {
+    const res = await requestExport({ format: selectedFormat });
+    if (res) {
+      setProgress(res.status === ExportStatus.COMPLETED ? 100 : 50);
+      if (res.downloadUrl) {
+        setDownloadUrl(res.downloadUrl);
+        onComplete?.(res.downloadUrl);
+      }
+    }
+  };
+
+  const checkStatus = async () => {
+    const res = await refreshStatus();
+    if (res) {
+      setProgress(res.status === ExportStatus.COMPLETED ? 100 : 50);
+      if (res.downloadUrl) {
+        setDownloadUrl(res.downloadUrl);
+        onComplete?.(res.downloadUrl);
+      }
     }
   };
 
   return (
-    <>{render({ selectedFormat, setSelectedFormat, selectedCategories, setSelectedCategories, includeTimestamp, setIncludeTimestamp, anonymize, setAnonymize, prettify, setPrettify, isLoading, error, handleExport })}</>
+    <>{render({
+      selectedFormat,
+      setSelectedFormat,
+      selectedCategories,
+      setSelectedCategories,
+      progress,
+      status: status ? status.status : null,
+      downloadUrl,
+      isLoading,
+      error,
+      initiateExport,
+      checkStatus
+    })}</>
   );
 }
+
+export default DataExport;


### PR DESCRIPTION
## Summary
- provide personal data export hook and headless component
- add notification preferences, privacy settings and profile headless components

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined)*