### PR TITLE
Refactor settings account deletion and company export

### DIFF
--- a/src/ui/styled/profile/CompanyDataExport.tsx
+++ b/src/ui/styled/profile/CompanyDataExport.tsx
@@ -1,79 +1,35 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { CompanyDataExport as HeadlessCompanyDataExport } from '@/ui/headless/profile/CompanyDataExport';
 
-const CompanyDataExport: React.FC = () => {
-  const [downloading, setDownloading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState<string | null>(null);
-
-  const handleExport = async () => {
-    setError(null);
-    setSuccess(null);
-    setDownloading(true);
-    // eslint-disable-next-line no-console
-    console.log('DEBUG: handleExport called');
-    try {
-      // eslint-disable-next-line no-console
-      console.log('DEBUG: Fetching /api/company/export');
-      const res = await fetch('/api/company/export');
-      // eslint-disable-next-line no-console
-      console.log('DEBUG: Fetch response', res);
-      if (!res.ok) {
-        // eslint-disable-next-line no-console
-        console.log('DEBUG: Response not ok');
-        throw new Error(await res.text());
-      }
-      const blob = await res.blob();
-      // eslint-disable-next-line no-console
-      console.log('DEBUG: Got blob', blob);
-      const contentDisposition = res.headers.get('content-disposition');
-      // eslint-disable-next-line no-console
-      console.log('DEBUG: contentDisposition', contentDisposition);
-      let filename = 'Company_Data_Export.json';
-      if (contentDisposition) {
-        const match = contentDisposition.match(/filename="(.+)"/);
-        if (match) filename = match[1];
-      }
-      const url = URL.createObjectURL(blob);
-      // eslint-disable-next-line no-console
-      console.log('DEBUG: Blob URL', url);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      // eslint-disable-next-line no-console
-      console.log('DEBUG: Clicking anchor');
-      a.click();
-      a.remove();
-      setSuccess('Company data export has been downloaded successfully.');
-      // eslint-disable-next-line no-console
-      console.log('DEBUG: setSuccess(true)');
-    } catch (err: any) {
-      // eslint-disable-next-line no-console
-      console.log('DEBUG: Error in handleExport', err);
-      setError('Failed to export company data.');
-    } finally {
-      setDownloading(false);
-    }
-  };
-
-  return (
-    <div className="rounded border p-4 max-w-lg mx-auto bg-white shadow mt-6">
-      <h3 className="text-lg font-semibold mb-2">Export Company Data</h3>
-      <p className="text-sm text-gray-600 mb-4">
-        Download a copy of your company profile, team members, roles, and activity logs. This export is provided in JSON format for compliance, backup, or migration needs. Only company admins can access this export.
-      </p>
-      <button
-        className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
-        onClick={handleExport}
-        disabled={downloading}
-        {...(downloading ? { role: "status" } : {})}
-      >
-        {downloading ? 'Generating export...' : 'Download Company Data'}
-      </button>
-      {success && <div className="text-green-600 text-sm mt-2" role="alert">{success}</div>}
-      {error && <div className="text-red-600 text-sm mt-2" role="alert">{error}</div>}
-    </div>
-  );
-};
+const CompanyDataExport: React.FC = () => (
+  <HeadlessCompanyDataExport>
+    {({ isExporting, error, success, exportData }) => (
+      <div className="rounded border p-4 max-w-lg mx-auto bg-white shadow mt-6">
+        <h3 className="text-lg font-semibold mb-2">Export Company Data</h3>
+        <p className="text-sm text-gray-600 mb-4">
+          Download a copy of your company profile, team members, roles, and activity logs. This export is provided in JSON format for compliance, backup, or migration needs. Only company admins can access this export.
+        </p>
+        <button
+          className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
+          onClick={exportData}
+          disabled={isExporting}
+          {...(isExporting ? { role: 'status' } : {})}
+        >
+          {isExporting ? 'Generating export...' : 'Download Company Data'}
+        </button>
+        {success && (
+          <div className="text-green-600 text-sm mt-2" role="alert">
+            {success}
+          </div>
+        )}
+        {error && (
+          <div className="text-red-600 text-sm mt-2" role="alert">
+            {error}
+          </div>
+        )}
+      </div>
+    )}
+  </HeadlessCompanyDataExport>
+);
 
 export default CompanyDataExport;

--- a/src/ui/styled/settings/AccountDeletion.tsx
+++ b/src/ui/styled/settings/AccountDeletion.tsx
@@ -1,152 +1,143 @@
-import { useState } from 'react';
-import { useAuth } from '@/hooks/auth/useAuth';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/ui/primitives/button';
 import { Input } from '@/ui/primitives/input';
 import { Label } from '@/ui/primitives/label';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/ui/primitives/card';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/ui/primitives/card';
 import { Alert, AlertDescription } from '@/ui/primitives/alert';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/ui/primitives/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/ui/primitives/dialog';
 import { Checkbox } from '@/ui/primitives/checkbox';
+import { AccountDeletion as HeadlessAccountDeletion } from '@/ui/headless/account/AccountDeletion';
 
 export function AccountDeletion() {
   const { t } = useTranslation();
-  const deleteAccount = useAuth().deleteAccount;
-  const isLoading = useAuth().isLoading;
-  const error = useAuth().error;
-  
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [password, setPassword] = useState('');
-  const [confirmText, setConfirmText] = useState('');
-  const [confirmChecked, setConfirmChecked] = useState(false);
-  const [localError, setLocalError] = useState<string | null>(null);
-  
-  // Handle account deletion
-  const handleDeleteAccount = async () => {
-    try {
-      setLocalError(null);
-      
-      // Validate confirmation text
-      if (confirmText !== 'DELETE') {
-        setLocalError(t('settings.accountDeletion.confirmTextError'));
-        return;
-      }
-      
-      // Validate confirmation checkbox
-      if (!confirmChecked) {
-        setLocalError(t('settings.accountDeletion.confirmCheckError'));
-        return;
-      }
-      
-      // Delete account
-      await deleteAccount(password);
-      
-      // Close dialog
-      setIsDialogOpen(false);
-      
-      // Reset form
-      setPassword('');
-      setConfirmText('');
-      setConfirmChecked(false);
-    } catch (error) {
-      if (process.env.NODE_ENV === 'development') { console.error('Error deleting account:', error) }
-    }
-  };
-  
+
   return (
-    <Card className="border-destructive/20">
-      <CardHeader>
-        <CardTitle className="text-destructive">{t('settings.accountDeletion.title')}</CardTitle>
-        <CardDescription>{t('settings.accountDeletion.description')}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <p className="text-sm text-muted-foreground mb-4">
-          {t('settings.accountDeletion.warning')}
-        </p>
-        
-        <ul className="list-disc pl-5 space-y-1 text-sm">
-          <li>{t('settings.accountDeletion.consequence1')}</li>
-          <li>{t('settings.accountDeletion.consequence2')}</li>
-          <li>{t('settings.accountDeletion.consequence3')}</li>
-        </ul>
-      </CardContent>
-      <CardFooter>
-        <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-          <DialogTrigger asChild>
-            <Button variant="destructive">
-              {t('settings.accountDeletion.deleteButton')}
-            </Button>
-          </DialogTrigger>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>{t('settings.accountDeletion.confirmTitle')}</DialogTitle>
-              <DialogDescription>
-                {t('settings.accountDeletion.confirmDescription')}
-              </DialogDescription>
-            </DialogHeader>
-            
-            {(error || localError) && (
-              <Alert variant="destructive" className="mt-4" role="alert">
-                <AlertDescription>{error || localError}</AlertDescription>
-              </Alert>
-            )}
-            
-            <div className="space-y-4 py-4">
-              <div className="space-y-2">
-                <Label htmlFor="password">{t('settings.accountDeletion.password')}</Label>
-                <Input
-                  id="password"
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  placeholder="••••••••"
-                />
-              </div>
-              
-              <div className="space-y-2">
-                <Label htmlFor="confirm-text">
-                  {t('settings.accountDeletion.typeDelete')}
-                </Label>
-                <Input
-                  id="confirm-text"
-                  value={confirmText}
-                  onChange={(e) => setConfirmText(e.target.value)}
-                  placeholder="DELETE"
-                />
-              </div>
-              
-              <div className="flex items-center space-x-2 pt-2">
-                <Checkbox
-                  id="confirm-checkbox"
-                  checked={confirmChecked}
-                  onCheckedChange={(checked) => setConfirmChecked(checked === true)}
-                />
-                <Label htmlFor="confirm-checkbox" className="text-sm">
-                  {t('settings.accountDeletion.confirmCheckbox')}
-                </Label>
-              </div>
-            </div>
-            
-            <DialogFooter>
-              <Button
-                variant="outline"
-                onClick={() => setIsDialogOpen(false)}
-              >
-                {t('common.cancel')}
-              </Button>
-              <Button
-                variant="destructive"
-                onClick={handleDeleteAccount}
-                disabled={isLoading}
-              >
-                {isLoading
-                  ? t('settings.accountDeletion.deleting')
-                  : t('settings.accountDeletion.confirmButton')}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      </CardFooter>
-    </Card>
+    <HeadlessAccountDeletion
+      render={({
+        isDialogOpen,
+        setIsDialogOpen,
+        password,
+        setPassword,
+        confirmText,
+        setConfirmText,
+        confirmChecked,
+        setConfirmChecked,
+        error,
+        localError,
+        isLoading,
+        handleDeleteAccount,
+      }) => (
+        <Card className="border-destructive/20">
+          <CardHeader>
+            <CardTitle className="text-destructive">
+              {t('settings.accountDeletion.title')}
+            </CardTitle>
+            <CardDescription>
+              {t('settings.accountDeletion.description')}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground mb-4">
+              {t('settings.accountDeletion.warning')}
+            </p>
+            <ul className="list-disc pl-5 space-y-1 text-sm">
+              <li>{t('settings.accountDeletion.consequence1')}</li>
+              <li>{t('settings.accountDeletion.consequence2')}</li>
+              <li>{t('settings.accountDeletion.consequence3')}</li>
+            </ul>
+          </CardContent>
+          <CardFooter>
+            <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+              <DialogTrigger asChild>
+                <Button variant="destructive">
+                  {t('settings.accountDeletion.deleteButton')}
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>
+                    {t('settings.accountDeletion.confirmTitle')}
+                  </DialogTitle>
+                  <DialogDescription>
+                    {t('settings.accountDeletion.confirmDescription')}
+                  </DialogDescription>
+                </DialogHeader>
+                {(error || localError) && (
+                  <Alert variant="destructive" className="mt-4" role="alert">
+                    <AlertDescription>{error || localError}</AlertDescription>
+                  </Alert>
+                )}
+                <div className="space-y-4 py-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="password">
+                      {t('settings.accountDeletion.password')}
+                    </Label>
+                    <Input
+                      id="password"
+                      type="password"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      placeholder="••••••••"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="confirm-text">
+                      {t('settings.accountDeletion.typeDelete')}
+                    </Label>
+                    <Input
+                      id="confirm-text"
+                      value={confirmText}
+                      onChange={(e) => setConfirmText(e.target.value)}
+                      placeholder="DELETE"
+                    />
+                  </div>
+                  <div className="flex items-center space-x-2 pt-2">
+                    <Checkbox
+                      id="confirm-checkbox"
+                      checked={confirmChecked}
+                      onCheckedChange={(checked) =>
+                        setConfirmChecked(checked === true)
+                      }
+                    />
+                    <Label htmlFor="confirm-checkbox" className="text-sm">
+                      {t('settings.accountDeletion.confirmCheckbox')}
+                    </Label>
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => setIsDialogOpen(false)}>
+                    {t('common.cancel')}
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    onClick={handleDeleteAccount}
+                    disabled={isLoading}
+                  >
+                    {isLoading
+                      ? t('settings.accountDeletion.deleting')
+                      : t('settings.accountDeletion.confirmButton')}
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          </CardFooter>
+        </Card>
+      )}
+    />
   );
-} 
+}


### PR DESCRIPTION
## Summary
- refactor AccountDeletion component in settings to use headless implementation
- refactor CompanyDataExport to rely on headless component logic

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined)*