### PR TITLE
Refactor profile settings to use headless components

### DIFF
--- a/src/ui/styled/profile/PrivacySettings.tsx
+++ b/src/ui/styled/profile/PrivacySettings.tsx
@@ -1,5 +1,4 @@
-import { useProfile } from '@/hooks/user/useProfile';
-import { Button } from '../ui/button';
+import { PrivacySettings as HeadlessPrivacySettings } from '@/ui/headless/profile/PrivacySettings';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Label } from '../ui/label';
 import { Switch } from '../ui/switch';
@@ -12,82 +11,64 @@ import {
 } from '../ui/select';
 
 export function PrivacySettings() {
-  const { profile, updatePrivacySettings, isLoading } = useProfile();
-
-  if (!profile) return null;
-
-  const handleVisibilityChange = (value: string) => {
-    updatePrivacySettings({
-      ...profile.privacySettings,
-      profileVisibility: value as 'public' | 'private' | 'contacts',
-    });
-  };
-
-  const handleToggleChange = (setting: 'showEmail' | 'showPhone') => {
-    updatePrivacySettings({
-      ...profile.privacySettings,
-      [setting]: !profile.privacySettings[setting],
-    });
-  };
-
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Privacy Settings</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-6">
-        <div className="space-y-2">
-          <Label>Profile Visibility</Label>
-          <Select
-            value={profile.privacySettings.profileVisibility}
-            onValueChange={handleVisibilityChange}
-            disabled={isLoading}
-          >
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="public">Public</SelectItem>
-              <SelectItem value="contacts">Contacts Only</SelectItem>
-              <SelectItem value="private">Private</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
+    <HeadlessPrivacySettings
+      render={({
+        visibility,
+        setVisibility,
+        showEmail,
+        toggleShowEmail,
+        showPhone,
+        toggleShowPhone,
+        isLoading,
+      }) => (
+        <Card>
+          <CardHeader>
+            <CardTitle>Privacy Settings</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="space-y-2">
+              <Label>Profile Visibility</Label>
+              <Select
+                value={visibility}
+                onValueChange={setVisibility}
+                disabled={isLoading}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="public">Public</SelectItem>
+                  <SelectItem value="contacts">Contacts Only</SelectItem>
+                  <SelectItem value="private">Private</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
 
-        <div className="space-y-4">
-          <div className="flex items-center justify-between">
-            <Label htmlFor="showEmail">Show Email Address</Label>
-            <Switch
-              id="showEmail"
-              checked={profile.privacySettings.showEmail}
-              onCheckedChange={() => handleToggleChange('showEmail')}
-              disabled={isLoading}
-            />
-          </div>
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <Label htmlFor="showEmail">Show Email Address</Label>
+                <Switch
+                  id="showEmail"
+                  checked={showEmail}
+                  onCheckedChange={toggleShowEmail}
+                  disabled={isLoading}
+                />
+              </div>
 
-          <div className="flex items-center justify-between">
-            <Label htmlFor="showPhone">Show Phone Number</Label>
-            <Switch
-              id="showPhone"
-              checked={profile.privacySettings.showPhone}
-              onCheckedChange={() => handleToggleChange('showPhone')}
-              disabled={isLoading}
-            />
-          </div>
-        </div>
-
-        <div className="pt-4">
-          <Button
-            variant="outline"
-            className="w-full"
-            onClick={() => {
-              // Download user data
-            }}
-          >
-            Download My Data
-          </Button>
-        </div>
-      </CardContent>
-    </Card>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="showPhone">Show Phone Number</Label>
+                <Switch
+                  id="showPhone"
+                  checked={showPhone}
+                  onCheckedChange={toggleShowPhone}
+                  disabled={isLoading}
+                />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    />
   );
 }

--- a/src/ui/styled/profile/SecuritySettings.tsx
+++ b/src/ui/styled/profile/SecuritySettings.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useProfile } from '@/lib/hooks/useProfile';
+import { SecuritySettings as HeadlessSecuritySettings } from '@/ui/headless/profile/SecuritySettings';
 import { Button } from '../ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Switch } from '../ui/switch';
