### PR TITLE
Add headless profile utilities

### DIFF
--- a/src/ui/headless/profile/ActivityLog.tsx
+++ b/src/ui/headless/profile/ActivityLog.tsx
@@ -1,0 +1,86 @@
+/**
+ * Headless Activity Log Component
+ *
+ * Provides activity history data with pagination and filtering.
+ * Connects to the user store for fetching audit logs.
+ */
+
+import { useEffect, useState } from 'react';
+import { useUserStore } from '@/lib/stores/user.store';
+
+export interface ActivityLogEntry {
+  id: string;
+  timestamp: string;
+  action: string;
+  description?: string;
+  status?: string;
+  [key: string]: any;
+}
+
+export interface ActivityLogFilters {
+  startDate?: string;
+  endDate?: string;
+  action?: string;
+  page?: number;
+  limit?: number;
+}
+
+export interface ActivityLogRenderProps {
+  logs: ActivityLogEntry[];
+  isLoading: boolean;
+  error: string | null;
+  page: number;
+  totalPages: number;
+  setFilter: (field: keyof ActivityLogFilters, value: any) => void;
+  refresh: () => Promise<void>;
+}
+
+export interface ActivityLogProps {
+  /** Render prop receiving log state and handlers */
+  children: (props: ActivityLogRenderProps) => React.ReactNode;
+}
+
+export function ActivityLog({ children }: ActivityLogProps) {
+  const fetchUserAuditLogs = useUserStore((s) => s.fetchUserAuditLogs);
+  const storeLoading = useUserStore((s) => s.isLoading);
+  const storeError = useUserStore((s) => s.error);
+
+  const [logs, setLogs] = useState<ActivityLogEntry[]>([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [filters, setFilters] = useState<ActivityLogFilters>({ limit: 20 });
+
+  const loadLogs = async () => {
+    try {
+      const data = await fetchUserAuditLogs({
+        page,
+        limit: filters.limit ?? 20,
+        sortBy: 'timestamp',
+        sortOrder: 'desc',
+        startDate: filters.startDate,
+        endDate: filters.endDate,
+        userId: undefined,
+      } as any);
+      setLogs(Array.isArray(data.logs) ? data.logs : []);
+      setTotalPages(data.pagination.totalPages);
+    } catch {
+      setLogs([]);
+    }
+  };
+
+  useEffect(() => {
+    loadLogs();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, filters.startDate, filters.endDate, filters.action]);
+
+  const setFilter = (field: keyof ActivityLogFilters, value: any) => {
+    if (field === 'page') setPage(value as number);
+    setFilters((prev) => ({ ...prev, [field]: value }));
+  };
+
+  return (
+    <>{children({ logs, isLoading: storeLoading, error: storeError, page, totalPages, setFilter, refresh: loadLogs })}</>
+  );
+}
+
+export default ActivityLog;

--- a/src/ui/headless/profile/AvatarUpload.tsx
+++ b/src/ui/headless/profile/AvatarUpload.tsx
@@ -1,0 +1,117 @@
+/**
+ * Headless Avatar Upload Component
+ *
+ * Handles avatar selection, cropping and upload logic using the profile store.
+ */
+
+import React, { useState, useRef, useCallback } from 'react';
+import { useProfileStore } from '@/lib/stores/profile.store';
+import { type Crop, PixelCrop } from 'react-image-crop';
+import {
+  isValidImage,
+  MAX_FILE_SIZE,
+  ALLOWED_IMAGE_TYPES,
+  canvasPreview
+} from '@/lib/utils/file-upload';
+
+export interface AvatarUploadRenderProps {
+  fileInputRef: React.RefObject<HTMLInputElement>;
+  imgRef: React.RefObject<HTMLImageElement>;
+  imgSrc: string;
+  crop: Crop | undefined;
+  completedCrop: PixelCrop | undefined;
+  isLoading: boolean;
+  error: string | null;
+  openFileDialog: () => void;
+  handleFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleCropAndUpload: () => Promise<void>;
+  setCrop: (c: Crop) => void;
+  setCompletedCrop: (c: PixelCrop) => void;
+  clear: () => void;
+}
+
+export interface AvatarUploadProps {
+  children: (props: AvatarUploadRenderProps) => React.ReactNode;
+}
+
+export function AvatarUpload({ children }: AvatarUploadProps) {
+  const { uploadAvatar, isLoading: storeLoading, error: storeError } = useProfileStore();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const imgRef = useRef<HTMLImageElement>(null);
+
+  const [imgSrc, setImgSrc] = useState('');
+  const [crop, setCrop] = useState<Crop>();
+  const [completedCrop, setCompletedCrop] = useState<PixelCrop>();
+  const [processing, setProcessing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const openFileDialog = () => {
+    setError(null);
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!isValidImage(file, ALLOWED_IMAGE_TYPES, MAX_FILE_SIZE)) {
+      setError('Invalid file');
+      return;
+    }
+    const reader = new FileReader();
+    reader.addEventListener('load', () => setImgSrc(reader.result?.toString() || ''));
+    reader.readAsDataURL(file);
+  };
+
+  const getCroppedImgBlob = async (image: HTMLImageElement, c: PixelCrop): Promise<Blob | null> => {
+    const canvas = document.createElement('canvas');
+    await canvasPreview(image, canvas, c);
+    return new Promise((resolve) => {
+      canvas.toBlob((blob) => resolve(blob), 'image/png', 0.9);
+    });
+  };
+
+  const handleCropAndUpload = useCallback(async () => {
+    if (!imgRef.current || !completedCrop) return;
+    setProcessing(true);
+    setError(null);
+    try {
+      const blob = await getCroppedImgBlob(imgRef.current, completedCrop);
+      if (!blob) throw new Error('Failed to process image');
+      await uploadAvatar(blob);
+      clear();
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setProcessing(false);
+    }
+  }, [completedCrop, uploadAvatar]);
+
+  const clear = () => {
+    setImgSrc('');
+    setCrop(undefined);
+    setCompletedCrop(undefined);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  return (
+    <>
+      {children({
+        fileInputRef,
+        imgRef,
+        imgSrc,
+        crop,
+        completedCrop,
+        isLoading: storeLoading || processing,
+        error: error || storeError,
+        openFileDialog,
+        handleFileChange,
+        handleCropAndUpload,
+        setCrop,
+        setCompletedCrop,
+        clear
+      })}
+    </>
+  );
+}
+
+export default AvatarUpload;

--- a/src/ui/headless/profile/CompanyDataExport.tsx
+++ b/src/ui/headless/profile/CompanyDataExport.tsx
@@ -1,0 +1,59 @@
+/**
+ * Headless Company Data Export Component
+ *
+ * Handles requesting and downloading company data exports.
+ */
+
+import { useState } from 'react';
+
+export interface CompanyDataExportRenderProps {
+  isExporting: boolean;
+  error: string | null;
+  success: string | null;
+  exportData: () => Promise<void>;
+}
+
+export interface CompanyDataExportProps {
+  children: (props: CompanyDataExportRenderProps) => React.ReactNode;
+}
+
+export function CompanyDataExport({ children }: CompanyDataExportProps) {
+  const [isExporting, setIsExporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const exportData = async () => {
+    setIsExporting(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const res = await fetch('/api/company/export');
+      if (!res.ok) {
+        throw new Error(await res.text());
+      }
+      const blob = await res.blob();
+      const contentDisposition = res.headers.get('content-disposition');
+      let filename = 'Company_Data_Export.json';
+      if (contentDisposition) {
+        const match = contentDisposition.match(/filename="(.+)"/);
+        if (match) filename = match[1];
+      }
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setSuccess('Company data export has been downloaded successfully.');
+    } catch (err: any) {
+      setError('Failed to export company data.');
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return <>{children({ isExporting, error, success, exportData })}</>;
+}
+
+export default CompanyDataExport;

--- a/src/ui/headless/profile/CompanyLogoUpload.tsx
+++ b/src/ui/headless/profile/CompanyLogoUpload.tsx
@@ -1,0 +1,129 @@
+/**
+ * Headless Company Logo Upload Component
+ *
+ * Handles uploading and cropping the company logo via the profile store.
+ */
+
+import React, { useState, useRef, useCallback } from 'react';
+import { useProfileStore } from '@/lib/stores/profile.store';
+import { type Crop, PixelCrop } from 'react-image-crop';
+import {
+  isValidImage,
+  MAX_FILE_SIZE,
+  ALLOWED_IMAGE_TYPES,
+  canvasPreview
+} from '@/lib/utils/file-upload';
+
+export interface CompanyLogoUploadRenderProps {
+  fileInputRef: React.RefObject<HTMLInputElement>;
+  imgRef: React.RefObject<HTMLImageElement>;
+  imgSrc: string;
+  crop: Crop | undefined;
+  completedCrop: PixelCrop | undefined;
+  isLoading: boolean;
+  error: string | null;
+  openFileDialog: () => void;
+  handleFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleCropAndUpload: () => Promise<void>;
+  handleRemove: () => Promise<void>;
+  setCrop: (c: Crop) => void;
+  setCompletedCrop: (c: PixelCrop) => void;
+  clear: () => void;
+}
+
+export interface CompanyLogoUploadProps {
+  children: (props: CompanyLogoUploadRenderProps) => React.ReactNode;
+}
+
+export function CompanyLogoUpload({ children }: CompanyLogoUploadProps) {
+  const {
+    uploadCompanyLogo,
+    removeCompanyLogo,
+    isLoading: storeLoading,
+    error: storeError,
+  } = useProfileStore();
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const imgRef = useRef<HTMLImageElement>(null);
+
+  const [imgSrc, setImgSrc] = useState('');
+  const [crop, setCrop] = useState<Crop>();
+  const [completedCrop, setCompletedCrop] = useState<PixelCrop>();
+  const [processing, setProcessing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const openFileDialog = () => {
+    setError(null);
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!isValidImage(file, ALLOWED_IMAGE_TYPES, MAX_FILE_SIZE)) {
+      setError('Invalid file');
+      return;
+    }
+    const reader = new FileReader();
+    reader.addEventListener('load', () => setImgSrc(reader.result?.toString() || ''));
+    reader.readAsDataURL(file);
+  };
+
+  const getCroppedImgBlob = async (image: HTMLImageElement, c: PixelCrop): Promise<Blob | null> => {
+    const canvas = document.createElement('canvas');
+    await canvasPreview(image, canvas, c);
+    return new Promise((resolve) => {
+      canvas.toBlob((blob) => resolve(blob), 'image/png', 0.9);
+    });
+  };
+
+  const handleCropAndUpload = useCallback(async () => {
+    if (!imgRef.current || !completedCrop) return;
+    setProcessing(true);
+    setError(null);
+    try {
+      const blob = await getCroppedImgBlob(imgRef.current, completedCrop);
+      if (!blob) throw new Error('Failed to process image');
+      await uploadCompanyLogo(blob);
+      clear();
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setProcessing(false);
+    }
+  }, [completedCrop, uploadCompanyLogo]);
+
+  const handleRemove = async () => {
+    await removeCompanyLogo();
+  };
+
+  const clear = () => {
+    setImgSrc('');
+    setCrop(undefined);
+    setCompletedCrop(undefined);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  return (
+    <>
+      {children({
+        fileInputRef,
+        imgRef,
+        imgSrc,
+        crop,
+        completedCrop,
+        isLoading: storeLoading || processing,
+        error: error || storeError,
+        openFileDialog,
+        handleFileChange,
+        handleCropAndUpload,
+        handleRemove,
+        setCrop,
+        setCompletedCrop,
+        clear,
+      })}
+    </>
+  );
+}
+
+export default CompanyLogoUpload;

--- a/src/ui/headless/profile/CorporateProfileSection.tsx
+++ b/src/ui/headless/profile/CorporateProfileSection.tsx
@@ -1,0 +1,66 @@
+/**
+ * Headless Corporate Profile Section
+ *
+ * Provides form state and validation for managing corporate profile information.
+ */
+
+import { useForm } from 'react-hook-form';
+import { useState } from 'react';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Company, companySchema, UserType } from '@/types/user-type';
+import { useUserManagement } from '@/lib/auth/UserManagementProvider';
+
+export interface CorporateProfileSectionProps {
+  userType: UserType;
+  company?: Company;
+  onUpdate: (company: Company) => Promise<void>;
+  isLoading?: boolean;
+  error?: string | null;
+  children: (props: {
+    form: ReturnType<typeof useForm<Company>>;
+    handleSubmit: () => Promise<void>;
+    isLoading: boolean;
+    error: string | null;
+    pendingVerification: boolean;
+  }) => React.ReactNode;
+}
+
+export function CorporateProfileSection({
+  userType,
+  company,
+  onUpdate,
+  isLoading = false,
+  error = null,
+  children,
+}: CorporateProfileSectionProps) {
+  const { corporateUsers } = useUserManagement();
+  const [pendingVerification, setPendingVerification] = useState(false);
+
+  const form = useForm<Company>({
+    resolver: zodResolver(companySchema as unknown as z.ZodType<Company>),
+    defaultValues: company,
+  });
+
+  if (!corporateUsers.enabled || userType !== UserType.CORPORATE) {
+    return null;
+  }
+
+  const handleSubmit = async () => {
+    setPendingVerification(false);
+    const values = form.getValues();
+    try {
+      await onUpdate(values);
+      if (company && (values.vatId !== company.vatId || values.name !== company.name)) {
+        setPendingVerification(true);
+      }
+    } catch (err) {
+      // errors handled via error prop
+    }
+  };
+
+  return <>{children({ form, handleSubmit: form.handleSubmit(handleSubmit), isLoading, error, pendingVerification })}</>;
+}
+
+export default CorporateProfileSection;
+


### PR DESCRIPTION
## Summary
- add headless components for profile domain
  - ActivityLog with pagination/filter logic
  - AvatarUpload with cropping support
  - CompanyDataExport for generating exports
  - CompanyLogoUpload with cropping logic
  - CorporateProfileSection using react-hook-form

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*