### PR TITLE
Implement API key adapters

### DIFF
--- a/src/adapters/api-keys/factory.ts
+++ b/src/adapters/api-keys/factory.ts
@@ -1,0 +1,15 @@
+import { ApiKeyDataProvider } from './interfaces';
+import { SupabaseApiKeyProvider } from './supabase-adapter';
+
+export function createSupabaseApiKeyProvider(options: { supabaseUrl: string; supabaseKey: string; [key: string]: any }): ApiKeyDataProvider {
+  return new SupabaseApiKeyProvider(options.supabaseUrl, options.supabaseKey);
+}
+
+export function createApiKeyProvider(config: { type: 'supabase' | string; options: Record<string, any> }): ApiKeyDataProvider {
+  switch (config.type) {
+    case 'supabase':
+      return createSupabaseApiKeyProvider(config.options);
+    default:
+      throw new Error(`Unsupported api key provider type: ${config.type}`);
+  }
+}

--- a/src/adapters/api-keys/index.ts
+++ b/src/adapters/api-keys/index.ts
@@ -1,0 +1,3 @@
+export * from './interfaces';
+export * from './factory';
+export * from './supabase-adapter';

--- a/src/adapters/api-keys/interfaces.ts
+++ b/src/adapters/api-keys/interfaces.ts
@@ -1,0 +1,16 @@
+/**
+ * API Key Data Provider Interface
+ */
+
+import { ApiKey, ApiKeyCreatePayload, ApiKeyCreateResult } from '../../core/api-keys/models';
+
+export interface ApiKeyDataProvider {
+  /** List API keys for a user */
+  listKeys(userId: string): Promise<ApiKey[]>;
+
+  /** Create a new API key */
+  createKey(userId: string, data: ApiKeyCreatePayload): Promise<ApiKeyCreateResult>;
+
+  /** Revoke an API key */
+  revokeKey(userId: string, keyId: string): Promise<{ success: boolean; key?: ApiKey; error?: string }>;
+}

--- a/src/adapters/api-keys/supabase-adapter.ts
+++ b/src/adapters/api-keys/supabase-adapter.ts
@@ -1,0 +1,89 @@
+/**
+ * Supabase API Key Provider Implementation
+ */
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { ApiKey, ApiKeyCreatePayload, ApiKeyCreateResult } from '../../core/api-keys/models';
+import { ApiKeyDataProvider } from './interfaces';
+import { generateApiKey } from '../../lib/api-keys/api-key-utils';
+
+export class SupabaseApiKeyProvider implements ApiKeyDataProvider {
+  private supabase: SupabaseClient;
+
+  constructor(supabaseUrl: string, supabaseKey: string) {
+    this.supabase = createClient(supabaseUrl, supabaseKey);
+  }
+
+  async listKeys(userId: string): Promise<ApiKey[]> {
+    const { data, error } = await this.supabase
+      .from('api_keys')
+      .select('id, name, prefix, scopes, expires_at, last_used_at, created_at, is_revoked')
+      .eq('user_id', userId)
+      .eq('is_revoked', false);
+
+    if (error || !data) {
+      throw new Error(error?.message || 'Failed to fetch API keys');
+    }
+
+    return data.map(this.mapDbKey);
+  }
+
+  async createKey(userId: string, payload: ApiKeyCreatePayload): Promise<ApiKeyCreateResult> {
+    const { key, hashedKey, prefix } = generateApiKey();
+    const { data, error } = await this.supabase
+      .from('api_keys')
+      .insert({
+        user_id: userId,
+        name: payload.name,
+        key_hash: hashedKey,
+        prefix,
+        scopes: payload.scopes,
+        expires_at: payload.expiresAt,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        is_revoked: false
+      })
+      .select('id, name, prefix, scopes, expires_at, created_at, is_revoked')
+      .single();
+
+    if (error || !data) {
+      return { success: false, error: error?.message || 'Failed to create API key' };
+    }
+
+    return {
+      success: true,
+      key: this.mapDbKey(data),
+      plaintext: key
+    };
+  }
+
+  async revokeKey(userId: string, keyId: string): Promise<{ success: boolean; key?: ApiKey; error?: string }> {
+    const { data, error } = await this.supabase
+      .from('api_keys')
+      .update({ is_revoked: true, updated_at: new Date().toISOString() })
+      .eq('id', keyId)
+      .eq('user_id', userId)
+      .select('id, user_id, name, prefix, scopes, expires_at, last_used_at, created_at, is_revoked')
+      .single();
+
+    if (error || !data) {
+      return { success: false, error: error?.message || 'Failed to revoke key' };
+    }
+
+    return { success: true, key: this.mapDbKey(data) };
+  }
+
+  private mapDbKey(data: any): ApiKey {
+    return {
+      id: data.id,
+      userId: data.user_id,
+      name: data.name,
+      prefix: data.prefix,
+      scopes: data.scopes || [],
+      expiresAt: data.expires_at,
+      lastUsedAt: data.last_used_at,
+      createdAt: data.created_at,
+      isRevoked: data.is_revoked
+    };
+  }
+}

