### PR TITLE
Add headless account deletion and data export components

### DIFF
--- a/src/ui/headless/auth/AccountDeletion.tsx
+++ b/src/ui/headless/auth/AccountDeletion.tsx
@@ -1,0 +1,131 @@
+import { useState, useCallback } from 'react';
+import { useAuth } from '@/hooks/auth/useAuth';
+import { useTeams } from '@/hooks/team/useTeams';
+import { useSubscriptionStore } from '@/lib/stores/subscription.store';
+import { SubscriptionStatus } from '@/types/subscription';
+import { UserType } from '@/types/user-type';
+
+/**
+ * Steps of the account deletion flow
+ */
+export type AccountDeletionStep = 'initial' | 'confirm' | 'completed';
+
+/**
+ * Render props provided by the AccountDeletion component
+ */
+export interface AccountDeletionRenderProps {
+  /** Whether the deletion request is in progress */
+  isDeleting: boolean;
+  /** Current value of the confirmation input */
+  confirmationValue: string;
+  /** Validation or server errors */
+  errors: {
+    confirmation?: string;
+    server?: string | null;
+  };
+  /** Current step in the deletion flow */
+  step: AccountDeletionStep;
+  /** Start the deletion process */
+  onInitiateDelete: () => void;
+  /** Confirm the deletion */
+  onConfirmDelete: () => Promise<void>;
+  /** Cancel the deletion process */
+  onCancelDelete: () => void;
+  /** Update the confirmation input */
+  onConfirmationChange: (value: string) => void;
+}
+
+/**
+ * Props for the AccountDeletion component
+ */
+export interface AccountDeletionProps {
+  /** Render prop function controlling UI rendering */
+  children: (props: AccountDeletionRenderProps) => React.ReactNode;
+}
+
+/**
+ * Headless component implementing the account deletion flow.
+ * It exposes state and handlers via render props and performs no UI rendering.
+ */
+export function AccountDeletion({ children }: AccountDeletionProps) {
+  const { deleteAccount, user, isLoading, error } = useAuth();
+  const { teams } = useTeams();
+  const { userSubscription } = useSubscriptionStore();
+
+  const [step, setStep] = useState<AccountDeletionStep>('initial');
+  const [confirmationValue, setConfirmationValue] = useState('');
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setStep('initial');
+    setConfirmationValue('');
+    setLocalError(null);
+  }, []);
+
+  const onInitiateDelete = useCallback(() => {
+    setLocalError(null);
+    // Business rules: block if user owns a team
+    const ownsTeam = teams.some(t => t.ownerId === user?.id);
+    if (ownsTeam) {
+      setLocalError('Transfer team ownership before deleting your account.');
+      return;
+    }
+    // Block if active subscription
+    if (userSubscription && userSubscription.status === SubscriptionStatus.ACTIVE) {
+      setLocalError('Cancel your active subscription before deleting your account.');
+      return;
+    }
+    setStep('confirm');
+  }, [teams, user, userSubscription]);
+
+  const validateConfirmation = useCallback(() => {
+    if (user?.userType === UserType.CORPORATE) {
+      if (!confirmationValue) {
+        setLocalError('Password is required');
+        return false;
+      }
+      return true;
+    }
+    if (confirmationValue !== 'DELETE') {
+      setLocalError('Please type DELETE to confirm');
+      return false;
+    }
+    return true;
+  }, [confirmationValue, user]);
+
+  const onConfirmDelete = useCallback(async () => {
+    setLocalError(null);
+    if (!validateConfirmation()) return;
+    try {
+      await deleteAccount(user?.userType === UserType.CORPORATE ? confirmationValue : undefined);
+      setStep('completed');
+    } catch (e: any) {
+      setLocalError(e.message || 'Failed to delete account');
+    }
+  }, [deleteAccount, confirmationValue, user, validateConfirmation]);
+
+  const onCancelDelete = useCallback(() => {
+    reset();
+  }, [reset]);
+
+  const onConfirmationChange = useCallback((value: string) => {
+    setConfirmationValue(value);
+  }, []);
+
+  return (
+    <>
+      {children({
+        isDeleting: isLoading,
+        confirmationValue,
+        errors: { confirmation: localError || undefined, server: error },
+        step,
+        onInitiateDelete,
+        onConfirmDelete,
+        onCancelDelete,
+        onConfirmationChange,
+      })}
+    </>
+  );
+}
+
+export default AccountDeletion;

