### PR TITLE
Refactor team API endpoints

### DIFF
--- a/app/api/team/invites/__tests__/route.test.ts
+++ b/app/api/team/invites/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/database/prisma';
 import { getServerSession } from 'next-auth';
 import { sendTeamInviteEmail } from '@/lib/email/teamInvite';
 import { generateInviteToken } from '@/lib/utils/token';
+import { ERROR_CODES } from '@/lib/api/common';
 
 // Mock dependencies
 vi.mock('next-auth', () => ({
@@ -77,7 +78,7 @@ describe('POST /api/team/invites', () => {
     const data = await response.json();
 
     expect(response.status).toBe(201);
-    expect(data).toEqual({
+    expect(data.data).toEqual({
       id: 'member-123',
       teamLicenseId: mockLicense.id,
       invitedEmail: 'new@example.com',
@@ -109,7 +110,7 @@ describe('POST /api/team/invites', () => {
     const data = await response.json();
 
     expect(response.status).toBe(401);
-    expect(data).toEqual({ error: 'Unauthorized' });
+    expect(data.error.code).toBe(ERROR_CODES.UNAUTHORIZED);
   });
 
   it('returns 400 when team license is not found', async () => {
@@ -129,7 +130,7 @@ describe('POST /api/team/invites', () => {
     const data = await response.json();
 
     expect(response.status).toBe(400);
-    expect(data).toEqual({ error: 'Invalid team license' });
+    expect(data.error.code).toBe(ERROR_CODES.NOT_FOUND);
   });
 
   it('returns 403 when team has reached seat limit', async () => {
@@ -148,8 +149,8 @@ describe('POST /api/team/invites', () => {
     const response = await POST(request);
     const data = await response.json();
 
-    expect(response.status).toBe(403);
-    expect(data).toEqual({ error: 'Team has reached its seat limit' });
+    expect(response.status).toBe(400);
+    expect(data.error.code).toBe(ERROR_CODES.INVALID_REQUEST);
   });
 
   it('returns 400 when email validation fails', async () => {
@@ -167,7 +168,7 @@ describe('POST /api/team/invites', () => {
     const data = await response.json();
 
     expect(response.status).toBe(400);
-    expect(data.error).toContain('Invalid email');
+    expect(data.error.code).toBe(ERROR_CODES.INVALID_REQUEST);
   });
 
   it('returns 400 when role validation fails', async () => {
@@ -185,6 +186,6 @@ describe('POST /api/team/invites', () => {
     const data = await response.json();
 
     expect(response.status).toBe(400);
-    expect(data.error).toContain('Invalid role');
+    expect(data.error.code).toBe(ERROR_CODES.INVALID_REQUEST);
   });
 }); 

--- a/app/api/team/invites/accept/__tests__/route.test.ts
+++ b/app/api/team/invites/accept/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../route';
 import { prisma } from '@/lib/prisma';
 import { getServerSession } from 'next-auth';
+import { ERROR_CODES } from '@/lib/api/common';
 
 // Mock dependencies
 vi.mock('next-auth', () => ({
@@ -94,7 +95,7 @@ describe('POST /api/team/invites/accept', () => {
     const data = await response.json();
 
     expect(response.status).toBe(401);
-    expect(data).toEqual({ error: 'Unauthorized' });
+    expect(data.error.code).toBe(ERROR_CODES.UNAUTHORIZED);
   });
 
   it('returns 400 when invite token is invalid', async () => {
@@ -112,7 +113,7 @@ describe('POST /api/team/invites/accept', () => {
     const data = await response.json();
 
     expect(response.status).toBe(400);
-    expect(data).toEqual({ error: 'Invalid or expired invitation' });
+    expect(data.error.code).toBe(ERROR_CODES.INVALID_REQUEST);
   });
 
   it('returns 400 when invite is expired', async () => {
@@ -133,7 +134,7 @@ describe('POST /api/team/invites/accept', () => {
     const data = await response.json();
 
     expect(response.status).toBe(400);
-    expect(data).toEqual({ error: 'Invitation has expired' });
+    expect(data.error.code).toBe(ERROR_CODES.INVALID_REQUEST);
   });
 
   it('returns 403 when invite email does not match user email', async () => {
@@ -154,7 +155,7 @@ describe('POST /api/team/invites/accept', () => {
     const data = await response.json();
 
     expect(response.status).toBe(403);
-    expect(data).toEqual({ error: 'This invitation was sent to a different email address' });
+    expect(data.error.code).toBe(ERROR_CODES.FORBIDDEN);
   });
 
   it('should return 400 when request body is invalid', async () => {
@@ -174,8 +175,8 @@ describe('POST /api/team/invites/accept', () => {
 
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe('Invalid request data');
-    expect(data.details).toBeDefined();
+    expect(data.error.code).toBe(ERROR_CODES.INVALID_REQUEST);
+    expect(data.error.details).toBeDefined();
   });
 
   it('should return 500 when database operation fails', async () => {
@@ -197,6 +198,6 @@ describe('POST /api/team/invites/accept', () => {
 
     expect(response.status).toBe(500);
     const data = await response.json();
-    expect(data.error).toBe('Failed to accept team invite');
+    expect(data.error.code).toBe(ERROR_CODES.INTERNAL_ERROR);
   });
 }); 

--- a/app/api/team/invites/route.ts
+++ b/app/api/team/invites/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse, NextRequest } from 'next/server';
+import { type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { prisma } from '@/lib/database/prisma';
 import { generateInviteToken } from '@/lib/utils/token';
@@ -7,6 +7,17 @@ import { createProtectedHandler } from '@/middleware/permissions';
 import { Permission } from '@/lib/rbac/roles';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth/index';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+  withValidation,
+  ApiError,
+  ERROR_CODES
+} from '@/lib/api/common';
+import {
+  createTeamNotFoundError,
+  createTeamMemberAlreadyExistsError
+} from '@/lib/api/team/error-handler';
 
 const inviteSchema = z.object({
   email: z.string().email(),
@@ -14,142 +25,90 @@ const inviteSchema = z.object({
   teamLicenseId: z.string(),
 });
 
-
-// Define the main handler logic
-async function handler(req: NextRequest) {
-  try {
-    const session = await getServerSession(authOptions);
-    if (!session?.user?.email || !session?.user?.id) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
-    }
-
-    // Get invoking user details (including role and teamId for permission check)
-    const invokingUser = await prisma.user.findUnique({
-      where: { id: session.user.id },
-      select: { id: true, teamMemberships: { select: { teamId: true, role: true } } },
-    });
-
-    if (!invokingUser || !invokingUser.teamMemberships || invokingUser.teamMemberships.length === 0) {
-      return NextResponse.json({ error: 'Invoking user not found or not part of any team' }, { status: 403 });
-    }
-    // Assuming user belongs to one team for this context
-    const invokingUserTeamId = invokingUser.teamMemberships[0].teamId;
-
-    const body = await req.json();
-    const validatedData = inviteSchema.parse(body);
-
-    // **** Resource-specific Permission Check ****
-    // Check if the invoking user belongs to the team associated with the target teamLicenseId
-    const targetLicense = await prisma.teamLicense.findUnique({
-      where: { id: validatedData.teamLicenseId },
-      select: { teamId: true }
-    });
-
-    if (!targetLicense) {
-      return NextResponse.json({ error: 'Target team license not found' }, { status: 404 });
-    }
-
-    // Perform the actual check: is the user in the target team?
-    // (Or more advanced: does the user's role grant permission *for this specific team*?)
-    // For now, let's assume being in the same team is sufficient if they have the INVITE permission.
-    if (targetLicense.teamId !== invokingUserTeamId) {
-      console.warn(`User ${invokingUser.id} tried to invite to license ${validatedData.teamLicenseId} (team ${targetLicense.teamId}) but belongs to team ${invokingUserTeamId}`);
-      return NextResponse.json({ error: 'Forbidden: Cannot invite members to this team license.' }, { status: 403 });
-    }
-    // **** End Resource Check ****
-
-    // Check seat limit
-    const teamLicense = await prisma.teamLicense.findUnique({
-      where: { id: validatedData.teamLicenseId },
-      select: {
-        usedSeats: true,
-        totalSeats: true,
-      },
-    });
-
-    if (!teamLicense) {
-      return NextResponse.json(
-        { error: 'Team license not found' },
-        { status: 404 }
-      );
-    }
-
-    if (teamLicense.usedSeats >= teamLicense.totalSeats) {
-      return NextResponse.json(
-        { error: 'Team has reached its seat limit' },
-        { status: 400 }
-      );
-    }
-
-    // Check if user is already a member or invited
-    const existingMember = await prisma.teamMember.findFirst({
-      where: {
-        OR: [
-          { userId: invokingUser.id, teamLicenseId: validatedData.teamLicenseId },
-          { invitedEmail: validatedData.email, teamLicenseId: validatedData.teamLicenseId },
-        ],
-      },
-    });
-
-    if (existingMember) {
-      return NextResponse.json(
-        { error: 'User is already a member or has a pending invitation' },
-        { status: 400 }
-      );
-    }
-
-    // Create invite
-    const inviteToken = generateInviteToken();
-    await prisma.teamMember.create({
-      data: {
-        teamLicenseId: validatedData.teamLicenseId,
-        role: validatedData.role,
-        invitedEmail: validatedData.email,
-        invitedBy: invokingUser.id,
-        inviteToken,
-        inviteExpires: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days
-        status: 'pending',
-      },
-    });
-
-    // Increment used seats
-    await prisma.teamLicense.update({
-      where: { id: validatedData.teamLicenseId },
-      data: { usedSeats: { increment: 1 } },
-    });
-
-    // Send invite email
-    await sendTeamInviteEmail({
-      to: validatedData.email,
-      inviteToken,
-      invitedByEmail: session.user.email,
-      teamName: 'Your Team', // TODO: Add team name to TeamLicense model
-      role: validatedData.role,
-    });
-
-    return NextResponse.json({ message: "Invite sent successfully" });
-  } catch (error) {
-    console.error('Failed to create team invite:', error);
-    
-    if (error instanceof z.ZodError) {
-      return NextResponse.json(
-        { error: 'Invalid request data', details: error.errors },
-        { status: 400 }
-      );
-    }
-
-    return NextResponse.json(
-      { error: 'Failed to create team invite' },
-      { status: 500 }
-    );
+async function handleInvite(req: NextRequest, data: z.infer<typeof inviteSchema>) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email || !session?.user?.id) {
+    throw new ApiError(ERROR_CODES.UNAUTHORIZED, 'Unauthorized', 401);
   }
+
+  const invokingUser = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { id: true, teamMemberships: { select: { teamId: true, role: true } } },
+  });
+  if (!invokingUser || !invokingUser.teamMemberships || invokingUser.teamMemberships.length === 0) {
+    throw new ApiError(ERROR_CODES.FORBIDDEN, 'Invoking user not found or not part of any team', 403);
+  }
+  const invokingUserTeamId = invokingUser.teamMemberships[0].teamId;
+
+  const targetLicense = await prisma.teamLicense.findUnique({
+    where: { id: data.teamLicenseId },
+    select: { teamId: true }
+  });
+  if (!targetLicense) {
+    throw createTeamNotFoundError(data.teamLicenseId);
+  }
+  if (targetLicense.teamId !== invokingUserTeamId) {
+    throw new ApiError(ERROR_CODES.FORBIDDEN, 'Forbidden: Cannot invite members to this team license.', 403);
+  }
+
+  const teamLicense = await prisma.teamLicense.findUnique({
+    where: { id: data.teamLicenseId },
+    select: { usedSeats: true, totalSeats: true },
+  });
+  if (!teamLicense) {
+    throw createTeamNotFoundError(data.teamLicenseId);
+  }
+  if (teamLicense.usedSeats >= teamLicense.totalSeats) {
+    throw new ApiError(ERROR_CODES.INVALID_REQUEST, 'Team has reached its seat limit', 400);
+  }
+
+  const existingMember = await prisma.teamMember.findFirst({
+    where: {
+      OR: [
+        { userId: invokingUser.id, teamLicenseId: data.teamLicenseId },
+        { invitedEmail: data.email, teamLicenseId: data.teamLicenseId },
+      ],
+    },
+  });
+  if (existingMember) {
+    throw createTeamMemberAlreadyExistsError();
+  }
+
+  const inviteToken = generateInviteToken();
+  const invite = await prisma.teamMember.create({
+    data: {
+      teamLicenseId: data.teamLicenseId,
+      role: data.role,
+      invitedEmail: data.email,
+      invitedBy: invokingUser.id,
+      inviteToken,
+      inviteExpires: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      status: 'pending',
+    },
+  });
+
+  await prisma.teamLicense.update({
+    where: { id: data.teamLicenseId },
+    data: { usedSeats: { increment: 1 } },
+  });
+
+  await sendTeamInviteEmail({
+    to: data.email,
+    inviteToken,
+    invitedByEmail: session.user.email,
+    teamName: 'Your Team',
+    role: data.role,
+  });
+
+  return createSuccessResponse(invite, 201);
 }
 
-// Export the protected handler, now only checking the general permission
+async function handler(req: NextRequest) {
+  const body = await req.json();
+  return withValidation(inviteSchema, handleInvite, req, body);
+}
+
 export const POST = createProtectedHandler(
-  handler, 
-  Permission.INVITE_TEAM_MEMBER // General permission check
-); 
+  (req) => withErrorHandling(handler, req),
+  Permission.INVITE_TEAM_MEMBER
+);

--- a/app/api/team/members/[memberId]/route.ts
+++ b/app/api/team/members/[memberId]/route.ts
@@ -1,70 +1,60 @@
-import { NextResponse } from 'next/server';
+import { type NextRequest } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/database/prisma';
-import { z } from 'zod';
 import { hasPermission } from '@/lib/auth/hasPermission';
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+  withValidation,
+  ApiError,
+  ERROR_CODES
+} from '@/lib/api/common';
+import { createTeamMemberNotFoundError } from '@/lib/api/team/error-handler';
 
-export async function DELETE(
-  request: Request,
-  { params }: { params: { memberId: string } }
+const paramSchema = z.object({ memberId: z.string().uuid() });
+
+async function handleDelete(
+  req: NextRequest,
+  params: z.infer<typeof paramSchema>
 ) {
-  try {
-    const session = await getServerSession(authOptions);
-    if (!session?.user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    // Check if user has permission to remove team members
-    if (!await hasPermission(session.user.id, 'REMOVE_TEAM_MEMBER')) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-    }
-
-    // Validate memberId parameter
-    const memberIdSchema = z.string().uuid();
-    const validationResult = memberIdSchema.safeParse(params.memberId);
-    if (!validationResult.success) {
-      return NextResponse.json({ error: 'Invalid member ID format' }, { status: 400 });
-    }
-
-    // Get the team member to be removed
-    const teamMember = await prisma.teamMember.findUnique({
-      where: { id: params.memberId },
-      include: {
-        team: {
-          include: {
-            members: {
-              where: {
-                role: 'ADMIN'
-              }
-            }
-          }
-        }
-      }
-    });
-
-    if (!teamMember) {
-      return NextResponse.json({ error: 'Team member not found' }, { status: 404 });
-    }
-
-    // Check if trying to remove self
-    if (teamMember.userId === session.user.id) {
-      return NextResponse.json({ error: 'Cannot remove yourself from the team' }, { status: 400 });
-    }
-
-    // Check if removing the last admin
-    if (teamMember.role === 'ADMIN' && teamMember.team.members.length === 1) {
-      return NextResponse.json({ error: 'Cannot remove the last admin from the team' }, { status: 400 });
-    }
-
-    // Remove the team member
-    await prisma.teamMember.delete({
-      where: { id: params.memberId }
-    });
-
-    return NextResponse.json({ message: 'Team member removed successfully' });
-  } catch (error) {
-    console.error('Error removing team member:', error);
-    return NextResponse.json({ error: 'Failed to remove team member' }, { status: 500 });
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    throw new ApiError(ERROR_CODES.UNAUTHORIZED, 'Authentication required', 401);
   }
+
+  if (!(await hasPermission(session.user.id, 'REMOVE_TEAM_MEMBER'))) {
+    throw new ApiError(ERROR_CODES.FORBIDDEN, 'Forbidden', 403);
+  }
+
+  const teamMember = await prisma.teamMember.findUnique({
+    where: { id: params.memberId },
+    include: {
+      team: { include: { members: { where: { role: 'ADMIN' } } } },
+    },
+  });
+
+  if (!teamMember) {
+    throw createTeamMemberNotFoundError();
+  }
+
+  if (teamMember.userId === session.user.id) {
+    throw new ApiError(ERROR_CODES.INVALID_REQUEST, 'Cannot remove yourself from the team', 400);
+  }
+
+  if (teamMember.role === 'ADMIN' && teamMember.team.members.length === 1) {
+    throw new ApiError(ERROR_CODES.INVALID_REQUEST, 'Cannot remove the last admin from the team', 400);
+  }
+
+  await prisma.teamMember.delete({ where: { id: params.memberId } });
+
+  return createSuccessResponse({ message: 'Team member removed successfully' });
 }
+
+async function handler(req: NextRequest, context: { params: { memberId: string } }) {
+  return withValidation(paramSchema, handleDelete, req, context.params);
+}
+
+export const DELETE = (req: NextRequest, ctx: { params: { memberId: string } }) =>
+  withErrorHandling((r) => handler(r, ctx), req);

--- a/app/api/team/members/__tests__/route.test.ts
+++ b/app/api/team/members/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { prisma } from '@/lib/database/prisma';
 import { GET } from '@/app/api/team/members/route';
+import { ERROR_CODES } from '@/lib/api/common';
 
 // Mocks
 vi.mock('next-auth', () => ({
@@ -69,7 +70,8 @@ describe('Team Members API', () => {
     const response = await GET(request);
 
     expect(response.status).toBe(401);
-    expect(await response.json()).toEqual({ error: 'Unauthorized' });
+    const data = await response.json();
+    expect(data.error.code).toBe(ERROR_CODES.UNAUTHORIZED);
   });
 
   it('returns team members with pagination', async () => {
@@ -78,7 +80,7 @@ describe('Team Members API', () => {
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data).toEqual({
+    expect(data.data).toEqual({
       users: mockUsers,
       pagination: {
         page: 1,
@@ -167,11 +169,8 @@ describe('Team Members API', () => {
     const response = await GET(request);
 
     expect(response.status).toBe(400);
-    expect(await response.json()).toEqual(
-      expect.objectContaining({
-        error: 'Invalid query parameters',
-      })
-    );
+    const data = await response.json();
+    expect(data.error.code).toBe(ERROR_CODES.INVALID_REQUEST);
   });
 
   it('handles database errors gracefully', async () => {
@@ -183,8 +182,7 @@ describe('Team Members API', () => {
     const response = await GET(request);
 
     expect(response.status).toBe(500);
-    expect(await response.json()).toEqual({
-      error: 'Internal server error',
-    });
+    const data = await response.json();
+    expect(data.error.code).toBe(ERROR_CODES.INTERNAL_ERROR);
   });
 });


### PR DESCRIPTION
## Summary
- refactor team member listing to use common API utils
- refactor team member deletion and role update routes
- refactor team invites creation and acceptance routes
- update associated unit tests for new response structure

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined)*