--- a/src/adapters/api-keys/supabase/factory.ts
+++ b/src/adapters/api-keys/supabase/factory.ts
@@ -1,0 +1,6 @@
+import { ApiKeyDataProvider } from '../interfaces';
+import { SupabaseApiKeyProvider } from '../supabase-adapter';
+
+export default function createSupabaseApiKeyProvider(options: { supabaseUrl: string; supabaseKey: string; [key: string]: any }): ApiKeyDataProvider {
+  return new SupabaseApiKeyProvider(options.supabaseUrl, options.supabaseKey);
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -10,6 +10,7 @@ export * from './auth';
 export * from './user';
 export * from './team';
 export * from './permission';
+export * from './api-keys';
 export * from './notification';
 
 // Import and register the Supabase adapter factory by default

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -11,6 +11,7 @@ import { AuthDataProvider } from './auth/interfaces';
 import { UserDataProvider } from './user/interfaces';
 import { TeamDataProvider } from './team/interfaces';
 import { PermissionDataProvider } from './permission/interfaces';
+import { ApiKeyDataProvider } from './api-keys/interfaces';
 
 /**
  * Interface for adapter factory options
@@ -43,6 +44,11 @@ export interface AdapterFactory {
    * Create a permission data provider
    */
   createPermissionProvider(): PermissionDataProvider;
+
+  /**
+   * Create an API key data provider
+   */
+  createApiKeyProvider(): ApiKeyDataProvider;
 }
 
 /**

--- a/src/adapters/supabase-factory.ts
+++ b/src/adapters/supabase-factory.ts
@@ -10,12 +10,14 @@ import { AuthDataProvider } from './auth/interfaces';
 import { UserDataProvider } from './user/interfaces';
 import { TeamDataProvider } from './team/interfaces';
 import { PermissionDataProvider } from './permission/interfaces';
+import { ApiKeyDataProvider } from './api-keys/interfaces';
 
 // Import domain-specific factories
 import createSupabaseAuthProvider from './auth/supabase/factory';
 import createSupabaseUserProvider from './user/supabase/factory';
 import createSupabaseTeamProvider from './team/supabase/factory';
 import createSupabasePermissionProvider from './permission/supabase/factory';
+import createSupabaseApiKeyProvider from './api-keys/supabase/factory';
 
 /**
  * Factory for creating Supabase adapters
@@ -69,6 +71,13 @@ export class SupabaseAdapterFactory implements AdapterFactory {
    */
   createPermissionProvider(): PermissionDataProvider {
     return createSupabasePermissionProvider(this.options);
+  }
+
+  /**
+   * Create a Supabase API key provider
+   */
+  createApiKeyProvider(): ApiKeyDataProvider {
+    return createSupabaseApiKeyProvider(this.options);
   }
 }
 

--- a/src/core/api-keys/index.ts
+++ b/src/core/api-keys/index.ts
@@ -1,0 +1,2 @@
+export * from './interfaces';
+export * from './models';

--- a/src/core/api-keys/interfaces.ts
+++ b/src/core/api-keys/interfaces.ts
@@ -1,0 +1,24 @@
+/**
+ * API Key Service Interface
+ *
+ * Defines the contract for API key management operations.
+ */
+
+import { ApiKey, ApiKeyCreatePayload, ApiKeyCreateResult } from './models';
+
+export interface ApiKeyService {
+  /**
+   * Get all API keys for a user.
+   */
+  listKeys(userId: string): Promise<ApiKey[]>;
+
+  /**
+   * Create a new API key for a user.
+   */
+  createKey(userId: string, data: ApiKeyCreatePayload): Promise<ApiKeyCreateResult>;
+
+  /**
+   * Revoke an existing API key.
+   */
+  revokeKey(userId: string, keyId: string): Promise<{ success: boolean; error?: string }>;
+}

--- a/src/core/api-keys/models.ts
+++ b/src/core/api-keys/models.ts
@@ -1,0 +1,34 @@
+/**
+ * API Key Domain Models
+ */
+
+import { z } from 'zod';
+
+/** API key entity */
+export interface ApiKey {
+  id: string;
+  userId: string;
+  name: string;
+  prefix: string;
+  scopes: string[];
+  expiresAt?: string | null;
+  lastUsedAt?: string | null;
+  createdAt: string;
+  isRevoked: boolean;
+}
+
+/** Payload for creating an API key */
+export const apiKeyCreateSchema = z.object({
+  name: z.string().min(1).max(100),
+  scopes: z.array(z.string()),
+  expiresAt: z.string().datetime().optional()
+});
+export type ApiKeyCreatePayload = z.infer<typeof apiKeyCreateSchema>;
+
+/** Result of API key creation */
+export interface ApiKeyCreateResult {
+  success: boolean;
+  key?: ApiKey;
+  plaintext?: string;
+  error?: string;
+}


### PR DESCRIPTION
## Summary
- add API key core models and interfaces
- implement API key adapter interface and Supabase provider
- extend adapter registry and factory to include API key provider
- expose new adapter in adapter index
- refactor API key routes to use provider
- update related unit tests

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*