### PR TITLE
Add CSRF core and adapter architecture

### DIFF
--- a/app/api/csrf/route.ts
+++ b/app/api/csrf/route.ts
@@ -1,18 +1,15 @@
 import { NextResponse } from 'next/server';
-import { randomBytes } from 'crypto';
+import { getApiCsrfService } from '@/lib/api/csrf/factory';
 
 // Configuration (consider moving to a shared config if used elsewhere)
 const cookieName = 'csrf-token';
 const secure = process.env.NODE_ENV === 'production';
 const sameSite = 'strict';
 
-function generateToken(): string {
-  return randomBytes(32).toString('hex');
-}
-
 export async function GET() {
   try {
-    const token = generateToken();
+    const csrfService = getApiCsrfService();
+    const { token } = await csrfService.generateToken();
     const response = NextResponse.json({ csrfToken: token }, { status: 200 });
 
     // Set the HttpOnly cookie

--- a/src/adapters/csrf/__tests__/default-adapter.test.ts
+++ b/src/adapters/csrf/__tests__/default-adapter.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { DefaultCsrfProvider } from '../default-adapter';
+
+describe('DefaultCsrfProvider', () => {
+  it('generates a random token', async () => {
+    const provider = new DefaultCsrfProvider();
+    const token = await provider.generateToken();
+    expect(typeof token).toBe('string');
+    expect(token.length).toBeGreaterThan(0);
+  });
+});

--- a/src/adapters/csrf/default-adapter.ts
+++ b/src/adapters/csrf/default-adapter.ts
@@ -1,0 +1,8 @@
+import { randomBytes } from 'crypto';
+import { CsrfDataProvider } from './interfaces';
+
+export class DefaultCsrfProvider implements CsrfDataProvider {
+  async generateToken(): Promise<string> {
+    return randomBytes(32).toString('hex');
+  }
+}

--- a/src/adapters/csrf/factory.ts
+++ b/src/adapters/csrf/factory.ts
@@ -1,0 +1,13 @@
+import { CsrfDataProvider } from './interfaces';
+import { DefaultCsrfProvider } from './default-adapter';
+
+export function createDefaultCsrfProvider(): CsrfDataProvider {
+  return new DefaultCsrfProvider();
+}
+
+export function createCsrfProvider(config?: { type?: 'default' | string; options?: Record<string, any> }): CsrfDataProvider {
+  if (!config || config.type === 'default') {
+    return createDefaultCsrfProvider();
+  }
+  throw new Error(`Unsupported CSRF provider type: ${config.type}`);
+}

--- a/src/adapters/csrf/index.ts
+++ b/src/adapters/csrf/index.ts
@@ -1,0 +1,3 @@
+export * from './interfaces';
+export * from './factory';
+export * from './default-adapter';

--- a/src/adapters/csrf/interfaces.ts
+++ b/src/adapters/csrf/interfaces.ts
@@ -1,0 +1,3 @@
+export interface CsrfDataProvider {
+  generateToken(): Promise<string>;
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -11,6 +11,7 @@ export * from './user';
 export * from './team';
 export * from './permission';
 export * from './notification';
+export * from './csrf';
 
 // Import and register the Supabase adapter factory by default
 import { AdapterRegistry } from './registry';

--- a/src/core/csrf/index.ts
+++ b/src/core/csrf/index.ts
@@ -1,0 +1,2 @@
+export * from './interfaces';
+export * from './models';

--- a/src/core/csrf/interfaces.ts
+++ b/src/core/csrf/interfaces.ts
@@ -1,0 +1,5 @@
+import { CsrfToken } from './models';
+
+export interface CsrfService {
+  generateToken(): Promise<CsrfToken>;
+}

--- a/src/core/csrf/models.ts
+++ b/src/core/csrf/models.ts
@@ -1,0 +1,4 @@
+export interface CsrfToken {
+  token: string;
+  expiresAt?: Date;
+}

--- a/src/lib/api/csrf/factory.ts
+++ b/src/lib/api/csrf/factory.ts
@@ -6,9 +6,8 @@
  */
 
 import { CsrfService } from '@/core/csrf/interfaces';
-import { UserManagementConfiguration } from '@/core/config';
 import { createCsrfProvider } from '@/adapters/csrf/factory';
-import { getServiceSupabase } from '@/lib/database/supabase';
+import { DefaultCsrfService } from '@/services/csrf/default-csrf.service';
 
 // Singleton instance for API routes
 let csrfServiceInstance: CsrfService | null = null;
@@ -20,26 +19,8 @@ let csrfServiceInstance: CsrfService | null = null;
  */
 export function getApiCsrfService(): CsrfService {
   if (!csrfServiceInstance) {
-    // Get Supabase configuration from the existing service
-    const supabase = getServiceSupabase();
-    
-    // Create CSRF data provider
-    const csrfDataProvider = createCsrfProvider({
-      type: 'supabase',
-      options: {
-        supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',
-        supabaseKey: process.env.SUPABASE_SERVICE_ROLE_KEY || ''
-      }
-    });
-    
-    // Create CSRF service with the data provider
-    csrfServiceInstance = UserManagementConfiguration.getServiceProvider('csrfService') as CsrfService;
-    
-    // If no CSRF service is registered, throw an error
-    if (!csrfServiceInstance) {
-      throw new Error('CSRF service not registered in UserManagementConfiguration');
-    }
+    const csrfDataProvider = createCsrfProvider({ type: 'default' });
+    csrfServiceInstance = new DefaultCsrfService(csrfDataProvider);
   }
-  
   return csrfServiceInstance;
 }

--- a/src/services/csrf/__tests__/default-csrf.service.test.ts
+++ b/src/services/csrf/__tests__/default-csrf.service.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DefaultCsrfService } from '../default-csrf.service';
+import type { CsrfDataProvider } from '@/adapters/csrf/interfaces';
+
+describe('DefaultCsrfService', () => {
+  it('returns token from provider', async () => {
+    const mockProvider: CsrfDataProvider = {
+      generateToken: vi.fn(async () => 'token123')
+    };
+    const service = new DefaultCsrfService(mockProvider);
+    const result = await service.generateToken();
+    expect(result).toEqual({ token: 'token123' });
+  });
+});

--- a/src/services/csrf/default-csrf.service.ts
+++ b/src/services/csrf/default-csrf.service.ts
@@ -1,0 +1,12 @@
+import { CsrfService } from '@/core/csrf/interfaces';
+import { CsrfToken } from '@/core/csrf/models';
+import type { CsrfDataProvider } from '@/adapters/csrf/interfaces';
+
+export class DefaultCsrfService implements CsrfService {
+  constructor(private csrfProvider: CsrfDataProvider) {}
+
+  async generateToken(): Promise<CsrfToken> {
+    const token = await this.csrfProvider.generateToken();
+    return { token };
+  }
+}

--- a/src/services/csrf/index.ts
+++ b/src/services/csrf/index.ts
@@ -1,0 +1,13 @@
+import { CsrfService } from '@/core/csrf/interfaces';
+import { DefaultCsrfService } from './default-csrf.service';
+import type { CsrfDataProvider } from '@/adapters/csrf/interfaces';
+
+export interface CsrfServiceConfig {
+  csrfDataProvider: CsrfDataProvider;
+}
+
+export function createCsrfService(config: CsrfServiceConfig): CsrfService {
+  return new DefaultCsrfService(config.csrfDataProvider);
+}
+
+export default { createCsrfService };


### PR DESCRIPTION
## Summary
- implement CSRF interfaces and models in the core layer
- add default CSRF provider and factory in adapter layer
- add CSRF service with simple token generation
- expose CSRF adapter from central index
- refactor API csrf route to use the service factory
- create basic unit tests for CSRF provider and service

## Testing
- `npx vitest run --coverage` *(fails: AuthService is not registered and React act warnings)*