--- a/src/ui/headless/auth/__tests__/account-deletion.test.tsx
+++ b/src/ui/headless/auth/__tests__/account-deletion.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AccountDeletion } from '../AccountDeletion';
+import { UserType } from '@/types/user-type';
+import { useAuth } from '@/hooks/auth/useAuth';
+import { useTeams } from '@/hooks/team/useTeams';
+import { useSubscriptionStore } from '@/lib/stores/subscription.store';
+
+vi.mock('@/hooks/auth/useAuth');
+vi.mock('@/hooks/team/useTeams');
+vi.mock('@/lib/stores/subscription.store');
+
+const mockUseAuth = useAuth as unknown as vi.Mock;
+const mockUseTeams = useTeams as unknown as vi.Mock;
+const mockUseSubscription = useSubscriptionStore as unknown as vi.Mock;
+
+describe('AccountDeletion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('confirms deletion for private account', async () => {
+    const deleteAccount = vi.fn().mockResolvedValue(undefined);
+    mockUseAuth.mockReturnValue({ deleteAccount, user: { id: '1', userType: UserType.PRIVATE }, isLoading: false, error: null });
+    mockUseTeams.mockReturnValue({ teams: [] });
+    mockUseSubscription.mockReturnValue({ userSubscription: null });
+
+    let props: any;
+    render(<AccountDeletion>{p => { props = p; return <div/>; }}</AccountDeletion>);
+
+    await act(async () => { props.onInitiateDelete(); });
+    expect(props.step).toBe('confirm');
+
+    act(() => { props.onConfirmationChange('DELETE'); });
+    await act(async () => { await props.onConfirmDelete(); });
+
+    expect(deleteAccount).toHaveBeenCalledWith(undefined);
+    expect(props.step).toBe('completed');
+  });
+
+  it('requires password for corporate account', async () => {
+    const deleteAccount = vi.fn().mockResolvedValue(undefined);
+    mockUseAuth.mockReturnValue({ deleteAccount, user: { id: '1', userType: UserType.CORPORATE }, isLoading: false, error: null });
+    mockUseTeams.mockReturnValue({ teams: [] });
+    mockUseSubscription.mockReturnValue({ userSubscription: null });
+
+    let props: any;
+    render(<AccountDeletion>{p => { props = p; return <div/>; }}</AccountDeletion>);
+
+    await act(async () => { props.onInitiateDelete(); });
+    expect(props.step).toBe('confirm');
+
+    await act(async () => { await props.onConfirmDelete(); });
+    expect(deleteAccount).not.toHaveBeenCalled();
+
+    act(() => { props.onConfirmationChange('pass'); });
+    await act(async () => { await props.onConfirmDelete(); });
+
+    expect(deleteAccount).toHaveBeenCalledWith('pass');
+  });
+
+  it('blocks deletion when team owner or active subscription', async () => {
+    const deleteAccount = vi.fn();
+    mockUseAuth.mockReturnValue({ deleteAccount, user: { id: '1', userType: UserType.PRIVATE }, isLoading: false, error: null });
+    mockUseTeams.mockReturnValue({ teams: [{ id: 't1', ownerId: '1' }] });
+    mockUseSubscription.mockReturnValue({ userSubscription: { status: 'active' } });
+
+    let props: any;
+    render(<AccountDeletion>{p => { props = p; return <div/>; }}</AccountDeletion>);
+
+    await act(async () => { props.onInitiateDelete(); });
+    expect(props.step).toBe('initial');
+    expect(props.errors.confirmation).toBeTruthy();
+  });
+});

