### PR TITLE
Refactor auth API endpoints

### DIFF
--- a/app/api/auth/account/route.ts
+++ b/app/api/auth/account/route.ts
@@ -1,19 +1,30 @@
-import { type NextRequest, NextResponse } from 'next/server';
-import { z } from 'zod';
-import { withSecurity } from '@/middleware/security';
-import { withAuthRateLimit } from '@/middleware/rate-limit';
-import { getApiAuthService } from '@/lib/api/auth/factory';
-import { logUserAction } from '@/lib/audit/auditLogger';
+import { type NextRequest } from "next/server";
+import { z } from "zod";
+import { withSecurity } from "@/middleware/security";
+import { withAuthRateLimit } from "@/middleware/rate-limit";
+import { getApiAuthService } from "@/lib/api/auth/factory";
+import { logUserAction } from "@/lib/audit/auditLogger";
+import {
+  createSuccessResponse,
+  withErrorHandling,
+  withValidation,
+  ApiError,
+  ERROR_CODES,
+} from "@/lib/api/common";
 
 // Zod schema for account deletion request
 const DeleteAccountSchema = z.object({
-  password: z.string().min(1, { message: 'Password confirmation is required.' }),
+  password: z
+    .string()
+    .min(1, { message: "Password confirmation is required." }),
 });
 