@@ -14,118 +14,111 @@ import {
 } from '../ui/dialog';
 
 export function SecuritySettings() {
-  const { profile, toggleTwoFactor, isLoading } = useProfile();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
-  if (!profile) return null;
-
   return (
-    <div className="space-y-6">
-      <Card>
-        <CardHeader>
-          <CardTitle>Two-Factor Authentication</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-4">
-              <Shield className="h-5 w-5 text-primary" />
-              <div>
-                <p className="font-medium">Two-Factor Authentication</p>
-                <p className="text-sm text-muted-foreground">
-                  Add an extra layer of security to your account
-                </p>
+    <HeadlessSecuritySettings
+      render={({ mfaEnabled, toggleMfa, loading }) => (
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Two-Factor Authentication</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-4">
+                  <Shield className="h-5 w-5 text-primary" />
+                  <div>
+                    <p className="font-medium">Two-Factor Authentication</p>
+                    <p className="text-sm text-muted-foreground">
+                      Add an extra layer of security to your account
+                    </p>
+                  </div>
+                </div>
+                <Switch
+                  checked={mfaEnabled}
+                  onCheckedChange={toggleMfa}
+                  disabled={loading}
+                  aria-label="Toggle two-factor authentication"
+                />
               </div>
-            </div>
-            <Switch
-              checked={profile.twoFactorEnabled}
-              onCheckedChange={toggleTwoFactor}
-              disabled={isLoading}
-              aria-label="Toggle two-factor authentication"
-            />
-          </div>
 
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-4">
-              <Mail className="h-5 w-5 text-primary" />
-              <div>
-                <p className="font-medium">Email Verification</p>
-                <p className="text-sm text-muted-foreground">
-                  Verify your email address
-                </p>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-4">
+                  <Mail className="h-5 w-5 text-primary" />
+                  <div>
+                    <p className="font-medium">Email Verification</p>
+                    <p className="text-sm text-muted-foreground">
+                      Verify your email address
+                    </p>
+                  </div>
+                </div>
+                <Button variant="default" disabled>
+                  Verify Email
+                </Button>
               </div>
-            </div>
-            <Button
-              variant={profile.emailVerified ? 'ghost' : 'default'}
-              disabled={profile.emailVerified}
-              aria-label={profile.emailVerified ? 'Email verified' : 'Verify your email address'}
-            >
-              {profile.emailVerified ? 'Verified' : 'Verify Email'}
-            </Button>
-          </div>
 
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-4">
-              <Smartphone className="h-5 w-5 text-primary" />
-              <div>
-                <p className="font-medium">Phone Verification</p>
-                <p className="text-sm text-muted-foreground">
-                  Verify your phone number
-                </p>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-4">
+                  <Smartphone className="h-5 w-5 text-primary" />
+                  <div>
+                    <p className="font-medium">Phone Verification</p>
+                    <p className="text-sm text-muted-foreground">
+                      Verify your phone number
+                    </p>
+                  </div>
+                </div>
+                <Button variant="default" disabled>
+                  Verify Phone
+                </Button>
               </div>
-            </div>
-            <Button
-              variant={profile.phoneVerified ? 'ghost' : 'default'}
-              disabled={profile.phoneVerified}
-              aria-label={profile.phoneVerified ? 'Phone verified' : 'Verify your phone number'}
-            >
-              {profile.phoneVerified ? 'Verified' : 'Verify Phone'}
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+            </CardContent>
+          </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Delete Account</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <Button
-            variant="destructive"
-            onClick={() => setShowDeleteDialog(true)}
-          >
-            Delete Account
-          </Button>
-        </CardContent>
-      </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Delete Account</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Button
+                variant="destructive"
+                onClick={() => setShowDeleteDialog(true)}
+              >
+                Delete Account
+              </Button>
+            </CardContent>
+          </Card>
 
-      <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Account</DialogTitle>
-            <DialogDescription>
-              This action cannot be undone. This will permanently delete your
-              account and remove your data from our servers.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="ghost"
-              onClick={() => setShowDeleteDialog(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={() => {
-                // Handle account deletion
-                setShowDeleteDialog(false);
-              }}
-            >
-              Delete Account
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+          <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Delete Account</DialogTitle>
+                <DialogDescription>
+                  This action cannot be undone. This will permanently delete
+                  your account and remove your data from our servers.
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button
+                  variant="ghost"
+                  onClick={() => setShowDeleteDialog(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  onClick={() => {
+                    // Handle account deletion
+                    setShowDeleteDialog(false);
+                  }}
+                >
+                  Delete Account
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </div>
+      )}
+    />
   );
 }

--- a/src/ui/styled/profile/SessionManagement.tsx
+++ b/src/ui/styled/profile/SessionManagement.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect } from 'react';
-import { useSessionStore } from '@/lib/stores/session.store';
+import React from 'react';
+import { SessionManagement as HeadlessSessionManagement } from '@/ui/headless/profile/SessionManagement';
 import { toast } from '@/ui/primitives/use-toast';
 import {
   AlertDialog,
@@ -14,106 +14,99 @@ import {
 } from '@/ui/primitives/alert-dialog';
 
 const SessionManagement: React.FC = () => {
-  const {
-    sessions,
-    sessionLoading,
-    sessionError,
-    fetchSessions,
-    revokeSession,
-  } = useSessionStore();
-
   const [pendingSessionId, setPendingSessionId] = React.useState<string | null>(null);
 
-  useEffect(() => {
-    fetchSessions();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const handleRevoke = async () => {
-    if (!pendingSessionId) return;
-    await revokeSession(pendingSessionId);
-    toast({
-      title: 'Session revoked',
-      description: 'The session has been successfully revoked.',
-    });
-    setPendingSessionId(null);
-  };
-
   return (
-    <div className="rounded border p-4 max-w-lg mx-auto bg-white shadow">
-      <h3 className="text-lg font-semibold mb-2">Active Sessions</h3>
-      {sessionLoading ? (
-        <div className="text-gray-500">Loading sessions...</div>
-      ) : sessionError ? (
-        <div className="text-red-600">{sessionError}</div>
-      ) : sessions.length === 0 ? (
-        <div className="text-gray-500">No active sessions found.</div>
-      ) : (
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 text-sm sm:text-base">
-            <thead>
-              <tr>
-                <th scope="col" className="px-4 py-2 text-left">Device</th>
-                <th scope="col" className="px-4 py-2 text-left">IP</th>
-                <th scope="col" className="px-4 py-2 text-left">Last Active</th>
-                <th scope="col" className="px-4 py-2 text-left">Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              {sessions.map((session) => (
-                <tr key={session.id} className={session.is_current ? 'bg-blue-50' : ''}>
-                  <td className="px-4 py-2">
-                    {session.user_agent || 'Unknown'}
-                    {session.is_current && (
-                      <span className="ml-2 text-xs text-blue-600 font-semibold">
-                        (Current)
-                        <span className="sr-only">(Current session)</span>
-                      </span>
-                    )}
-                  </td>
-                  <td className="px-4 py-2">{session.ip_address || '-'}</td>
-                  <td className="px-4 py-2">{session.last_active_at ? new Date(session.last_active_at).toLocaleString() : '-'}</td>
-                  <td className="px-4 py-2">
-                    {session.is_current ? (
-                      <span className="text-gray-400">Active</span>
-                    ) : (
-                      <AlertDialog>
-                        <AlertDialogTrigger asChild>
-                          <button
-                            className="text-red-600 hover:underline disabled:opacity-50"
-                            onClick={() => setPendingSessionId(session.id)}
-                            disabled={sessionLoading}
-                            aria-label="Revoke this session"
-                          >
-                            Revoke
-                          </button>
-                        </AlertDialogTrigger>
-                        <AlertDialogContent>
-                          <AlertDialogHeader>
-                            <AlertDialogTitle>Revoke Session</AlertDialogTitle>
-                            <AlertDialogDescription>
-                              Are you sure you want to revoke this session? This will log out the device associated with this session.
-                            </AlertDialogDescription>
-                          </AlertDialogHeader>
-                          <AlertDialogFooter>
-                            <AlertDialogCancel onClick={() => setPendingSessionId(null)}>
-                              Cancel
-                            </AlertDialogCancel>
-                            <AlertDialogAction onClick={handleRevoke} disabled={sessionLoading}>
-                              Revoke
-                            </AlertDialogAction>
-                          </AlertDialogFooter>
-                        </AlertDialogContent>
-                      </AlertDialog>
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </div>
+    <HeadlessSessionManagement
+      render={({ sessions, loading, error, revoke }) => {
+        const handleRevoke = async () => {
+          if (!pendingSessionId) return;
+          await revoke(pendingSessionId);
+          toast({
+            title: 'Session revoked',
+            description: 'The session has been successfully revoked.',
+          });
+          setPendingSessionId(null);
+        };
+
+        return (
+          <div className="rounded border p-4 max-w-lg mx-auto bg-white shadow">
+            <h3 className="text-lg font-semibold mb-2">Active Sessions</h3>
+            {loading ? (
+              <div className="text-gray-500">Loading sessions...</div>
+            ) : error ? (
+              <div className="text-red-600">{error}</div>
+            ) : sessions.length === 0 ? (
+              <div className="text-gray-500">No active sessions found.</div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200 text-sm sm:text-base">
+                  <thead>
+                    <tr>
+                      <th scope="col" className="px-4 py-2 text-left">Device</th>
+                      <th scope="col" className="px-4 py-2 text-left">IP</th>
+                      <th scope="col" className="px-4 py-2 text-left">Last Active</th>
+                      <th scope="col" className="px-4 py-2 text-left">Action</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sessions.map((session) => (
+                      <tr key={session.id} className={session.is_current ? 'bg-blue-50' : ''}>
+                        <td className="px-4 py-2">
+                          {session.user_agent || 'Unknown'}
+                          {session.is_current && (
+                            <span className="ml-2 text-xs text-blue-600 font-semibold">
+                              (Current)
+                              <span className="sr-only">(Current session)</span>
+                            </span>
+                          )}
+                        </td>
+                        <td className="px-4 py-2">{session.ip_address || '-'}</td>
+                        <td className="px-4 py-2">{session.last_active_at ? new Date(session.last_active_at).toLocaleString() : '-'}</td>
+                        <td className="px-4 py-2">
+                          {session.is_current ? (
+                            <span className="text-gray-400">Active</span>
+                          ) : (
+                            <AlertDialog>
+                              <AlertDialogTrigger asChild>
+                                <button
+                                  className="text-red-600 hover:underline disabled:opacity-50"
+                                  onClick={() => setPendingSessionId(session.id)}
+                                  disabled={loading}
+                                  aria-label="Revoke this session"
+                                >
+                                  Revoke
+                                </button>
+                              </AlertDialogTrigger>
+                              <AlertDialogContent>
+                                <AlertDialogHeader>
+                                  <AlertDialogTitle>Revoke Session</AlertDialogTitle>
+                                  <AlertDialogDescription>
+                                    Are you sure you want to revoke this session? This will log out the device associated with this session.
+                                  </AlertDialogDescription>
+                                </AlertDialogHeader>
+                                <AlertDialogFooter>
+                                  <AlertDialogCancel onClick={() => setPendingSessionId(null)}>
+                                    Cancel
+                                  </AlertDialogCancel>
+                                  <AlertDialogAction onClick={handleRevoke} disabled={loading}>
+                                    Revoke
+                                  </AlertDialogAction>
+                                </AlertDialogFooter>
+                              </AlertDialogContent>
+                            </AlertDialog>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        );
+      }}
+    />
   );
 };
 


### PR DESCRIPTION
## Summary
- refactor PrivacySettings, SecuritySettings and SessionManagement styled components to use their headless counterparts

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*