### PR TITLE
Add session management adapters

### DIFF
--- a/app/api/session/[sessionId]/route.ts
+++ b/app/api/session/[sessionId]/route.ts
@@ -1,17 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getUserFromRequest } from '@/lib/auth/utils';
-import { createClient } from '@/lib/supabase';
+import { createSessionProvider } from '@/adapters/session/factory';
 
 // DELETE /api/session/:sessionId - Revoke a specific session for the current user
 export async function DELETE(req: NextRequest, { params }: { params: { sessionId: string } }) {
   const user = await getUserFromRequest(req);
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const { sessionId } = params;
-  const supabase = createClient();
+  const provider = createSessionProvider({
+    type: 'supabase',
+    options: {
+      supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',
+      supabaseKey: process.env.SUPABASE_SERVICE_ROLE_KEY || ''
+    }
+  });
   try {
-    // Revoke the session for the user
-    const { error } = await supabase.auth.admin.deleteUserSession(user.id, sessionId);
-    if (error) throw error;
+    await provider.deleteUserSession(user.id, sessionId);
     return NextResponse.json({ success: true });
   } catch (error) {
     return NextResponse.json({ error: 'Failed to revoke session' }, { status: 500 });

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -11,6 +11,7 @@ export * from './user';
 export * from './team';
 export * from './permission';
 export * from './notification';
+export * from './session';
 
 // Import and register the Supabase adapter factory by default
 import { AdapterRegistry } from './registry';

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -11,6 +11,7 @@ import { AuthDataProvider } from './auth/interfaces';
 import { UserDataProvider } from './user/interfaces';
 import { TeamDataProvider } from './team/interfaces';
 import { PermissionDataProvider } from './permission/interfaces';
+import { SessionDataProvider } from './session/interfaces';
 
 /**
  * Interface for adapter factory options
@@ -38,11 +39,16 @@ export interface AdapterFactory {
    * Create a team data provider
    */
   createTeamProvider(): TeamDataProvider;
-  
+
   /**
    * Create a permission data provider
    */
   createPermissionProvider(): PermissionDataProvider;
+
+  /**
+   * Create a session data provider
+   */
+  createSessionProvider(): SessionDataProvider;
 }
 
 /**

--- a/src/adapters/session/factory.ts
+++ b/src/adapters/session/factory.ts
@@ -1,0 +1,28 @@
+/**
+ * Session Data Provider Factory
+ */
+
+import { SessionDataProvider } from './interfaces';
+import { SupabaseSessionProvider } from './supabase-adapter';
+
+export function createSupabaseSessionProvider(options: {
+  supabaseUrl: string;
+  supabaseKey: string;
+  [key: string]: any;
+}): SessionDataProvider {
+  return new SupabaseSessionProvider(options.supabaseUrl, options.supabaseKey);
+}
+
+export function createSessionProvider(config: {
+  type: 'supabase' | string;
+  options: Record<string, any>;
+}): SessionDataProvider {
+  switch (config.type) {
+    case 'supabase':
+      return createSupabaseSessionProvider(config.options);
+    default:
+      throw new Error(`Unsupported session provider type: ${config.type}`);
+  }
+}
+
+export default createSupabaseSessionProvider;

--- a/src/adapters/session/index.ts
+++ b/src/adapters/session/index.ts
@@ -1,0 +1,3 @@
+export * from './interfaces';
+export * from './factory';
+export * from './supabase-adapter';

--- a/src/adapters/session/interfaces.ts
+++ b/src/adapters/session/interfaces.ts
@@ -1,0 +1,14 @@
+/**
+ * Session Data Provider Interface
+ *
+ * Defines database operations required for session management.
+ */
+
+import { SessionInfo } from '../../core/session/models';
+
+export interface SessionDataProvider {
+  /** List all sessions for a user */
+  listUserSessions(userId: string): Promise<SessionInfo[]>;
+  /** Delete a specific user session */
+  deleteUserSession(userId: string, sessionId: string): Promise<void>;
+}

--- a/src/adapters/session/supabase-adapter.ts
+++ b/src/adapters/session/supabase-adapter.ts
@@ -1,0 +1,39 @@
+/**
+ * Supabase Session Provider Implementation
+ */
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { SessionInfo } from '../../core/session/models';
+import { SessionDataProvider } from './interfaces';
+
+export class SupabaseSessionProvider implements SessionDataProvider {
+  private supabase: SupabaseClient;
+
+  constructor(supabaseUrl: string, supabaseKey: string) {
+    this.supabase = createClient(supabaseUrl, supabaseKey);
+  }
+
+  async listUserSessions(userId: string): Promise<SessionInfo[]> {
+    const { data, error } = await this.supabase.auth.admin.listUserSessions(userId);
+    if (error) {
+      throw new Error(error.message);
+    }
+    return (data || []).map((session: any) => ({
+      id: session.id,
+      createdAt: session.created_at,
+      lastActiveAt: session.user_metadata?.last_activity,
+      ipAddress: session.ip_address,
+      userAgent: session.user_agent,
+      // Preserve original metadata for policy checks
+      user_metadata: session.user_metadata,
+      created_at: session.created_at,
+    })) as any;
+  }
+
+  async deleteUserSession(userId: string, sessionId: string): Promise<void> {
+    const { error } = await this.supabase.auth.admin.deleteUserSession(userId, sessionId);
+    if (error) {
+      throw new Error(error.message);
+    }
+  }
+}

--- a/src/adapters/supabase-factory.ts
+++ b/src/adapters/supabase-factory.ts
@@ -10,12 +10,14 @@ import { AuthDataProvider } from './auth/interfaces';
 import { UserDataProvider } from './user/interfaces';
 import { TeamDataProvider } from './team/interfaces';
 import { PermissionDataProvider } from './permission/interfaces';
+import { SessionDataProvider } from './session/interfaces';
 
 // Import domain-specific factories
 import createSupabaseAuthProvider from './auth/supabase/factory';
 import createSupabaseUserProvider from './user/supabase/factory';
 import createSupabaseTeamProvider from './team/supabase/factory';
 import createSupabasePermissionProvider from './permission/supabase/factory';
+import { createSupabaseSessionProvider } from './session/factory';
 
 /**
  * Factory for creating Supabase adapters
@@ -69,6 +71,13 @@ export class SupabaseAdapterFactory implements AdapterFactory {
    */
   createPermissionProvider(): PermissionDataProvider {
     return createSupabasePermissionProvider(this.options);
+  }
+
+  /**
+   * Create a Supabase session provider
+   */
+  createSessionProvider(): SessionDataProvider {
+    return createSupabaseSessionProvider(this.options);
   }
 }
 

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Session Domain Exports
+ */
+
+export * from './interfaces';
+export * from './models';