-async function handler(request: NextRequest) {
-  // Get IP and User Agent early for logging
-  const ipAddress = request.headers.get('x-forwarded-for') || 'unknown';
-  const userAgent = request.headers.get('user-agent') || 'unknown';
+async function handleDeleteAccount(
+  req: NextRequest,
+  data: z.infer<typeof DeleteAccountSchema>,
+) {
+  const ipAddress = req.headers.get("x-forwarded-for") || "unknown";
+  const userAgent = req.headers.get("user-agent") || "unknown";
 
   let userId: string | undefined;
   let userEmail: string | undefined;
@@ -21,172 +32,200 @@ async function handler(request: NextRequest) {
   try {
     // 1. Get AuthService
     const authService = getApiAuthService();
-    
+
     // 2. Get current user
     const user = authService.getCurrentUser();
-    
+
     if (!user) {
-      return NextResponse.json({ error: 'User not authenticated' }, { status: 401 });
+      throw new ApiError(
+        ERROR_CODES.UNAUTHORIZED,
+        "User not authenticated",
+        401,
+      );
     }
-    
+
     userId = user.id;
     userEmail = user.email;
 
     if (!userEmail) {
-      return NextResponse.json({ error: 'User email not found, cannot verify password.' }, { status: 400 });
+      throw new ApiError(
+        ERROR_CODES.INVALID_REQUEST,
+        "User email not found, cannot verify password.",
+        400,
+      );
     }
 
     // 3. Parse and Validate Body
-    let body;
-    try {
-      body = await request.json();
-    } catch (e) {
-      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
-    }
+    const { password } = data;
 
-    const parseResult = DeleteAccountSchema.safeParse(body);
-    if (!parseResult.success) {
-      return NextResponse.json({ error: 'Validation failed', details: parseResult.error.format() }, { status: 400 });
-    }
-    const { password } = parseResult.data;
+    console.log("Account deletion attempt initiated for user:", userId);
 
-    console.log('Account deletion attempt initiated for user:', userId);
-    
     // Log the account deletion attempt
     await logUserAction({
       userId,
-      action: 'ACCOUNT_DELETION_INITIATED',
-      status: 'PENDING',
+      action: "ACCOUNT_DELETION_INITIATED",
+      status: "PENDING",
       ipAddress,
       userAgent,
-      targetResourceType: 'account',
-      targetResourceId: userId
+      targetResourceType: "account",
+      targetResourceId: userId,
     });
 
     // 4. Delete account using the AuthService
     const result = await authService.deleteAccount({
       userId,
-      password
+      password,
     });
-    
+
     // 5. Handle the result
     if (!result.success) {
-      console.error('Account deletion failed for user:', userId, result.error);
-      
+      console.error("Account deletion failed for user:", userId, result.error);
+
       // Log the failed deletion
       await logUserAction({
         userId,
-        action: 'ACCOUNT_DELETION_FAILED',
-        status: 'FAILURE',
+        action: "ACCOUNT_DELETION_FAILED",
+        status: "FAILURE",
         ipAddress,
         userAgent,
-        targetResourceType: 'account',
+        targetResourceType: "account",
         targetResourceId: userId,
-        details: { error: result.error }
+        details: { error: result.error },
       });
-      
+
       // Return appropriate error based on the error type
-      if (result.error === 'INVALID_PASSWORD') {
-        return NextResponse.json({ error: 'Incorrect password provided.' }, { status: 401 });
+      if (result.error === "INVALID_PASSWORD") {
+        throw new ApiError(
+          ERROR_CODES.UNAUTHORIZED,
+          "Incorrect password provided.",
+          401,
+        );
       } else {
-        return NextResponse.json({ error: result.error || 'Account deletion failed.' }, { status: 500 });
+        throw new ApiError(
+          ERROR_CODES.INTERNAL_ERROR,
+          result.error || "Account deletion failed.",
+          500,
+        );
       }
     }
-    
+
     // Log the successful deletion
     await logUserAction({
-      action: 'ACCOUNT_DELETION_COMPLETED',
-      status: 'SUCCESS',
+      action: "ACCOUNT_DELETION_COMPLETED",
+      status: "SUCCESS",
       ipAddress,
       userAgent,
-      targetResourceType: 'account',
-      targetResourceId: userId
+      targetResourceType: "account",
+      targetResourceId: userId,
     });
 
-    console.log('Account deletion successful for user:', userId);
+    console.log("Account deletion successful for user:", userId);
 
     // Return success
     // Client should handle redirecting or signing out locally
-    return NextResponse.json({ message: 'Account successfully deleted.' });
-
+    return createSuccessResponse({ message: "Account successfully deleted." });
   } catch (error) {
     // Handle Unexpected Errors
-    console.error('Account deletion process error for user:', userId, error);
-    const message = error instanceof Error ? error.message : 'An unexpected error occurred';
-    
+    console.error("Account deletion process error for user:", userId, error);
+    const message =
+      error instanceof Error ? error.message : "An unexpected error occurred";
+
     // Log the error
     await logUserAction({
       userId,
-      action: 'ACCOUNT_DELETION_ERROR',
-      status: 'FAILURE',
+      action: "ACCOUNT_DELETION_ERROR",
+      status: "FAILURE",
       ipAddress,
       userAgent,
-      targetResourceType: 'account',
+      targetResourceType: "account",
       targetResourceId: userId,
-      details: { error: message }
+      details: { error: message },
     });
-    
+
     // Avoid sending specific details unless it was a known validation/auth error handled above
-    return NextResponse.json({ error: 'Account deletion failed due to an unexpected error.' }, { status: 500 });
+    throw new ApiError(
+      ERROR_CODES.INTERNAL_ERROR,
+      "Account deletion failed due to an unexpected error.",
+      500,
+    );
   }
 }
 
 // Apply rate limiting and security middleware
-export const DELETE = withSecurity(
-  async (request: NextRequest) => withAuthRateLimit(request, handler)
+async function deleteHandler(req: NextRequest) {
+  return withErrorHandling(
+    async (r) => withValidation(DeleteAccountSchema, handleDeleteAccount, r),
+    req,
+  );
+}
+
+export const DELETE = withSecurity(async (request: NextRequest) =>
+  withAuthRateLimit(request, deleteHandler),
 );
 
 // GET handler to fetch account info
-async function getHandler(request: NextRequest) {
-  // Get IP and User Agent early for logging
-  const ipAddress = request.headers.get('x-forwarded-for') || 'unknown';
-  const userAgent = request.headers.get('user-agent') || 'unknown';
-  
+async function handleGetAccount(req: NextRequest) {
+  const ipAddress = req.headers.get("x-forwarded-for") || "unknown";
+  const userAgent = req.headers.get("user-agent") || "unknown";
+
   try {
     // Get AuthService
     const authService = getApiAuthService();
-    
+
     // Get current user
     const user = authService.getCurrentUser();
-    
+
     if (!user) {
-      return NextResponse.json({ error: 'User not authenticated' }, { status: 401 });
+      throw new ApiError(
+        ERROR_CODES.UNAUTHORIZED,
+        "User not authenticated",
+        401,
+      );
     }
-    
+
     // Get user account details
     const accountDetails = await authService.getUserAccount(user.id);
-    
+
     // Log the account info request
     await logUserAction({
       userId: user.id,
-      action: 'ACCOUNT_INFO_REQUESTED',
-      status: 'SUCCESS',
+      action: "ACCOUNT_INFO_REQUESTED",
+      status: "SUCCESS",
       ipAddress,
       userAgent,
-      targetResourceType: 'account',
-      targetResourceId: user.id
+      targetResourceType: "account",
+      targetResourceId: user.id,
     });
-    
-    return NextResponse.json(accountDetails);
+
+    return createSuccessResponse(accountDetails);
   } catch (error) {
-    console.error('Error fetching account info:', error);
-    const message = error instanceof Error ? error.message : 'An unexpected error occurred';
-    
+    console.error("Error fetching account info:", error);
+    const message =
+      error instanceof Error ? error.message : "An unexpected error occurred";
+
     // Log the error
     await logUserAction({
-      action: 'ACCOUNT_INFO_ERROR',
-      status: 'FAILURE',
+      action: "ACCOUNT_INFO_ERROR",
+      status: "FAILURE",
       ipAddress,
       userAgent,
-      targetResourceType: 'account',
-      details: { error: message }
+      targetResourceType: "account",
+      details: { error: message },
     });
-    
-    return NextResponse.json({ error: 'Failed to fetch account information' }, { status: 500 });
+
+    throw new ApiError(
+      ERROR_CODES.INTERNAL_ERROR,
+      "Failed to fetch account information",
+      500,
+    );
   }
 }
 
 // Apply rate limiting and security middleware for GET
-export const GET = withSecurity(
-  async (request: NextRequest) => withAuthRateLimit(request, getHandler)
+async function getHandler(req: NextRequest) {
+  return withErrorHandling(handleGetAccount, req);
+}
+
+export const GET = withSecurity(async (request: NextRequest) =>
+  withAuthRateLimit(request, getHandler),
 );

--- a/app/api/auth/csrf/route.ts
+++ b/app/api/auth/csrf/route.ts
@@ -1,47 +1,58 @@
-import { NextResponse } from 'next/server';
-import { type NextRequest } from 'next/server';
-import { withSecurity } from '@/middleware/security';
-import { getCSRFToken } from '@/middleware/csrf';
-import { logUserAction } from '@/lib/audit/auditLogger';
+import { type NextRequest } from "next/server";
+import { withSecurity } from "@/middleware/security";
+import { getCSRFToken } from "@/middleware/csrf";
+import { logUserAction } from "@/lib/audit/auditLogger";
+import {
+  createSuccessResponse,
+  withErrorHandling,
+  ApiError,
+  ERROR_CODES,
+} from "@/lib/api/common";
 
-async function handler(req: NextRequest) {
-  // Get IP and User Agent for logging
-  const ipAddress = req.headers.get('x-forwarded-for') || 'unknown';
-  const userAgent = req.headers.get('user-agent') || 'unknown';
-  
+async function handleCsrf(req: NextRequest) {
+  const ipAddress = req.headers.get("x-forwarded-for") || "unknown";
+  const userAgent = req.headers.get("user-agent") || "unknown";
+
   try {
     const token = getCSRFToken(req);
-    
+
     // Log the CSRF token generation
     await logUserAction({
-      action: 'CSRF_TOKEN_GENERATED',
-      status: 'SUCCESS',
+      action: "CSRF_TOKEN_GENERATED",
+      status: "SUCCESS",
       ipAddress,
       userAgent,
-      targetResourceType: 'security'
+      targetResourceType: "security",
     });
-    
-    return NextResponse.json({ token });
+
+    return createSuccessResponse({ token });
   } catch (error) {
-    console.error('CSRF token generation error:', error);
-    
+    console.error("CSRF token generation error:", error);
+
     // Log the error
     await logUserAction({
-      action: 'CSRF_TOKEN_ERROR',
-      status: 'FAILURE',
+      action: "CSRF_TOKEN_ERROR",
+      status: "FAILURE",
       ipAddress,
       userAgent,
-      targetResourceType: 'security',
-      details: { error: error instanceof Error ? error.message : 'Unknown error' }
+      targetResourceType: "security",
+      details: {
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
     });
-    
-    return NextResponse.json(
-      { error: 'Failed to generate CSRF token' },
-      { status: 500 }
+
+    throw new ApiError(
+      ERROR_CODES.INTERNAL_ERROR,
+      "Failed to generate CSRF token",
+      500,
     );
   }
 }
 
+async function handler(req: NextRequest) {
+  return withErrorHandling(handleCsrf, req);
+}
+
 export const GET = withSecurity(handler, {
-  skipMiddlewares: ['csrf'] // Skip CSRF check for the token endpoint
+  skipMiddlewares: ["csrf"], // Skip CSRF check for the token endpoint
 });

--- a/app/api/auth/mfa/verify/route.ts
+++ b/app/api/auth/mfa/verify/route.ts
@@ -1,10 +1,17 @@
-import { NextResponse } from 'next/server';
-import { z } from 'zod';
-import { TwoFactorMethod } from '@/types/2fa';
-import { getApiAuthService } from '@/lib/api/auth/factory';
-import { logUserAction } from '@/lib/audit/auditLogger';
-import { withAuthRateLimit } from '@/middleware/rate-limit';
-import { withSecurity } from '@/middleware/security';
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { TwoFactorMethod } from "@/types/2fa";
+import { getApiAuthService } from "@/lib/api/auth/factory";
+import { logUserAction } from "@/lib/audit/auditLogger";
+import { withAuthRateLimit } from "@/middleware/rate-limit";
+import { withSecurity } from "@/middleware/security";
+import {
+  createSuccessResponse,
+  withErrorHandling,
+  withValidation,
+  ApiError,
+  ERROR_CODES,
+} from "@/lib/api/common";
 
 // Request schema for MFA verification
 const mfaVerifySchema = z.object({
@@ -14,49 +21,49 @@ const mfaVerifySchema = z.object({
   rememberDevice: z.boolean().optional(),
 });
 
-async function handler(request: Request) {
-  // Get IP and User Agent early for logging
-  const ipAddress = request.headers.get('x-forwarded-for') || 'unknown';
-  const userAgent = request.headers.get('user-agent') || 'unknown';
-  
+async function handleMfaVerify(
+  req: NextRequest,
+  data: z.infer<typeof mfaVerifySchema>,
+) {
+  const ipAddress = req.headers.get("x-forwarded-for") || "unknown";
+  const userAgent = req.headers.get("user-agent") || "unknown";
+
   try {
-    // Parse and validate request body
-    const body = await request.json();
-    const { code, method, accessToken, rememberDevice } = mfaVerifySchema.parse(body);
+    const { code, method, accessToken, rememberDevice } = data;
 
     // Get AuthService
     const authService = getApiAuthService();
-    
+
     // Verify MFA code using the AuthService
     const verifyResult = await authService.verifyMfaCode({
       code,
       method,
       accessToken,
-      rememberDevice: rememberDevice || false
+      rememberDevice: rememberDevice || false,
     });
-    
+
     // Log the MFA verification attempt
     await logUserAction({
-      action: 'MFA_VERIFICATION_ATTEMPT',
-      status: verifyResult.success ? 'SUCCESS' : 'FAILURE',
+      action: "MFA_VERIFICATION_ATTEMPT",
+      status: verifyResult.success ? "SUCCESS" : "FAILURE",
       ipAddress,
       userAgent,
-      targetResourceType: 'auth',
+      targetResourceType: "auth",
       details: {
         method,
-        error: verifyResult.error || null
-      }
+        error: verifyResult.error || null,
+      },
     });
-    
-    // Handle verification failure
-    if (!verifyResult.success) {
-      console.error('MFA verification failed:', verifyResult.error);
-      return NextResponse.json(
-        { error: verifyResult.error || 'MFA verification failed' },
-        { status: 400 }
+
+    if (!verifyResult.success || !verifyResult.user || !verifyResult.session) {
+      console.error("MFA verification failed:", verifyResult.error);
+      throw new ApiError(
+        ERROR_CODES.INVALID_REQUEST,
+        verifyResult.error || "MFA verification failed",
+        400,
       );
     }
-    
+
     // Get user from result
     const { user } = verifyResult;
 
@@ -64,33 +71,46 @@ async function handler(request: Request) {
     const { session } = verifyResult;
 
     // Return full authenticated session
-    return NextResponse.json({
+    return createSuccessResponse({
       user,
       token: session.access_token,
       expiresAt: session.expires_at,
-      rememberDevice: !!rememberDevice
+      rememberDevice: !!rememberDevice,
     });
   } catch (error) {
-    console.error('Error in MFA verification:', error);
-    
+    console.error("Error in MFA verification:", error);
+
     // Log the error
     await logUserAction({
-      action: 'MFA_VERIFICATION_ERROR',
-      status: 'FAILURE',
+      action: "MFA_VERIFICATION_ERROR",
+      status: "FAILURE",
       ipAddress,
       userAgent,
-      targetResourceType: 'auth',
-      details: { error: error instanceof Error ? error.message : 'An unexpected error occurred' }
+      targetResourceType: "auth",
+      details: {
+        error:
+          error instanceof Error
+            ? error.message
+            : "An unexpected error occurred",
+      },
     });
-    
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'An unexpected error occurred' },
-      { status: 500 }
+
+    throw new ApiError(
+      ERROR_CODES.INTERNAL_ERROR,
+      error instanceof Error ? error.message : "An unexpected error occurred",
+      500,
     );
   }
 }
 
 // Apply rate limiting and security middleware
-export const POST = withSecurity(
-  async (request: Request) => withAuthRateLimit(request, handler)
+async function handler(req: NextRequest) {
+  return withErrorHandling(
+    async (r) => withValidation(mfaVerifySchema, handleMfaVerify, r),
+    req,
+  );
+}
+
+export const POST = withSecurity(async (request: NextRequest) =>
+  withAuthRateLimit(request, handler),
 );

--- a/app/api/auth/oauth/__tests__/route.test.ts
+++ b/app/api/auth/oauth/__tests__/route.test.ts
@@ -1,22 +1,41 @@
-import { POST } from '../route';
+import { POST } from "../route";
 // import { cookies } from 'next/headers';
 // import { NextResponse } from 'next/server';
-import { OAuthProvider } from '@/types/oauth';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OAuthProvider } from "@/types/oauth";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // --- Mocks ---
 
 // Mock next/headers cookies
 const mockCookies = new Map<string, any>();
-vi.mock('next/headers', () => ({
+vi.mock("next/headers", () => ({
   cookies: () => ({
     get: (key: string) => mockCookies.get(key),
-    set: (key: string | { name: string; [key: string]: any }, value?: string | object) => {
-      if (typeof key === 'string') {
-        mockCookies.set(key, { name: key, value: value, httpOnly: true, secure: true, sameSite: 'lax', maxAge: 600, path: '/', ...((typeof value === 'object') ? value : {}) });
+    set: (
+      key: string | { name: string; [key: string]: any },
+      value?: string | object,
+    ) => {
+      if (typeof key === "string") {
+        mockCookies.set(key, {
+          name: key,
+          value: value,
+          httpOnly: true,
+          secure: true,
+          sameSite: "lax",
+          maxAge: 600,
+          path: "/",
+          ...(typeof value === "object" ? value : {}),
+        });
       } else {
         // Handle object syntax for set (key is the object)
-        mockCookies.set(key.name, { httpOnly: true, secure: true, sameSite: 'lax', maxAge: 600, path: '/', ...key });
+        mockCookies.set(key.name, {
+          httpOnly: true,
+          secure: true,
+          sameSite: "lax",
+          maxAge: 600,
+          path: "/",
+          ...key,
+        });
       }
     },
     has: (key: string) => mockCookies.has(key),
@@ -26,24 +45,33 @@ vi.mock('next/headers', () => ({
 }));
 
 // Mock crypto for state/PKCE generation (making it deterministic)
-const mockStateValue = 'deterministic-state-value-1234567890';
-const mockPKCEVerifier = 'deterministic-pkce-verifier-value-abcdefg';
-const mockPKCEChallenge = 'deterministic-pkce-challenge-mock';
+const mockStateValue = "deterministic-state-value-1234567890";
+const mockPKCEVerifier = "deterministic-pkce-verifier-value-abcdefg";
+const mockPKCEChallenge = "deterministic-pkce-challenge-mock";
 
-vi.stubGlobal('crypto', {
+vi.stubGlobal("crypto", {
   getRandomValues: vi.fn((array: Uint8Array) => {
     // Fill with deterministic values for state generation
     // Use Buffer.from with hex encoding for simplicity if the mockStateValue allows
-    const stateBytes = Buffer.from(mockStateValue.substring(0, array.length * 2).padEnd(array.length * 2, '0'), 'hex');
+    const stateBytes = Buffer.from(
+      mockStateValue
+        .substring(0, array.length * 2)
+        .padEnd(array.length * 2, "0"),
+      "hex",
+    );
     stateBytes.copy(array);
     return array;
   }),
   subtle: {
-    digest: vi.fn(async (algorithm: string /*, _data: BufferSource */) => { // Removed unused data parameter
+    digest: vi.fn(async (algorithm: string /*, _data: BufferSource */) => {
+      // Removed unused data parameter
       // Simple mock, doesn't need to be cryptographically correct for the test
-      if (algorithm === 'SHA-256') {
+      if (algorithm === "SHA-256") {
         const challengeBuffer = Buffer.from(mockPKCEChallenge);
-        return challengeBuffer.buffer.slice(challengeBuffer.byteOffset, challengeBuffer.byteOffset + challengeBuffer.byteLength);
+        return challengeBuffer.buffer.slice(
+          challengeBuffer.byteOffset,
+          challengeBuffer.byteOffset + challengeBuffer.byteLength,
+        );
       }
       throw new Error(`Unsupported algorithm: ${algorithm}`);
     }),
@@ -51,27 +79,36 @@ vi.stubGlobal('crypto', {
 });
 
 // Mock environment variables (adjust values as needed)
-vi.stubEnv('NEXT_PUBLIC_GOOGLE_CLIENT_ID', 'test-google-client-id');
-vi.stubEnv('NEXT_PUBLIC_GOOGLE_REDIRECT_URI', 'http://localhost:3000/api/auth/oauth/callback');
-vi.stubEnv('NEXT_PUBLIC_GITHUB_CLIENT_ID', 'test-github-client-id');
-vi.stubEnv('NEXT_PUBLIC_GITHUB_REDIRECT_URI', 'http://localhost:3000/api/auth/oauth/callback');
-vi.stubEnv('NEXT_PUBLIC_APPLE_CLIENT_ID', 'test-apple-client-id'); // Mock Apple env vars
-vi.stubEnv('NEXT_PUBLIC_APPLE_REDIRECT_URI', 'http://localhost:3000/api/auth/oauth/callback');
+vi.stubEnv("NEXT_PUBLIC_GOOGLE_CLIENT_ID", "test-google-client-id");
+vi.stubEnv(
+  "NEXT_PUBLIC_GOOGLE_REDIRECT_URI",
+  "http://localhost:3000/api/auth/oauth/callback",
+);
+vi.stubEnv("NEXT_PUBLIC_GITHUB_CLIENT_ID", "test-github-client-id");
+vi.stubEnv(
+  "NEXT_PUBLIC_GITHUB_REDIRECT_URI",
+  "http://localhost:3000/api/auth/oauth/callback",
+);
+vi.stubEnv("NEXT_PUBLIC_APPLE_CLIENT_ID", "test-apple-client-id"); // Mock Apple env vars
+vi.stubEnv(
+  "NEXT_PUBLIC_APPLE_REDIRECT_URI",
+  "http://localhost:3000/api/auth/oauth/callback",
+);
 // Add mocks for other providers if testing them
 
 // --- Test Suite ---
 
-describe('POST /api/auth/oauth', () => {
+describe("POST /api/auth/oauth", () => {
   beforeEach(() => {
     mockCookies.clear();
     vi.clearAllMocks(); // Clear mocks between tests
   });
 
-  it('should return authorization URL and state for a valid provider (Google)', async () => {
+  it("should return authorization URL and state for a valid provider (Google)", async () => {
     const requestBody = JSON.stringify({ provider: OAuthProvider.GOOGLE });
-    const request = new Request('http://localhost/api/auth/oauth', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    const request = new Request("http://localhost/api/auth/oauth", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: requestBody,
     });
 
@@ -79,36 +116,40 @@ describe('POST /api/auth/oauth', () => {
     const responseBody = await response.json();
 
     expect(response.status).toBe(200);
-    expect(responseBody).toHaveProperty('url');
-    expect(responseBody).toHaveProperty('state', mockStateValue);
+    expect(responseBody.data).toHaveProperty("url");
+    expect(responseBody.data).toHaveProperty("state", mockStateValue);
 
     // Check URL parameters
-    const url = new URL(responseBody.url);
-    expect(url.origin).toBe('https://accounts.google.com');
-    expect(url.pathname).toBe('/o/oauth2/v2/auth');
-    expect(url.searchParams.get('client_id')).toBe('test-google-client-id');
-    expect(url.searchParams.get('redirect_uri')).toBe('http://localhost:3000/api/auth/oauth/callback');
-    expect(url.searchParams.get('response_type')).toBe('code');
-    expect(url.searchParams.get('scope')).toBe('profile email');
-    expect(url.searchParams.get('state')).toBe(mockStateValue);
-    expect(url.searchParams.has('code_challenge')).toBe(false); // Google doesn't use PKCE in this mock setup
+    const url = new URL(responseBody.data.url);
+    expect(url.origin).toBe("https://accounts.google.com");
+    expect(url.pathname).toBe("/o/oauth2/v2/auth");
+    expect(url.searchParams.get("client_id")).toBe("test-google-client-id");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "http://localhost:3000/api/auth/oauth/callback",
+    );
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("scope")).toBe("profile email");
+    expect(url.searchParams.get("state")).toBe(mockStateValue);
+    expect(url.searchParams.has("code_challenge")).toBe(false); // Google doesn't use PKCE in this mock setup
 
     // Check cookie
     expect(mockCookies.has(`oauth_state_${OAuthProvider.GOOGLE}`)).toBe(true);
-    const googleStateCookie = mockCookies.get(`oauth_state_${OAuthProvider.GOOGLE}`);
+    const googleStateCookie = mockCookies.get(
+      `oauth_state_${OAuthProvider.GOOGLE}`,
+    );
     expect(googleStateCookie.value).toBe(mockStateValue);
     expect(googleStateCookie.httpOnly).toBe(true);
     expect(googleStateCookie.secure).toBe(true);
-    expect(googleStateCookie.sameSite).toBe('lax');
+    expect(googleStateCookie.sameSite).toBe("lax");
   });
 
-  it('should return authorization URL with PKCE for Apple', async () => {
+  it("should return authorization URL with PKCE for Apple", async () => {
     // Note: This test assumes the Apple provider config in the route file can be enabled.
     // If the config is static and disabled, this test would fail unless the config source is mocked.
     const requestBody = JSON.stringify({ provider: OAuthProvider.APPLE });
-    const request = new Request('http://localhost/api/auth/oauth', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    const request = new Request("http://localhost/api/auth/oauth", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: requestBody,
     });
 
@@ -118,34 +159,36 @@ describe('POST /api/auth/oauth', () => {
     // Adjust this assertion if the route code's config handling changes
     if (response.status === 400) {
       const responseBody = await response.json();
-      expect(responseBody.error).toBe('Provider not supported or not enabled.');
+      expect(responseBody.error).toBe("Provider not supported or not enabled.");
     } else {
       // If Apple *was* enabled somehow (e.g., mocked config)
       expect(response.status).toBe(200);
       const responseBody = await response.json();
-      expect(responseBody).toHaveProperty('url');
-      const url = new URL(responseBody.url);
+      expect(responseBody.data).toHaveProperty("url");
+      const url = new URL(responseBody.data.url);
 
       // Assert PKCE params are present
-      expect(url.searchParams.get('code_challenge')).toBe(mockPKCEChallenge);
-      expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+      expect(url.searchParams.get("code_challenge")).toBe(mockPKCEChallenge);
+      expect(url.searchParams.get("code_challenge_method")).toBe("S256");
 
       // Check cookies
       expect(mockCookies.has(`oauth_state_${OAuthProvider.APPLE}`)).toBe(true);
       expect(mockCookies.has(`oauth_pkce_${OAuthProvider.APPLE}`)).toBe(true);
-      const applePKCECookie = mockCookies.get(`oauth_pkce_${OAuthProvider.APPLE}`);
+      const applePKCECookie = mockCookies.get(
+        `oauth_pkce_${OAuthProvider.APPLE}`,
+      );
       expect(applePKCECookie.value).toBe(mockPKCEVerifier);
       expect(applePKCECookie.httpOnly).toBe(true);
       expect(applePKCECookie.secure).toBe(true);
-      expect(applePKCECookie.sameSite).toBe('lax');
+      expect(applePKCECookie.sameSite).toBe("lax");
     }
   });
 
-  it('should return 400 if provider is missing', async () => {
+  it("should return 400 if provider is missing", async () => {
     const requestBody = JSON.stringify({}); // Missing provider
-    const request = new Request('http://localhost/api/auth/oauth', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    const request = new Request("http://localhost/api/auth/oauth", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: requestBody,
     });
 
@@ -153,15 +196,15 @@ describe('POST /api/auth/oauth', () => {
     const responseBody = await response.json();
 
     expect(response.status).toBe(400);
-    expect(responseBody).toHaveProperty('error');
-    expect(responseBody.error).toContain('provider'); // Zod error message
+    expect(responseBody).toHaveProperty("error");
+    expect(responseBody.error).toContain("provider"); // Zod error message
   });
 
-  it('should return 400 if provider is invalid', async () => {
-    const requestBody = JSON.stringify({ provider: 'invalid-provider' });
-    const request = new Request('http://localhost/api/auth/oauth', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+  it("should return 400 if provider is invalid", async () => {
+    const requestBody = JSON.stringify({ provider: "invalid-provider" });
+    const request = new Request("http://localhost/api/auth/oauth", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: requestBody,
     });
 
@@ -169,15 +212,15 @@ describe('POST /api/auth/oauth', () => {
     const responseBody = await response.json();
 
     expect(response.status).toBe(400);
-    expect(responseBody).toHaveProperty('error');
-    expect(responseBody.error).toContain('provider'); // Zod error message
+    expect(responseBody).toHaveProperty("error");
+    expect(responseBody.error).toContain("provider"); // Zod error message
   });
 
-  it('should return 400 if provider is not enabled (e.g., Facebook)', async () => {
+  it("should return 400 if provider is not enabled (e.g., Facebook)", async () => {
     const requestBody = JSON.stringify({ provider: OAuthProvider.FACEBOOK });
-    const request = new Request('http://localhost/api/auth/oauth', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    const request = new Request("http://localhost/api/auth/oauth", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: requestBody,
     });
 
@@ -185,14 +228,17 @@ describe('POST /api/auth/oauth', () => {
     const responseBody = await response.json();
 
     expect(response.status).toBe(400);
-    expect(responseBody).toHaveProperty('error', 'Provider not supported or not enabled.');
+    expect(responseBody).toHaveProperty(
+      "error",
+      "Provider not supported or not enabled.",
+    );
   });
 
-  it('should handle JSON parsing errors', async () => {
-    const requestBody = 'invalid json';
-    const request = new Request('http://localhost/api/auth/oauth', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+  it("should handle JSON parsing errors", async () => {
+    const requestBody = "invalid json";
+    const request = new Request("http://localhost/api/auth/oauth", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: requestBody,
     });
 
@@ -200,11 +246,11 @@ describe('POST /api/auth/oauth', () => {
     const responseBody = await response.json();
 
     expect(response.status).toBe(400);
-    expect(responseBody).toHaveProperty('error');
+    expect(responseBody).toHaveProperty("error");
     // Error message might vary depending on the runtime
     expect(responseBody.error).toMatch(/unexpected token|invalid json/i); // More flexible check
   });
 
   // Note: Testing disallowed methods (GET, PUT, etc.) is typically handled
   // automatically by Next.js App Router if only POST is exported.
-}); 
+});

--- a/app/api/auth/oauth/callback/__tests__/route.test.ts
+++ b/app/api/auth/oauth/callback/__tests__/route.test.ts
@@ -1,30 +1,49 @@
-import { POST } from '../route';
+import { POST } from "../route";
 // import { cookies } from 'next/headers'; // Mocked
 // import { NextResponse } from 'next/server'; // Unused
-import { OAuthProvider } from '@/types/oauth';
-import { describe, it, expect, vi, beforeEach, MockedFunction } from 'vitest';
+import { OAuthProvider } from "@/types/oauth";
+import { describe, it, expect, vi, beforeEach, MockedFunction } from "vitest";
 // import { createServerClient } from '@supabase/ssr'; // Mocked
 // import { prisma } from '@/lib/database/prisma'; // Mocked
-import { logUserAction } from '@/lib/audit/auditLogger'; // Mocked, but type used
+import { logUserAction } from "@/lib/audit/auditLogger"; // Mocked, but type used
 
 // --- Mocks ---
 
 // 1. Mock next/headers cookies
 const mockCookies = new Map<string, any>();
-vi.mock('next/headers', () => ({
+vi.mock("next/headers", () => ({
   cookies: () => ({
     get: (key: string) => mockCookies.get(key),
-    set: (key: string | { name: string; [key: string]: any }, value?: string | object) => {
-      if (typeof key === 'string') {
-        mockCookies.set(key, { name: key, value: value, httpOnly: true, secure: true, sameSite: 'lax', maxAge: 600, path: '/', ...((typeof value === 'object') ? value : {}) });
+    set: (
+      key: string | { name: string; [key: string]: any },
+      value?: string | object,
+    ) => {
+      if (typeof key === "string") {
+        mockCookies.set(key, {
+          name: key,
+          value: value,
+          httpOnly: true,
+          secure: true,
+          sameSite: "lax",
+          maxAge: 600,
+          path: "/",
+          ...(typeof value === "object" ? value : {}),
+        });
       } else {
-        mockCookies.set(key.name, { httpOnly: true, secure: true, sameSite: 'lax', maxAge: 600, path: '/', ...key });
+        mockCookies.set(key.name, {
+          httpOnly: true,
+          secure: true,
+          sameSite: "lax",
+          maxAge: 600,
+          path: "/",
+          ...key,
+        });
       }
     },
     has: (key: string) => mockCookies.has(key),
     delete: (key: string) => mockCookies.delete(key),
     // Mocking `getAll` might be needed if Supabase client uses it internally
-    getAll: () => Array.from(mockCookies.values()), 
+    getAll: () => Array.from(mockCookies.values()),
   }),
 }));
 
@@ -38,7 +57,7 @@ const mockSupabaseClient = {
   auth: mockSupabaseAuth,
   // Add other Supabase client parts if needed
 };
-vi.mock('@supabase/ssr', () => ({
+vi.mock("@supabase/ssr", () => ({
   createServerClient: vi.fn(() => mockSupabaseClient),
 }));
 
@@ -49,7 +68,7 @@ const mockPrismaAccount = {
   create: vi.fn(),
   update: vi.fn(),
 };
-vi.mock('@/lib/database/prisma', () => ({
+vi.mock("@/lib/database/prisma", () => ({
   prisma: {
     account: mockPrismaAccount,
     // Add other models if needed
@@ -57,41 +76,41 @@ vi.mock('@/lib/database/prisma', () => ({
 }));
 
 // 4. Mock Audit Logger
-vi.mock('@/lib/audit/auditLogger', () => ({
+vi.mock("@/lib/audit/auditLogger", () => ({
   logUserAction: vi.fn(),
 }));
 
 const mockLogUserAction = logUserAction as MockedFunction<typeof logUserAction>; // For type safety
 
 // --- Test Data ---
-const validState = 'valid-state-from-cookie';
-const validCode = 'valid-authorization-code';
-const testEmail = 'test@example.com';
+const validState = "valid-state-from-cookie";
+const validCode = "valid-authorization-code";
+const testEmail = "test@example.com";
 const testProvider = OAuthProvider.GOOGLE;
-const testProviderAccountId = 'google-user-123';
-const testUserId = 'supabase-user-id-abc';
-const testAccessToken = 'mock-access-token';
+const testProviderAccountId = "google-user-123";
+const testUserId = "supabase-user-id-abc";
+const testAccessToken = "mock-access-token";
 
 const mockSupabaseUser = {
   id: testUserId,
   email: testEmail,
   app_metadata: {
-    provider: 'google',
-    provider_id: testProviderAccountId, 
-    providers: ['google']
+    provider: "google",
+    provider_id: testProviderAccountId,
+    providers: ["google"],
   },
-  user_metadata: { name: 'Test User' },
+  user_metadata: { name: "Test User" },
   created_at: new Date().toISOString(),
   updated_at: new Date().toISOString(),
 };
 
 const mockExistingUser = {
-  id: 'existing-user-id-xyz',
+  id: "existing-user-id-xyz",
   // ... other user fields
 };
 
 const mockExistingAccount = {
-  id: 'account-id-1',
+  id: "account-id-1",
   user_id: mockExistingUser.id,
   provider: testProvider.toLowerCase(),
   provider_account_id: testProviderAccountId,
@@ -101,123 +120,203 @@ const mockExistingAccount = {
 
 // --- Test Suite ---
 
-describe('POST /api/auth/oauth/callback', () => {
+describe("POST /api/auth/oauth/callback", () => {
   beforeEach(() => {
     // Reset all mocks and cookies before each test
     vi.resetAllMocks();
     mockCookies.clear();
     // Set the valid state cookie for most tests
-    mockCookies.set(`oauth_state_${testProvider}`, { name: `oauth_state_${testProvider}`, value: validState });
+    mockCookies.set(`oauth_state_${testProvider}`, {
+      name: `oauth_state_${testProvider}`,
+      value: validState,
+    });
   });
 
   // Helper to create request
   const createRequest = (body: object) => {
-    return new Request('http://localhost/api/auth/oauth/callback', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    return new Request("http://localhost/api/auth/oauth/callback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     });
   };
 
-  it('should return 400 if state is missing', async () => {
+  it("should return 400 if state is missing", async () => {
     const request = createRequest({ provider: testProvider, code: validCode }); // No state
     const response = await POST(request);
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toContain('Invalid or missing state');
-    expect(mockLogUserAction).toHaveBeenCalledWith(expect.objectContaining({ status: 'FAILURE' }));
+    expect(body.error).toContain("Invalid or missing state");
+    expect(mockLogUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "FAILURE" }),
+    );
   });
 
-  it('should return 400 if state does not match cookie', async () => {
-    const request = createRequest({ provider: testProvider, code: validCode, state: 'invalid-state' });
+  it("should return 400 if state does not match cookie", async () => {
+    const request = createRequest({
+      provider: testProvider,
+      code: validCode,
+      state: "invalid-state",
+    });
     const response = await POST(request);
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toContain('Invalid or missing state');
-    expect(mockLogUserAction).toHaveBeenCalledWith(expect.objectContaining({ status: 'FAILURE' }));
+    expect(body.error).toContain("Invalid or missing state");
+    expect(mockLogUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "FAILURE" }),
+    );
   });
 
-  it('should return 409 if user already has a session', async () => {
-    mockSupabaseAuth.getSession.mockResolvedValue({ data: { session: { user: { id: 'existing' } } }, error: null });
+  it("should return 409 if user already has a session", async () => {
+    mockSupabaseAuth.getSession.mockResolvedValue({
+      data: { session: { user: { id: "existing" } } },
+      error: null,
+    });
 
-    const request = createRequest({ provider: testProvider, code: validCode, state: validState });
+    const request = createRequest({
+      provider: testProvider,
+      code: validCode,
+      state: validState,
+    });
     const response = await POST(request);
     const body = await response.json();
 
     expect(response.status).toBe(409);
-    expect(body.error).toContain('User already authenticated');
-    expect(mockLogUserAction).toHaveBeenCalledWith(expect.objectContaining({ status: 'FAILURE' }));
+    expect(body.error).toContain("User already authenticated");
+    expect(mockLogUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "FAILURE" }),
+    );
   });
 
-  it('should return 400 if code exchange fails', async () => {
-    mockSupabaseAuth.getSession.mockResolvedValue({ data: { session: null }, error: null });
-    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({ data: null, error: { message: 'Invalid code', status: 400 } });
+  it("should return 400 if code exchange fails", async () => {
+    mockSupabaseAuth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({
+      data: null,
+      error: { message: "Invalid code", status: 400 },
+    });
 
-    const request = createRequest({ provider: testProvider, code: 'invalid-code', state: validState });
+    const request = createRequest({
+      provider: testProvider,
+      code: "invalid-code",
+      state: validState,
+    });
     const response = await POST(request);
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toBe('Invalid code');
-    expect(mockLogUserAction).toHaveBeenCalledWith(expect.objectContaining({ status: 'FAILURE' }));
+    expect(body.error).toBe("Invalid code");
+    expect(mockLogUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "FAILURE" }),
+    );
   });
 
-  it('should return 400 if fetching Supabase user fails after code exchange', async () => {
-    mockSupabaseAuth.getSession.mockResolvedValue({ data: { session: null }, error: null });
-    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({ data: { session: { access_token: testAccessToken } }, error: null });
-    mockSupabaseAuth.getUser.mockResolvedValue({ data: null, error: { message: 'Failed to fetch', status: 500 } });
+  it("should return 400 if fetching Supabase user fails after code exchange", async () => {
+    mockSupabaseAuth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({
+      data: { session: { access_token: testAccessToken } },
+      error: null,
+    });
+    mockSupabaseAuth.getUser.mockResolvedValue({
+      data: null,
+      error: { message: "Failed to fetch", status: 500 },
+    });
 
-    const request = createRequest({ provider: testProvider, code: validCode, state: validState });
+    const request = createRequest({
+      provider: testProvider,
+      code: validCode,
+      state: validState,
+    });
     const response = await POST(request);
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toBe('Failed to fetch');
-    expect(mockLogUserAction).toHaveBeenCalledWith(expect.objectContaining({ status: 'FAILURE' }));
+    expect(body.error).toBe("Failed to fetch");
+    expect(mockLogUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "FAILURE" }),
+    );
   });
 
-  it('should successfully log in an existing user found via provider ID', async () => {
+  it("should successfully log in an existing user found via provider ID", async () => {
     // Setup mocks
-    mockSupabaseAuth.getSession.mockResolvedValue({ data: { session: null }, error: null });
-    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({ data: { session: { access_token: testAccessToken } }, error: null });
-    mockSupabaseAuth.getUser.mockResolvedValue({ data: { user: mockSupabaseUser }, error: null });
+    mockSupabaseAuth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({
+      data: { session: { access_token: testAccessToken } },
+      error: null,
+    });
+    mockSupabaseAuth.getUser.mockResolvedValue({
+      data: { user: mockSupabaseUser },
+      error: null,
+    });
     mockPrismaAccount.findUnique.mockResolvedValue(mockExistingAccount); // Found account
     mockPrismaAccount.findFirst.mockResolvedValue(null); // No email collision check needed
 
     // Make request
-    const request = createRequest({ provider: testProvider, code: validCode, state: validState });
+    const request = createRequest({
+      provider: testProvider,
+      code: validCode,
+      state: validState,
+    });
     const response = await POST(request);
     const body = await response.json();
 
     // Assertions
     expect(response.status).toBe(200);
-    expect(body.user).toEqual(mockExistingUser);
-    expect(body.token).toBe(testAccessToken);
-    expect(body.isNewUser).toBe(false);
-    expect(body.info).toContain('Logged in via linked provider account');
+    expect(body.data.user).toEqual(mockExistingUser);
+    expect(body.data.token).toBe(testAccessToken);
+    expect(body.data.isNewUser).toBe(false);
+    expect(body.data.info).toContain("Logged in via linked provider account");
 
     expect(mockPrismaAccount.findUnique).toHaveBeenCalledWith({
-      where: { provider_provider_account_id: { provider: testProvider.toLowerCase(), provider_account_id: testProviderAccountId } },
+      where: {
+        provider_provider_account_id: {
+          provider: testProvider.toLowerCase(),
+          provider_account_id: testProviderAccountId,
+        },
+      },
       include: { users: true },
     });
     expect(mockPrismaAccount.create).not.toHaveBeenCalled(); // Should not create new account
     expect(mockPrismaAccount.update).not.toHaveBeenCalled(); // Email didn't change
-    expect(mockLogUserAction).toHaveBeenCalledWith(expect.objectContaining({ userId: testUserId, action: 'SSO_LOGIN', status: 'SUCCESS' }));
+    expect(mockLogUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: testUserId,
+        action: "SSO_LOGIN",
+        status: "SUCCESS",
+      }),
+    );
   });
-  
-  it('should create a new user and account if not found', async () => {
+
+  it("should create a new user and account if not found", async () => {
     // Setup mocks
-    mockSupabaseAuth.getSession.mockResolvedValue({ data: { session: null }, error: null });
-    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({ data: { session: { access_token: testAccessToken } }, error: null });
-    mockSupabaseAuth.getUser.mockResolvedValue({ data: { user: mockSupabaseUser }, error: null });
+    mockSupabaseAuth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({
+      data: { session: { access_token: testAccessToken } },
+      error: null,
+    });
+    mockSupabaseAuth.getUser.mockResolvedValue({
+      data: { user: mockSupabaseUser },
+      error: null,
+    });
     mockPrismaAccount.findUnique.mockResolvedValue(null); // No account found by provider ID
     mockPrismaAccount.findFirst.mockResolvedValue(null); // No email collision
     // Mock the creation - return value needs to match expected structure including `users` relation
     const createdAccount = {
       ...mockExistingAccount, // Use similar structure
-      id: 'new-account-id-456',
+      id: "new-account-id-456",
       user_id: testUserId,
       provider_account_id: testProviderAccountId,
       users: { ...mockExistingUser, id: testUserId }, // Link to the *new* supabase user ID
@@ -225,16 +324,20 @@ describe('POST /api/auth/oauth/callback', () => {
     mockPrismaAccount.create.mockResolvedValue(createdAccount);
 
     // Make request
-    const request = createRequest({ provider: testProvider, code: validCode, state: validState });
+    const request = createRequest({
+      provider: testProvider,
+      code: validCode,
+      state: validState,
+    });
     const response = await POST(request);
     const body = await response.json();
 
     // Assertions
     expect(response.status).toBe(200);
-    expect(body.user).toEqual(createdAccount.users);
-    expect(body.token).toBe(testAccessToken);
-    expect(body.isNewUser).toBe(true);
-    expect(body.info).toContain('New provider account linked');
+    expect(body.data.user).toEqual(createdAccount.users);
+    expect(body.data.token).toBe(testAccessToken);
+    expect(body.data.isNewUser).toBe(true);
+    expect(body.info).toContain("New provider account linked");
 
     expect(mockPrismaAccount.findUnique).toHaveBeenCalled();
     expect(mockPrismaAccount.findFirst).toHaveBeenCalled();
@@ -247,55 +350,96 @@ describe('POST /api/auth/oauth/callback', () => {
       },
       include: { users: true },
     });
-    expect(mockLogUserAction).toHaveBeenCalledWith(expect.objectContaining({ userId: testUserId, action: 'SSO_LOGIN', status: 'SUCCESS', details: expect.objectContaining({ isNewUser: true }) }));
+    expect(mockLogUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: testUserId,
+        action: "SSO_LOGIN",
+        status: "SUCCESS",
+        details: expect.objectContaining({ isNewUser: true }),
+      }),
+    );
   });
-  
-  it('should return 409 on email collision', async () => {
+
+  it("should return 409 on email collision", async () => {
     // Setup mocks
-    mockSupabaseAuth.getSession.mockResolvedValue({ data: { session: null }, error: null });
-    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({ data: { session: { access_token: testAccessToken } }, error: null });
-    mockSupabaseAuth.getUser.mockResolvedValue({ data: { user: mockSupabaseUser }, error: null });
+    mockSupabaseAuth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({
+      data: { session: { access_token: testAccessToken } },
+      error: null,
+    });
+    mockSupabaseAuth.getUser.mockResolvedValue({
+      data: { user: mockSupabaseUser },
+      error: null,
+    });
     mockPrismaAccount.findUnique.mockResolvedValue(null); // No account found by provider ID
     // Found account via email
     mockPrismaAccount.findFirst.mockResolvedValue({
       ...mockExistingAccount,
-      provider: 'password', // Belongs to a different provider
-      provider_account_id: '',
+      provider: "password", // Belongs to a different provider
+      provider_account_id: "",
     });
 
     // Make request
-    const request = createRequest({ provider: testProvider, code: validCode, state: validState });
+    const request = createRequest({
+      provider: testProvider,
+      code: validCode,
+      state: validState,
+    });
     const response = await POST(request);
     const body = await response.json();
 
     // Assertions
     expect(response.status).toBe(409);
-    expect(body.error).toContain('account with this email already exists');
+    expect(body.error).toContain("account with this email already exists");
     expect(body.collision).toBe(true);
     expect(mockPrismaAccount.create).not.toHaveBeenCalled();
-    expect(mockLogUserAction).toHaveBeenCalledWith(expect.objectContaining({ status: 'FAILURE' }));
+    expect(mockLogUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "FAILURE" }),
+    );
   });
 
-  it('should successfully log in and update email on existing account if changed', async () => {
+  it("should successfully log in and update email on existing account if changed", async () => {
     // Setup mocks
-    const oldEmail = 'old.email@example.com';
-    const accountWithOldEmail = { ...mockExistingAccount, provider_email: oldEmail };
-    mockSupabaseAuth.getSession.mockResolvedValue({ data: { session: null }, error: null });
-    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({ data: { session: { access_token: testAccessToken } }, error: null });
-    mockSupabaseAuth.getUser.mockResolvedValue({ data: { user: mockSupabaseUser }, error: null }); // Returns new email
+    const oldEmail = "old.email@example.com";
+    const accountWithOldEmail = {
+      ...mockExistingAccount,
+      provider_email: oldEmail,
+    };
+    mockSupabaseAuth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({
+      data: { session: { access_token: testAccessToken } },
+      error: null,
+    });
+    mockSupabaseAuth.getUser.mockResolvedValue({
+      data: { user: mockSupabaseUser },
+      error: null,
+    }); // Returns new email
     mockPrismaAccount.findUnique.mockResolvedValue(accountWithOldEmail); // Found account with old email
-    mockPrismaAccount.update.mockResolvedValue({ ...accountWithOldEmail, provider_email: testEmail }); // Simulate successful update
+    mockPrismaAccount.update.mockResolvedValue({
+      ...accountWithOldEmail,
+      provider_email: testEmail,
+    }); // Simulate successful update
 
     // Make request
-    const request = createRequest({ provider: testProvider, code: validCode, state: validState });
+    const request = createRequest({
+      provider: testProvider,
+      code: validCode,
+      state: validState,
+    });
     const response = await POST(request);
     const body = await response.json();
 
     // Assertions
     expect(response.status).toBe(200);
-    expect(body.user).toEqual(mockExistingUser); // Should still return the original user linked
-    expect(body.token).toBe(testAccessToken);
-    expect(body.isNewUser).toBe(false);
+    expect(body.data.user).toEqual(mockExistingUser); // Should still return the original user linked
+    expect(body.data.token).toBe(testAccessToken);
+    expect(body.data.isNewUser).toBe(false);
 
     // Check that update was called correctly
     expect(mockPrismaAccount.update).toHaveBeenCalledTimes(1);
@@ -304,22 +448,44 @@ describe('POST /api/auth/oauth/callback', () => {
       data: { provider_email: testEmail }, // Updated with the new email from provider
     });
     expect(mockPrismaAccount.create).not.toHaveBeenCalled();
-    expect(mockLogUserAction).toHaveBeenCalledWith(expect.objectContaining({ userId: testUserId, action: 'SSO_LOGIN', status: 'SUCCESS' }));
+    expect(mockLogUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: testUserId,
+        action: "SSO_LOGIN",
+        status: "SUCCESS",
+      }),
+    );
   });
 
-  it('should handle errors during prisma account update', async () => {
+  it("should handle errors during prisma account update", async () => {
     // Setup mocks
-    const oldEmail = 'old.email@example.com';
-    const accountWithOldEmail = { ...mockExistingAccount, provider_email: oldEmail };
-    mockSupabaseAuth.getSession.mockResolvedValue({ data: { session: null }, error: null });
-    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({ data: { session: { access_token: testAccessToken } }, error: null });
-    mockSupabaseAuth.getUser.mockResolvedValue({ data: { user: mockSupabaseUser }, error: null }); // Returns new email
+    const oldEmail = "old.email@example.com";
+    const accountWithOldEmail = {
+      ...mockExistingAccount,
+      provider_email: oldEmail,
+    };
+    mockSupabaseAuth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({
+      data: { session: { access_token: testAccessToken } },
+      error: null,
+    });
+    mockSupabaseAuth.getUser.mockResolvedValue({
+      data: { user: mockSupabaseUser },
+      error: null,
+    }); // Returns new email
     mockPrismaAccount.findUnique.mockResolvedValue(accountWithOldEmail); // Found account with old email
-    const updateError = new Error('DB update failed');
+    const updateError = new Error("DB update failed");
     mockPrismaAccount.update.mockRejectedValue(updateError); // Simulate update failure
 
     // Make request
-    const request = createRequest({ provider: testProvider, code: validCode, state: validState });
+    const request = createRequest({
+      provider: testProvider,
+      code: validCode,
+      state: validState,
+    });
     const response = await POST(request);
     const body = await response.json();
 
@@ -327,21 +493,40 @@ describe('POST /api/auth/oauth/callback', () => {
     expect(response.status).toBe(500); // Expecting internal server error
     expect(body.error).toBe(updateError.message);
     expect(mockPrismaAccount.update).toHaveBeenCalledTimes(1);
-    expect(mockLogUserAction).toHaveBeenCalledWith(expect.objectContaining({ action: 'SSO_LOGIN', status: 'FAILURE', details: { error: updateError.message } }));
+    expect(mockLogUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "SSO_LOGIN",
+        status: "FAILURE",
+        details: { error: updateError.message },
+      }),
+    );
   });
 
-  it('should handle errors during prisma account create', async () => {
+  it("should handle errors during prisma account create", async () => {
     // Setup mocks for new user flow
-    mockSupabaseAuth.getSession.mockResolvedValue({ data: { session: null }, error: null });
-    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({ data: { session: { access_token: testAccessToken } }, error: null });
-    mockSupabaseAuth.getUser.mockResolvedValue({ data: { user: mockSupabaseUser }, error: null });
+    mockSupabaseAuth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({
+      data: { session: { access_token: testAccessToken } },
+      error: null,
+    });
+    mockSupabaseAuth.getUser.mockResolvedValue({
+      data: { user: mockSupabaseUser },
+      error: null,
+    });
     mockPrismaAccount.findUnique.mockResolvedValue(null); // Not found by provider ID
     mockPrismaAccount.findFirst.mockResolvedValue(null); // No email collision
-    const createError = new Error('DB create failed');
+    const createError = new Error("DB create failed");
     mockPrismaAccount.create.mockRejectedValue(createError); // Simulate create failure
 
     // Make request
-    const request = createRequest({ provider: testProvider, code: validCode, state: validState });
+    const request = createRequest({
+      provider: testProvider,
+      code: validCode,
+      state: validState,
+    });
     const response = await POST(request);
     const body = await response.json();
 
@@ -349,78 +534,129 @@ describe('POST /api/auth/oauth/callback', () => {
     expect(response.status).toBe(500); // Expecting internal server error
     expect(body.error).toBe(createError.message);
     expect(mockPrismaAccount.create).toHaveBeenCalledTimes(1);
-    expect(mockLogUserAction).toHaveBeenCalledWith(expect.objectContaining({ action: 'SSO_LOGIN', status: 'FAILURE', details: { error: createError.message } }));
+    expect(mockLogUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "SSO_LOGIN",
+        status: "FAILURE",
+        details: { error: createError.message },
+      }),
+    );
   });
 
-  it('should return 400 if provider returns neither email nor providerAccountId', async () => {
+  it("should return 400 if provider returns neither email nor providerAccountId", async () => {
     // Setup mocks
     const userWithoutIds = {
-        ...mockSupabaseUser,
-        email: undefined, // No email
-        app_metadata: { ...mockSupabaseUser.app_metadata, provider_id: undefined }, // No provider ID
+      ...mockSupabaseUser,
+      email: undefined, // No email
+      app_metadata: {
+        ...mockSupabaseUser.app_metadata,
+        provider_id: undefined,
+      }, // No provider ID
     };
-    mockSupabaseAuth.getSession.mockResolvedValue({ data: { session: null }, error: null });
-    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({ data: { session: { access_token: testAccessToken } }, error: null });
-    mockSupabaseAuth.getUser.mockResolvedValue({ data: { user: userWithoutIds }, error: null });
+    mockSupabaseAuth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({
+      data: { session: { access_token: testAccessToken } },
+      error: null,
+    });
+    mockSupabaseAuth.getUser.mockResolvedValue({
+      data: { user: userWithoutIds },
+      error: null,
+    });
     // Prisma calls shouldn't be reached
 
     // Make request
-    const request = createRequest({ provider: testProvider, code: validCode, state: validState });
+    const request = createRequest({
+      provider: testProvider,
+      code: validCode,
+      state: validState,
+    });
     const response = await POST(request);
     const body = await response.json();
 
     // Assertions
     expect(response.status).toBe(400);
-    expect(body.error).toContain('Provider did not return a unique identifier');
+    expect(body.error).toContain("Provider did not return a unique identifier");
     expect(mockPrismaAccount.findUnique).not.toHaveBeenCalled();
     expect(mockPrismaAccount.findFirst).not.toHaveBeenCalled();
     expect(mockPrismaAccount.create).not.toHaveBeenCalled();
-    expect(mockLogUserAction).toHaveBeenCalledWith(expect.objectContaining({ status: 'FAILURE' }));
+    expect(mockLogUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "FAILURE" }),
+    );
   });
 
-  it('should successfully create a new user using GitHub provider', async () => {
+  it("should successfully create a new user using GitHub provider", async () => {
     const githubProvider = OAuthProvider.GITHUB;
-    const githubProviderAccountId = 'github-user-xyz';
-    const githubEmail = 'github@example.com';
+    const githubProviderAccountId = "github-user-xyz";
+    const githubEmail = "github@example.com";
     const githubSupabaseUser = {
       ...mockSupabaseUser,
       email: githubEmail,
       app_metadata: {
-        provider: 'github',
+        provider: "github",
         provider_id: githubProviderAccountId,
-        providers: ['github']
+        providers: ["github"],
       },
     };
 
     // Setup mocks
-    mockCookies.set(`oauth_state_${githubProvider}`, { name: `oauth_state_${githubProvider}`, value: validState }); // Set state cookie for GitHub
-    mockSupabaseAuth.getSession.mockResolvedValue({ data: { session: null }, error: null });
-    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({ data: { session: { access_token: testAccessToken } }, error: null });
-    mockSupabaseAuth.getUser.mockResolvedValue({ data: { user: githubSupabaseUser }, error: null });
+    mockCookies.set(`oauth_state_${githubProvider}`, {
+      name: `oauth_state_${githubProvider}`,
+      value: validState,
+    }); // Set state cookie for GitHub
+    mockSupabaseAuth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({
+      data: { session: { access_token: testAccessToken } },
+      error: null,
+    });
+    mockSupabaseAuth.getUser.mockResolvedValue({
+      data: { user: githubSupabaseUser },
+      error: null,
+    });
     mockPrismaAccount.findUnique.mockResolvedValue(null); // Not found by provider ID
     mockPrismaAccount.findFirst.mockResolvedValue(null); // No email collision
-    const createdAccount = { id: 'new-github-account', user_id: githubSupabaseUser.id, users: { id: githubSupabaseUser.id } };
+    const createdAccount = {
+      id: "new-github-account",
+      user_id: githubSupabaseUser.id,
+      users: { id: githubSupabaseUser.id },
+    };
     mockPrismaAccount.create.mockResolvedValue(createdAccount);
 
     // Make request
-    const request = createRequest({ provider: githubProvider, code: validCode, state: validState });
+    const request = createRequest({
+      provider: githubProvider,
+      code: validCode,
+      state: validState,
+    });
     const response = await POST(request);
     const body = await response.json();
 
     // Assertions
     expect(response.status).toBe(200);
-    expect(body.isNewUser).toBe(true);
-    expect(body.user).toEqual(createdAccount.users);
-    expect(mockPrismaAccount.create).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        provider: githubProvider.toLowerCase(),
-        provider_account_id: githubProviderAccountId,
-        provider_email: githubEmail,
-      })
-    }));
-    expect(mockLogUserAction).toHaveBeenCalledWith(expect.objectContaining({ status: 'SUCCESS', details: expect.objectContaining({ provider: githubProvider }) }));
+    expect(body.data.isNewUser).toBe(true);
+    expect(body.data.user).toEqual(createdAccount.users);
+    expect(mockPrismaAccount.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          provider: githubProvider.toLowerCase(),
+          provider_account_id: githubProviderAccountId,
+          provider_email: githubEmail,
+        }),
+      }),
+    );
+    expect(mockLogUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "SUCCESS",
+        details: expect.objectContaining({ provider: githubProvider }),
+      }),
+    );
   });
 
   // TODO: Add more tests:
   // - PKCE validation test (if applicable for any provider used in the route)
-}); 
+});

--- a/app/api/auth/oauth/callback/route.ts
+++ b/app/api/auth/oauth/callback/route.ts
@@ -1,9 +1,16 @@
-import { NextResponse } from 'next/server';
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
-import { z } from 'zod';
-import { OAuthProvider } from '@/types/oauth';
-import { logUserAction } from '@/lib/audit/auditLogger';
+import { NextRequest } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import { z } from "zod";
+import { OAuthProvider } from "@/types/oauth";
+import { logUserAction } from "@/lib/audit/auditLogger";
+import {
+  createSuccessResponse,
+  withErrorHandling,
+  withValidation,
+  ApiError,
+  ERROR_CODES,
+} from "@/lib/api/common";
 
 // Request schema
 const callbackRequestSchema = z.object({
@@ -13,199 +20,185 @@ const callbackRequestSchema = z.object({
   state: z.string().optional(), // Add state for CSRF protection
 });
 
-export async function POST(request: Request) {
-  try {
-    // Parse and validate request body
-    const body = await request.json();
-    const { provider, code, state } = callbackRequestSchema.parse(body);
+async function handleCallback(
+  req: NextRequest,
+  data: z.infer<typeof callbackRequestSchema>,
+) {
+  const { provider, code, state } = data;
 
-    // CSRF protection: validate state parameter
-    const cookieStore = cookies();
-    const stateCookie = cookieStore.get(`oauth_state_${provider}`)?.value;
-    if (!state || !stateCookie || state !== stateCookie) {
-      return NextResponse.json({ error: 'Invalid or missing state parameter. Possible CSRF attack.' }, { status: 400 });
-    }
-    // Optionally clear the state cookie after use
-    cookieStore.set({ name: `oauth_state_${provider}`, value: '', maxAge: 0, path: '/' });
-
-    // Initialize Supabase client
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      {
-        cookies: {
-          get(name: string) {
-            return cookieStore.get(name)?.value;
-          },
-          set(name: string, value: string, options: any) {
-            cookieStore.set({ name, value, ...options });
-          },
-          remove(name: string, options: any) {
-            cookieStore.set({ name, value: '', ...options });
-          },
-        },
-      }
+  const cookieStore = cookies();
+  const stateCookie = cookieStore.get(`oauth_state_${provider}`)?.value;
+  if (!state || !stateCookie || state !== stateCookie) {
+    throw new ApiError(
+      ERROR_CODES.INVALID_REQUEST,
+      "Invalid or missing state parameter. Possible CSRF attack.",
+      400,
     );
+  }
+  cookieStore.set({
+    name: `oauth_state_${provider}`,
+    value: "",
+    maxAge: 0,
+    path: "/",
+  });
 
-    // Check if a user is already authenticated (session present)
-    const { data: currentSession, error: sessionError } = await supabase.auth.getSession();
-    if (sessionError) {
-      return NextResponse.json({ error: 'Failed to check current session.' }, { status: 500 });
-    }
-    if (currentSession?.session) {
-      // User is already logged in; this should be handled as account linking
-      // For now, return a clear error and instruct to use the /oauth/link endpoint
-      return NextResponse.json({ error: 'User already authenticated. Use the account linking endpoint to link a new provider.' }, { status: 409 });
-    }
-
-    // Exchange authorization code for tokens
-    const { data, error } = await supabase.auth.exchangeCodeForSession(code);
-    if (error) {
-      // Handle revoked provider access
-      if (error.message && error.message.toLowerCase().includes('revoked')) {
-        return NextResponse.json(
-          { error: 'Access to your provider account has been revoked. Please re-link your account or use another login method.' },
-          { status: 400 }
-        );
-      }
-      console.error('OAuth callback error:', error);
-      return NextResponse.json(
-        { error: error.message },
-        { status: 400 }
-      );
-    }
-
-    // Use the session's access token to fetch user data
-    const { data: userData, error: userError } = await supabase.auth.getUser();
-    if (userError || !userData?.user) {
-      console.error('Failed to fetch user data:', userError);
-      return NextResponse.json(
-        { error: userError?.message || 'Failed to fetch user data' },
-        { status: 400 }
-      );
-    }
-
-    // --- Provider linkage logic using Prisma Account model ---
-    const { prisma } = await import('@/lib/database/prisma');
-    const providerAccountId = userData.user.app_metadata?.provider_id;
-    const email = userData.user.email;
-    if (!providerAccountId && !email) {
-      return NextResponse.json({ error: 'Provider did not return a unique identifier (email or provider user ID).' }, { status: 400 });
-    }
-
-    // 1. Try to find an existing account for this provider+providerAccountId
-    let account = null;
-    if (providerAccountId) {
-      account = await prisma.account.findUnique({
-        where: {
-          provider_provider_account_id: {
-            provider: provider.toLowerCase(),
-            provider_account_id: providerAccountId,
-          },
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value;
         },
-        include: { users: true },
-      });
-    }
+        set(name: string, value: string, options: any) {
+          cookieStore.set({ name, value, ...options });
+        },
+        remove(name: string, options: any) {
+          cookieStore.set({ name, value: "", ...options });
+        },
+      },
+    },
+  );
 
-    // 2. If account exists, update email if changed
-    if (account) {
-      if (email && account.provider_email !== email) {
-        await prisma.account.update({
-          where: { id: account.id },
-          data: { provider_email: email },
-        });
-      }
-      // Return the linked user
-      return NextResponse.json({
-        user: account.users,
-        token: data.session?.access_token,
-        isNewUser: false,
-        info: 'Logged in via linked provider account.'
-      });
-    }
+  const { data: currentSession, error: sessionError } =
+    await supabase.auth.getSession();
+  if (sessionError) {
+    throw new ApiError(
+      ERROR_CODES.INTERNAL_ERROR,
+      "Failed to check current session.",
+      500,
+    );
+  }
+  if (currentSession?.session) {
+    throw new ApiError(
+      ERROR_CODES.INVALID_REQUEST,
+      "User already authenticated. Use the account linking endpoint to link a new provider.",
+      409,
+    );
+  }
 
-    // 3. If no account, check for email collision
-    let emailCollision = null;
-    if (email) {
-      emailCollision = await prisma.account.findFirst({
-        where: { provider_email: email },
-        include: { users: true },
-      });
+  const { data: sessionData, error } =
+    await supabase.auth.exchangeCodeForSession(code);
+  if (error) {
+    if (error.message && error.message.toLowerCase().includes("revoked")) {
+      throw new ApiError(
+        ERROR_CODES.OAUTH_ERROR,
+        "Access to your provider account has been revoked. Please re-link your account or use another login method.",
+        400,
+      );
     }
-    if (emailCollision) {
-      // Email collision: require explicit confirmation or handle as needed
-      return NextResponse.json({
-        error: 'An account with this email already exists. Please log in and link your provider from your account settings.',
-        collision: true,
-      }, { status: 409 });
-    }
+    throw new ApiError(ERROR_CODES.OAUTH_ERROR, error.message, 400);
+  }
 
-    // 4. No collision, create new account record
-    const newAccount = await prisma.account.create({
-      data: {
-        user_id: userData.user.id,
-        provider: provider.toLowerCase(),
-        provider_account_id: providerAccountId || '',
-        provider_email: email || '',
+  const { data: userData, error: userError } = await supabase.auth.getUser();
+  if (userError || !userData?.user) {
+    throw new ApiError(
+      ERROR_CODES.OAUTH_ERROR,
+      userError?.message || "Failed to fetch user data",
+      400,
+    );
+  }
+
+  const { prisma } = await import("@/lib/database/prisma");
+  const providerAccountId = userData.user.app_metadata?.provider_id;
+  const email = userData.user.email;
+  if (!providerAccountId && !email) {
+    throw new ApiError(
+      ERROR_CODES.OAUTH_ERROR,
+      "Provider did not return a unique identifier (email or provider user ID).",
+      400,
+    );
+  }
+
+  let account = null;
+  if (providerAccountId) {
+    account = await prisma.account.findUnique({
+      where: {
+        provider_provider_account_id: {
+          provider: provider.toLowerCase(),
+          provider_account_id: providerAccountId,
+        },
       },
       include: { users: true },
     });
+  }
 
-    // Return the linked user for the new account
-    return NextResponse.json({
-      user: newAccount.users,
-      token: data.session?.access_token,
-      isNewUser: true,
-      info: 'New provider account linked and user created.'
+  if (account) {
+    if (email && account.provider_email !== email) {
+      await prisma.account.update({
+        where: { id: account.id },
+        data: { provider_email: email },
+      });
+    }
+
+    await logUserAction({
+      userId: userData.user.id,
+      action: "SSO_LOGIN",
+      status: "SUCCESS",
+      targetResourceType: "auth",
+      targetResourceId: userData.user.id,
+      details: { provider, email, isNewUser: false },
     });
 
-    // --- End provider linkage logic ---
-
-    // Defensive: If userData.user is null, return error (should not happen here)
-    if (!userData.user) {
-      return NextResponse.json({ error: 'User data missing after provider linkage.' }, { status: 500 });
-    }
-
-    // Get user metadata to check if this is a new sign-up
-    const isNewUser = userData.user!.app_metadata?.provider_id === provider && 
-                     userData.user!.created_at === userData.user!.updated_at;
-
-    // Return the user and session data
-    // --- Audit log: SSO login ---
-    try {
-      await logUserAction({
-        userId: userData.user!.id,
-        action: 'SSO_LOGIN',
-        status: 'SUCCESS',
-        targetResourceType: 'auth',
-        targetResourceId: userData.user!.id,
-        details: { provider, email, isNewUser },
-        // Optionally: ipAddress, userAgent (if available from request headers)
-      });
-    } catch (logError) {
-      // Log but do not block the response
-      console.error('Failed to log SSO_LOGIN action:', logError);
-    }
-    return NextResponse.json({
-      user: userData.user!,
-      token: data.session?.access_token,
-      isNewUser
+    return createSuccessResponse({
+      user: account.users,
+      token: sessionData.session?.access_token,
+      isNewUser: false,
+      info: "Logged in via linked provider account.",
     });
-  } catch (error) {
-    console.error('Error in OAuth callback:', error);
-    // --- Audit log: SSO login failure ---
-    try {
-      await logUserAction({
-        action: 'SSO_LOGIN',
-        status: 'FAILURE',
-        details: { error: error instanceof Error ? error.message : 'Unknown error' },
-      });
-    } catch (logError) {
-      console.error('Failed to log SSO_LOGIN failure:', logError);
-    }
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'An unexpected error occurred' },
-      { status: 500 }
+  }
+
+  let emailCollision = null;
+  if (email) {
+    emailCollision = await prisma.account.findFirst({
+      where: { provider_email: email },
+      include: { users: true },
+    });
+  }
+  if (emailCollision) {
+    await logUserAction({
+      action: "SSO_LOGIN",
+      status: "FAILURE",
+      details: { error: "email collision" },
+    });
+    throw new ApiError(
+      ERROR_CODES.CONFLICT,
+      "An account with this email already exists. Please log in and link your provider from your account settings.",
+      409,
+      { collision: true },
     );
   }
-} 
+
+  const newAccount = await prisma.account.create({
+    data: {
+      user_id: userData.user.id,
+      provider: provider.toLowerCase(),
+      provider_account_id: providerAccountId || "",
+      provider_email: email || "",
+    },
+    include: { users: true },
+  });
+
+  await logUserAction({
+    userId: userData.user.id,
+    action: "SSO_LOGIN",
+    status: "SUCCESS",
+    targetResourceType: "auth",
+    targetResourceId: userData.user.id,
+    details: { provider, email, isNewUser: true },
+  });
+
+  return createSuccessResponse({
+    user: newAccount.users,
+    token: sessionData.session?.access_token,
+    isNewUser: true,
+    info: "New provider account linked and user created.",
+  });
+}
+
+export async function POST(request: NextRequest) {
+  return withErrorHandling(
+    async (req) => withValidation(callbackRequestSchema, handleCallback, req),
+    request,
+  );
+}

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,97 +1,62 @@
-import { type NextRequest, NextResponse } from 'next/server';
-import { z } from 'zod';
-import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
-import { withSecurity } from '@/middleware/with-security';
-import { logUserAction } from '@/lib/audit/auditLogger';
-import { getApiAuthService } from '@/lib/api/auth/factory';
+import { type NextRequest } from "next/server";
+import { z } from "zod";
+import { withAuthRateLimit } from "@/middleware/with-auth-rate-limit";
+import { withSecurity } from "@/middleware/with-security";
+import { logUserAction } from "@/lib/audit/auditLogger";
+import { getApiAuthService } from "@/lib/api/auth/factory";
+import {
+  createSuccessResponse,
+  withErrorHandling,
+  withValidation,
+} from "@/lib/api/common";
 
 // Zod schema for password reset request
 const ResetRequestSchema = z.object({
-  email: z.string().email({ message: 'Invalid email address' }),
+  email: z.string().email({ message: "Invalid email address" }),
 });
 
-async function handler(request: NextRequest): Promise<NextResponse> {
-  // Get IP and User Agent early
-  const ipAddress = request.ip;
-  const userAgent = request.headers.get('user-agent');
-  let emailForLogging: string | null = null; // Variable to hold email for logging
+async function handlePasswordReset(
+  req: NextRequest,
+  data: z.infer<typeof ResetRequestSchema>,
+) {
+  const ipAddress = req.ip || req.headers.get("x-forwarded-for") || "unknown";
+  const userAgent = req.headers.get("user-agent") || "unknown";
 
-  if (request.method !== 'POST') {
-    return new NextResponse(JSON.stringify({ error: 'Method not allowed' }), {
-      status: 405,
-      headers: { 'Content-Type': 'application/json' }
-    });
-  }
+  const { email } = data;
 
-  try {
-    const body = await request.json();
-    
-    // Validate request body
-    const parseResult = ResetRequestSchema.safeParse(body);
-    if (!parseResult.success) {
-      emailForLogging = body?.email;
-      const errors = parseResult.error.errors.map(err => ({
-        field: err.path.join('.'),
-        message: err.message,
-      }));
-      return NextResponse.json({ error: 'Validation failed', details: errors }, { status: 400 });
-    }
+  const authService = getApiAuthService();
+  const resetResult = await authService.resetPassword(email);
 
-    const { email } = parseResult.data;
-    emailForLogging = email; // Store for logging
-    
-    // Get AuthService and call resetPassword method
-    const authService = getApiAuthService();
-    
-    // Send password reset email using the AuthService
-    const resetResult = await authService.resetPassword(email);
+  await logUserAction({
+    action: "PASSWORD_RESET_REQUEST",
+    status: resetResult.success ? "INITIATED" : "FAILURE",
+    ipAddress,
+    userAgent,
+    targetResourceType: "auth",
+    targetResourceId: email,
+    details: { error: resetResult.error || null },
+  });
 
-    // Log the attempt regardless of result, due to email enumeration prevention
-    await logUserAction({
-        action: 'PASSWORD_RESET_REQUEST',
-        status: resetResult.success ? 'INITIATED' : 'FAILURE',
-        ipAddress: ipAddress,
-        userAgent: userAgent,
-        targetResourceType: 'auth',
-        targetResourceId: email, // Log the email attempted
-        details: { 
-            error: resetResult.error || null
-        }
-    });
-
-    if (!resetResult.success) {
-      // Logged above, now just return standard response
-      console.error('Password reset error (will still return generic success):', resetResult.error);
-    }
-
-    // Always return success to prevent email enumeration
-    return NextResponse.json({
-      message: 'If an account exists with this email, you will receive password reset instructions.',
-    });
-  } catch (error) {
-    console.error('Password reset error:', error);
-    const message = error instanceof Error ? error.message : 'An unexpected error occurred';
-    
-    // Log the unexpected error
-    await logUserAction({
-        action: 'PASSWORD_RESET_UNEXPECTED_ERROR',
-        status: 'FAILURE',
-        ipAddress: ipAddress,
-        userAgent: userAgent,
-        targetResourceType: 'auth',
-        targetResourceId: emailForLogging, // Use stored email if available
-        details: { error: message }
-    });
-
-    // Use generic message to prevent email enumeration even on unexpected errors
-    return NextResponse.json(
-      { message: 'If an account exists with this email, you will receive password reset instructions.' },
-      { status: 200 } // Return 200 OK
+  if (!resetResult.success) {
+    console.error(
+      "Password reset error (will still return generic success):",
+      resetResult.error,
     );
   }
+
+  return createSuccessResponse({
+    message:
+      "If an account exists with this email, you will receive password reset instructions.",
+  });
 }
 
-// Apply rate limiting and security middleware
-export const POST = withSecurity(
-  async (request: NextRequest) => withAuthRateLimit(request, handler)
-); 
+async function handler(request: NextRequest) {
+  return withErrorHandling(
+    async (req) => withValidation(ResetRequestSchema, handlePasswordReset, req),
+    request,
+  );
+}
+
+export const POST = withSecurity(async (request: NextRequest) =>
+  withAuthRateLimit(request, handler),
+);

--- a/app/api/auth/update-password/route.ts
+++ b/app/api/auth/update-password/route.ts
@@ -1,125 +1,92 @@
-import { type NextRequest, NextResponse } from 'next/server';
-import { z } from 'zod';
-import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
-import { withSecurity } from '@/middleware/with-security';
-import { logUserAction } from '@/lib/audit/auditLogger';
-import { getApiAuthService } from '@/lib/api/auth/factory';
+import { type NextRequest } from "next/server";
+import { z } from "zod";
+import { withAuthRateLimit } from "@/middleware/with-auth-rate-limit";
+import { withSecurity } from "@/middleware/with-security";
+import { logUserAction } from "@/lib/audit/auditLogger";
+import { getApiAuthService } from "@/lib/api/auth/factory";
+import {
+  createSuccessResponse,
+  withErrorHandling,
+  withValidation,
+  ApiError,
+  ERROR_CODES,
+} from "@/lib/api/common";
 
 // Zod schema for password update
 const UpdatePasswordSchema = z.object({
-  password: z.string()
-    .min(8, { message: 'Password must be at least 8 characters long' })
-    .regex(/[A-Z]/, { message: 'Password must contain at least one uppercase letter' })
-    .regex(/[0-9]/, { message: 'Password must contain at least one number' }),
+  password: z
+    .string()
+    .min(8, { message: "Password must be at least 8 characters long" })
+    .regex(/[A-Z]/, {
+      message: "Password must contain at least one uppercase letter",
+    })
+    .regex(/[0-9]/, { message: "Password must contain at least one number" }),
 });
 
-async function handler(request: NextRequest): Promise<NextResponse> {
-  const ipAddress = request.ip;
-  const userAgent = request.headers.get('user-agent');
+async function handleUpdatePassword(
+  req: NextRequest,
+  data: z.infer<typeof UpdatePasswordSchema>,
+) {
+  const ipAddress = req.ip || req.headers.get("x-forwarded-for") || "unknown";
+  const userAgent = req.headers.get("user-agent") || "unknown";
   let userIdForLogging: string | null = null;
 
-  if (request.method !== 'POST') {
-    return new NextResponse(JSON.stringify({ error: 'Method not allowed' }), {
-      status: 405,
-      headers: { 'Content-Type': 'application/json' }
+  const authService = getApiAuthService();
+  const currentUser = authService.getCurrentUser();
+
+  if (!currentUser) {
+    await logUserAction({
+      action: "PASSWORD_UPDATE_UNAUTHORIZED",
+      status: "FAILURE",
+      ipAddress,
+      userAgent,
+      targetResourceType: "auth",
+      details: { reason: "No user session found" },
     });
+    throw new ApiError(ERROR_CODES.UNAUTHORIZED, "Unauthorized", 401);
   }
+
+  userIdForLogging = currentUser.id;
 
   try {
-    // Get AuthService
-    const authService = getApiAuthService();
-
-    // Get the current user
-    const currentUser = authService.getCurrentUser();
-
-    if (!currentUser) {
-      // Log unauthorized attempt if possible
-      await logUserAction({
-          action: 'PASSWORD_UPDATE_UNAUTHORIZED',
-          status: 'FAILURE',
-          ipAddress: ipAddress,
-          userAgent: userAgent,
-          targetResourceType: 'auth',
-          details: { reason: 'No user session found' }
-      });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    userIdForLogging = currentUser.id; // Store for logging
-
-    const body = await request.json();
-    
-    // Validate request body
-    const parseResult = UpdatePasswordSchema.safeParse(body);
-    if (!parseResult.success) {
-      const errors = parseResult.error.errors.map(err => ({
-        field: err.path.join('.'),
-        message: err.message,
-      }));
-      return NextResponse.json({ error: 'Validation failed', details: errors }, { status: 400 });
-    }
-
-    const { password } = parseResult.data;
-
-    try {
-      // Update password using AuthService
-      // Since we're setting a new password without knowing the old one (password reset flow),
-      // we'll pass an empty string as the old password
-      await authService.updatePassword('', password);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Failed to update password';
-      
-      // Log the failed password update
-      await logUserAction({
-          userId: userIdForLogging,
-          action: 'PASSWORD_UPDATE_FAILURE',
-          status: 'FAILURE',
-          ipAddress: ipAddress,
-          userAgent: userAgent,
-          targetResourceType: 'auth',
-          targetResourceId: userIdForLogging,
-          details: { reason: errorMessage }
-      });
-      return NextResponse.json({ error: errorMessage }, { status: 400 });
-    }
-
-    // Log successful password update
-    await logUserAction({
-        userId: userIdForLogging,
-        action: 'PASSWORD_UPDATE_SUCCESS',
-        status: 'SUCCESS',
-        ipAddress: ipAddress,
-        userAgent: userAgent,
-        targetResourceType: 'auth',
-        targetResourceId: userIdForLogging
-    });
-
-    return NextResponse.json({
-      message: 'Password updated successfully',
-    });
+    await authService.updatePassword("", data.password);
   } catch (error) {
-    console.error('Password update error:', error);
-    const message = error instanceof Error ? error.message : 'An unexpected error occurred';
-
-    // Log the unexpected error
+    const errorMessage =
+      error instanceof Error ? error.message : "Failed to update password";
     await logUserAction({
-        userId: userIdForLogging, // May be null if error happened before user fetch
-        action: 'PASSWORD_UPDATE_UNEXPECTED_ERROR',
-        status: 'FAILURE',
-        ipAddress: ipAddress,
-        userAgent: userAgent,
-        targetResourceType: 'auth',
-        targetResourceId: userIdForLogging,
-        details: { error: message }
+      userId: userIdForLogging,
+      action: "PASSWORD_UPDATE_FAILURE",
+      status: "FAILURE",
+      ipAddress,
+      userAgent,
+      targetResourceType: "auth",
+      targetResourceId: userIdForLogging,
+      details: { reason: errorMessage },
     });
-
-    return NextResponse.json(
-      { error: 'Failed to update password. Please try again.' },
-      { status: 500 }
-    );
+    throw new ApiError(ERROR_CODES.INVALID_REQUEST, errorMessage, 400);
   }
+
+  await logUserAction({
+    userId: userIdForLogging,
+    action: "PASSWORD_UPDATE_SUCCESS",
+    status: "SUCCESS",
+    ipAddress,
+    userAgent,
+    targetResourceType: "auth",
+    targetResourceId: userIdForLogging,
+  });
+
+  return createSuccessResponse({ message: "Password updated successfully" });
 }
 
-// Apply rate limiting and security middleware
-export const POST = withSecurity(
-  async (request: NextRequest) => withAuthRateLimit(request, handler)
-); 
+async function handler(request: NextRequest) {
+  return withErrorHandling(
+    async (req) =>
+      withValidation(UpdatePasswordSchema, handleUpdatePassword, req),
+    request,
+  );
+}
+
+export const POST = withSecurity(async (request: NextRequest) =>
+  withAuthRateLimit(request, handler),
+);


### PR DESCRIPTION
## Summary
- standardize password reset, update password, MFA verify, logout, CSRF, account and OAuth callback endpoints
- update OAuth tests for new response format

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined)*