### PR TITLE
Refactor admin APIs with new utilities

### DIFF
--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,60 @@
+import { type NextRequest } from 'next/server';
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  createNoContentResponse,
+  withErrorHandling,
+  withValidation,
+} from '@/lib/api/common';
+import { getApiAdminService } from '@/lib/api/admin/factory';
+import { createUserNotFoundError } from '@/lib/api/admin/error-handler';
+import { createProtectedHandler } from '@/middleware/permissions';
+
+const updateUserSchema = z.object({
+  name: z.string().optional(),
+  email: z.string().email().optional(),
+  role: z.string().optional(),
+  status: z.enum(['active', 'inactive', 'suspended']).optional(),
+});
+
+type UpdateUser = z.infer<typeof updateUserSchema>;
+
+async function handleGetUser(req: NextRequest, { params }: { params: { id: string } }) {
+  const adminService = getApiAdminService();
+  const user = await adminService.getUserById(params.id);
+  if (!user) {
+    throw createUserNotFoundError(params.id);
+  }
+  return createSuccessResponse({ user });
+}
+
+async function handleUpdateUser(req: NextRequest, data: UpdateUser, { params }: { params: { id: string } }) {
+  const adminService = getApiAdminService();
+  const updated = await adminService.updateUser(params.id, data);
+  return createSuccessResponse({ user: updated });
+}
+
+async function handleDeleteUser(req: NextRequest, { params }: { params: { id: string } }) {
+  const adminService = getApiAdminService();
+  await adminService.deleteUser(params.id);
+  return createNoContentResponse();
+}
+
+export const GET = createProtectedHandler(
+  (req, ctx) => withErrorHandling(() => handleGetUser(req, ctx), req),
+  'admin.users.view'
+);
+
+export const PUT = createProtectedHandler(
+  (req, ctx) =>
+    withErrorHandling(async () => {
+      const data = await req.json();
+      return withValidation(updateUserSchema, (r, validated) => handleUpdateUser(r, validated, ctx), req, data);
+    }, req),
+  'admin.users.update'
+);
+
+export const DELETE = createProtectedHandler(
+  (req, ctx) => withErrorHandling(() => handleDeleteUser(req, ctx), req),
+  'admin.users.delete'
+);

--- a/src/core/admin/interfaces.ts
+++ b/src/core/admin/interfaces.ts
@@ -1,0 +1,29 @@
+import { PaginationMeta } from '@/lib/api/common/response-formatter';
+
+export interface ListUsersParams {
+  page: number;
+  limit: number;
+  search?: string;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
+}
+
+export interface AuditLogQuery {
+  page: number;
+  limit: number;
+  userId?: string;
+  action?: string;
+  resource?: string;
+  startDate?: string;
+  endDate?: string;
+  sortOrder?: 'asc' | 'desc';
+  [key: string]: any;
+}
+
+export interface AdminService {
+  listUsers(params: ListUsersParams): Promise<{ users: any[]; pagination: PaginationMeta }>;
+  getUserById(id: string): Promise<any | null>;
+  updateUser(id: string, data: Record<string, any>): Promise<any>;
+  deleteUser(id: string): Promise<void>;
+  getAuditLogs(params: AuditLogQuery): Promise<{ logs: any[]; pagination: PaginationMeta }>;
+}

--- a/src/lib/api/admin/error-handler.ts
+++ b/src/lib/api/admin/error-handler.ts
@@ -1,0 +1,70 @@
+/**
+ * Admin Domain Error Handler
+ * 
+ * Specialized error handling for the admin domain.
+ * This module provides error handling specific to admin operations.
+ */
+
+import { ApiError, ERROR_CODES } from '../common';
+
+/**
+ * Create an admin operation failed error
+ */
+export function createAdminOperationFailedError(message = 'Admin operation failed', details?: Record<string, any>) {
+  return new ApiError(
+    ERROR_CODES.OPERATION_FAILED,
+    message,
+    500,
+    details
+  );
+}
+
+/**
+ * Create a user not found error
+ */
+export function createUserNotFoundError(userId?: string) {
+  const message = userId
+    ? `User with ID ${userId} not found`
+    : 'User not found';
+
+  return new ApiError(
+    ERROR_CODES.NOT_FOUND,
+    message,
+    404
+  );
+}
+
+/**
+ * Create an audit log retrieval error
+ */
+export function createAuditLogRetrievalError(message = 'Failed to retrieve audit logs', details?: Record<string, any>) {
+  return new ApiError(
+    ERROR_CODES.RETRIEVAL_FAILED,
+    message,
+    500,
+    details
+  );
+}
+
+/**
+ * Map admin service errors to API errors
+ */
+export function mapAdminServiceError(error: Error): ApiError {
+  // Check for specific error types based on message
+  const message = error.message.toLowerCase();
+
+  if (message.includes('user not found') || message.includes('user does not exist')) {
+    return createUserNotFoundError();
+  }
+
+  if (message.includes('audit log') || message.includes('audit trail')) {
+    return createAuditLogRetrievalError();
+  }
+
+  // Default to a server error if no specific mapping is found
+  return new ApiError(
+    ERROR_CODES.INTERNAL_ERROR,
+    'An unexpected admin operation error occurred',
+    500
+  );
+}

--- a/src/lib/api/admin/factory.ts
+++ b/src/lib/api/admin/factory.ts
@@ -1,0 +1,45 @@
+/**
+ * Admin Service Factory for API Routes
+ *
+ * This file provides factory functions for creating admin services for use in API routes.
+ * It ensures consistent configuration and dependency injection across all API endpoints.
+ */
+
+import { AdminService } from '@/core/admin/interfaces';
+import { UserManagementConfiguration } from '@/core/config';
+import { createAdminProvider } from '@/adapters/admin/factory';
+import { getServiceSupabase } from '@/lib/database/supabase';
+
+// Singleton instance for API routes
+let adminServiceInstance: AdminService | null = null;
+
+/**
+ * Get the configured admin service instance for API routes
+ *
+ * @returns Configured AdminService instance
+ */
+export function getApiAdminService(): AdminService {
+  if (!adminServiceInstance) {
+    // Get Supabase configuration from the existing service
+    const supabase = getServiceSupabase();
+
+    // Create admin data provider
+    const adminDataProvider = createAdminProvider({
+      type: 'supabase',
+      options: {
+        supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',
+        supabaseKey: process.env.SUPABASE_SERVICE_ROLE_KEY || ''
+      }
+    });
+
+    // Create admin service with the data provider
+    adminServiceInstance = UserManagementConfiguration.getServiceProvider('adminService') as AdminService;
+
+    // If no admin service is registered, throw an error
+    if (!adminServiceInstance) {
+      throw new Error('Admin service not registered in UserManagementConfiguration');
+    }
+  }
+
+  return adminServiceInstance;
+}

--- a/src/lib/api/common/error-codes.ts
+++ b/src/lib/api/common/error-codes.ts
@@ -59,6 +59,8 @@ export const SERVER_ERROR_CODES = {
   INTERNAL_ERROR: 'server/internal_error',
   SERVICE_UNAVAILABLE: 'server/service_unavailable',
   DATABASE_ERROR: 'server/database_error',
+  OPERATION_FAILED: 'server/operation_failed',
+  RETRIEVAL_FAILED: 'server/retrieval_failed',
 } as const;
 
 // Combine all error codes for easy export


### PR DESCRIPTION
## Summary
- implement admin-specific error handler and service factory
- extend error codes for generic admin errors
- define AdminService interface
- refactor admin user endpoints to use common API utilities
- add endpoints for specific user operations and audit logs

## Testing
- `npm run test:coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*