--- a/src/core/session/interfaces.ts
+++ b/src/core/session/interfaces.ts
@@ -1,0 +1,22 @@
+/**
+ * Session Service Interfaces
+ *
+ * Defines the contracts for session management services.
+ */
+
+import { SessionInfo } from './models';
+
+/**
+ * Core session service interface
+ */
+export interface SessionService {
+  /**
+   * List all sessions for the specified user
+   */
+  listUserSessions(userId: string): Promise<SessionInfo[]>;
+
+  /**
+   * Revoke a specific session for the user
+   */
+  revokeUserSession(userId: string, sessionId: string): Promise<void>;
+}

--- a/src/core/session/models.ts
+++ b/src/core/session/models.ts
@@ -1,0 +1,23 @@
+/**
+ * Session Management Models
+ *
+ * Defines the core entities used for session management.
+ */
+
+/**
+ * Basic information about a user session
+ */
+export interface SessionInfo {
+  /** Unique session identifier */
+  id: string;
+  /** Timestamp when the session was created */
+  createdAt: string;
+  /** Timestamp of the last recorded activity */
+  lastActiveAt?: string;
+  /** IP address associated with the session */
+  ipAddress?: string;
+  /** User agent string for the session */
+  userAgent?: string;
+  /** True if this is the currently authenticated session */
+  isCurrent?: boolean;
+}


### PR DESCRIPTION
## Summary
- implement session domain interfaces and models
- create session adapter with Supabase provider and factory
- extend adapter registry and Supabase factory for session provider
- refactor session API routes to use the new provider

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined, etc.)*