--- a/src/ui/headless/profile/DataExport.tsx
+++ b/src/ui/headless/profile/DataExport.tsx
@@ -1,0 +1,100 @@
+import { useState, useCallback } from 'react';
+import useDataExport from '@/hooks/user/useDataExport';
+import { ExportStatus } from '@/lib/exports/types';
+
+/** Possible states of the export process */
+export type PersonalExportStatus = 'not_started' | 'in_progress' | 'ready' | 'error';
+
+/** Render props for the DataExport component */
+export interface DataExportRenderProps {
+  /** Current export status */
+  exportStatus: PersonalExportStatus;
+  /** Download URL if available */
+  downloadUrl: string | null;
+  /** Expiration time for the download URL */
+  expiryTime: Date | null;
+  /** Error message if any */
+  errors: string | null;
+  /** Date of the last export request */
+  lastExportDate: Date | null;
+  /** Initiate a new export */
+  onRequestExport: () => Promise<void>;
+  /** Attempt to download the export */
+  onDownload: () => Promise<void>;
+  /** Whether an export request is currently processing */
+  isLoading: boolean;
+}
+
+/** Props for DataExport */
+export interface DataExportProps {
+  /** Render prop to control rendering */
+  children: (props: DataExportRenderProps) => React.ReactNode;
+}
+
+/**
+ * Headless component handling personal data export flow.
+ */
+export function DataExport({ children }: DataExportProps) {
+  const { requestExport, refreshStatus, status, isLoading, error } = useDataExport();
+
+  const [exportStatus, setExportStatus] = useState<PersonalExportStatus>('not_started');
+  const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
+  const [expiryTime, setExpiryTime] = useState<Date | null>(null);
+  const [lastExportDate, setLastExportDate] = useState<Date | null>(null);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const onRequestExport = useCallback(async () => {
+    setLocalError(null);
+    const res = await requestExport();
+    if (!res) {
+      setExportStatus('error');
+      setLocalError(error);
+      return;
+    }
+    setLastExportDate(new Date());
+    if (res.status === ExportStatus.COMPLETED) {
+      setExportStatus('ready');
+      setDownloadUrl(res.downloadUrl || null);
+      setExpiryTime(new Date(Date.now() + 24 * 60 * 60 * 1000));
+    } else {
+      setExportStatus('in_progress');
+    }
+  }, [requestExport, error]);
+
+  const onDownload = useCallback(async () => {
+    setLocalError(null);
+    if (exportStatus === 'in_progress') {
+      const res = await refreshStatus();
+      if (!res) {
+        setExportStatus('error');
+        setLocalError(error);
+        return;
+      }
+      if (res.status === ExportStatus.COMPLETED) {
+        setExportStatus('ready');
+        setDownloadUrl(res.downloadUrl || null);
+        setExpiryTime(new Date(Date.now() + 24 * 60 * 60 * 1000));
+      } else if (res.status === ExportStatus.FAILED) {
+        setExportStatus('error');
+        setLocalError(res.message);
+      }
+    }
+  }, [exportStatus, refreshStatus, error]);
+
+  return (
+    <>
+      {children({
+        exportStatus,
+        downloadUrl,
+        expiryTime,
+        errors: localError,
+        lastExportDate,
+        onRequestExport,
+        onDownload,
+        isLoading,
+      })}
+    </>
+  );
+}
+
+export default DataExport;

--- a/src/ui/headless/profile/__tests__/data-export.test.tsx
+++ b/src/ui/headless/profile/__tests__/data-export.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DataExport } from '../DataExport';
+import { ExportStatus } from '@/lib/exports/types';
+import useDataExport from '@/hooks/user/useDataExport';
+
+vi.mock('@/hooks/user/useDataExport');
+const mockHook = useDataExport as unknown as vi.Mock;
+
+describe('DataExport headless', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('handles immediate export', async () => {
+    const requestExport = vi.fn().mockResolvedValue({ status: ExportStatus.COMPLETED, downloadUrl: 'url' });
+    mockHook.mockReturnValue({ requestExport, refreshStatus: vi.fn(), status: null, isLoading: false, error: null });
+
+    let props: any;
+    render(<DataExport>{p => { props = p; return <div/>; }}</DataExport>);
+
+    await act(async () => {
+      await props.onRequestExport();
+    });
+    expect(props.exportStatus).toBe('ready');
+    expect(props.downloadUrl).toBe('url');
+  });
+
+  it('handles asynchronous export', async () => {
+    const requestExport = vi.fn().mockResolvedValue({ status: ExportStatus.PENDING });
+    const refreshStatus = vi.fn().mockResolvedValue({ status: ExportStatus.COMPLETED, downloadUrl: 'url' });
+    mockHook.mockReturnValue({ requestExport, refreshStatus, status: null, isLoading: false, error: null });
+
+    let props: any;
+    render(<DataExport>{p => { props = p; return <div/>; }}</DataExport>);
+
+    await act(async () => {
+      await props.onRequestExport();
+    });
+    expect(props.exportStatus).toBe('in_progress');
+    await act(async () => {
+      await props.onDownload();
+    });
+    expect(props.exportStatus).toBe('ready');
+    expect(refreshStatus).toHaveBeenCalled();
+  });
+
+  it('handles export error', async () => {
+    const requestExport = vi.fn().mockResolvedValue(null);
+    mockHook.mockReturnValue({ requestExport, refreshStatus: vi.fn(), status: null, isLoading: false, error: 'fail' });
+
+    let props: any;
+    render(<DataExport>{p => { props = p; return <div/>; }}</DataExport>);
+
+    await act(async () => {
+      await props.onRequestExport();
+    });
+    expect(props.exportStatus).toBe('error');
+    expect(props.errors).toBe('fail');
+  });
+});


### PR DESCRIPTION
## Summary
- add headless AccountDeletion component under auth
- add headless DataExport component under profile
- implement tests for new headless components

## Testing
- `npx vitest run src/ui/headless/auth/__tests__/account-deletion.test.tsx src/ui/headless/profile/__tests__/data-export.test.tsx`