### PR TITLE
Implement audit log adapter

### DIFF
--- a/src/adapters/audit/__tests__/supabase-audit-adapter.test.ts
+++ b/src/adapters/audit/__tests__/supabase-audit-adapter.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SupabaseAuditAdapter } from '../supabase-adapter';
+import { setTableMockData, resetSupabaseMock } from '@/tests/mocks/supabase';
+
+const SUPABASE_URL = 'http://localhost';
+const SUPABASE_KEY = 'anon';
+
+const logRecord = {
+  id: 1,
+  created_at: '2024-01-01T00:00:00Z',
+  user_id: 'user-1',
+  action: 'LOGIN',
+  status: 'SUCCESS',
+  ip_address: '127.0.0.1',
+  user_agent: 'test',
+  target_resource_type: 'auth',
+  target_resource_id: 'user-1',
+  details: { foo: 'bar' },
+};
+
+describe('SupabaseAuditAdapter', () => {
+  beforeEach(() => {
+    resetSupabaseMock();
+    setTableMockData('user_actions_log', { data: [logRecord], error: null, count: 1 });
+  });
+
+  it('fetches user action logs', async () => {
+    const adapter = new SupabaseAuditAdapter(SUPABASE_URL, SUPABASE_KEY);
+    const { logs, count } = await adapter.getUserActionLogs({ page: 1, limit: 10 });
+
+    expect(count).toBe(1);
+    expect(logs[0]).toEqual({
+      id: '1',
+      createdAt: '2024-01-01T00:00:00Z',
+      userId: 'user-1',
+      action: 'LOGIN',
+      status: 'SUCCESS',
+      ipAddress: '127.0.0.1',
+      userAgent: 'test',
+      targetResourceType: 'auth',
+      targetResourceId: 'user-1',
+      details: { foo: 'bar' },
+    });
+  });
+});

--- a/src/adapters/audit/factory.ts
+++ b/src/adapters/audit/factory.ts
@@ -1,0 +1,24 @@
+import { AuditDataProvider } from './interfaces';
+import { SupabaseAuditAdapter } from './supabase-adapter';
+
+export function createSupabaseAuditProvider(
+  supabaseUrl: string,
+  supabaseKey: string
+): AuditDataProvider {
+  return new SupabaseAuditAdapter(supabaseUrl, supabaseKey);
+}
+
+export function createAuditProvider(config: {
+  type: 'supabase' | string;
+  options: Record<string, any>;
+}): AuditDataProvider {
+  switch (config.type) {
+    case 'supabase':
+      return createSupabaseAuditProvider(
+        config.options.supabaseUrl,
+        config.options.supabaseKey
+      );
+    default:
+      throw new Error(`Unsupported audit provider type: ${config.type}`);
+  }
+}

--- a/src/adapters/audit/index.ts
+++ b/src/adapters/audit/index.ts
@@ -1,0 +1,3 @@
+export * from './interfaces';
+export * from './factory';
+export * from './supabase-adapter';

--- a/src/adapters/audit/interfaces.ts
+++ b/src/adapters/audit/interfaces.ts
@@ -1,0 +1,7 @@
+import { AuditLogEntry, AuditLogQuery } from '@/core/audit/models';
+
+export interface AuditDataProvider {
+  getUserActionLogs(
+    query: AuditLogQuery
+  ): Promise<{ logs: AuditLogEntry[]; count: number }>;
+}

--- a/src/adapters/audit/supabase-adapter.ts
+++ b/src/adapters/audit/supabase-adapter.ts
@@ -1,0 +1,65 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { AuditDataProvider } from './interfaces';
+import { AuditLogEntry, AuditLogQuery } from '@/core/audit/models';
+
+export class SupabaseAuditAdapter implements AuditDataProvider {
+  private supabase: SupabaseClient;
+
+  constructor(supabaseUrl: string, supabaseKey: string) {
+    this.supabase = createClient(supabaseUrl, supabaseKey);
+  }
+
+  private mapDbLog(record: any): AuditLogEntry {
+    return {
+      id: record.id.toString(),
+      createdAt: record.created_at,
+      userId: record.user_id || undefined,
+      action: record.action,
+      status: record.status,
+      ipAddress: record.ip_address || undefined,
+      userAgent: record.user_agent || undefined,
+      targetResourceType: record.target_resource_type || undefined,
+      targetResourceId: record.target_resource_id || undefined,
+      details: record.details || undefined,
+    };
+  }
+
+  async getUserActionLogs(
+    query: AuditLogQuery
+  ): Promise<{ logs: AuditLogEntry[]; count: number }> {
+    let q = this.supabase
+      .from('user_actions_log')
+      .select('*', { count: 'exact' });
+
+    if (query.userId) q = q.eq('user_id', query.userId);
+    if (query.startDate) q = q.gte('created_at', query.startDate);
+    if (query.endDate) q = q.lte('created_at', query.endDate);
+    if (query.action) q = q.eq('action', query.action);
+    if (query.status) q = q.eq('status', query.status);
+    if (query.resourceType) q = q.eq('target_resource_type', query.resourceType);
+    if (query.resourceId) q = q.eq('target_resource_id', query.resourceId);
+    if (query.ipAddress) q = q.ilike('ip_address', `%${query.ipAddress}%`);
+    if (query.userAgent) q = q.ilike('user_agent', `%${query.userAgent}%`);
+    if (query.search) {
+      q = q.or(
+        `action.ilike.%${query.search}%,details::text.ilike.%${query.search}%,error.ilike.%${query.search}%,target_resource_id.ilike.%${query.search}%,target_resource_type.ilike.%${query.search}%`
+      );
+    }
+
+    const sortBy = query.sortBy || 'created_at';
+    const ascending = query.sortOrder === 'asc';
+
+    q = q.order(sortBy, { ascending }).range(
+      (query.page - 1) * query.limit,
+      query.page * query.limit - 1
+    );
+
+    const { data, error, count } = await q;
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    const logs = (data || []).map((r: any) => this.mapDbLog(r));
+    return { logs, count: count ?? logs.length };
+  }
+}

--- a/src/core/audit/index.ts
+++ b/src/core/audit/index.ts
@@ -1,0 +1,2 @@
+export * from './interfaces';
+export * from './models';

--- a/src/core/audit/interfaces.ts
+++ b/src/core/audit/interfaces.ts
@@ -1,0 +1,8 @@
+import { PaginationMeta } from '@/lib/api/common/response-formatter';
+import { AuditLogEntry, AuditLogQuery } from './models';
+
+export interface AuditService {
+  getUserActionLogs(
+    query: AuditLogQuery
+  ): Promise<{ logs: AuditLogEntry[]; pagination: PaginationMeta }>;
+}

--- a/src/core/audit/models.ts
+++ b/src/core/audit/models.ts
@@ -1,0 +1,31 @@
+export interface AuditLogEntry {
+  id: string;
+  createdAt: string;
+  userId?: string;
+  action: string;
+  status: AuditLogStatus;
+  ipAddress?: string;
+  userAgent?: string;
+  targetResourceType?: string;
+  targetResourceId?: string;
+  details?: Record<string, any>;
+}
+
+export type AuditLogStatus = 'SUCCESS' | 'FAILURE' | 'INITIATED' | 'COMPLETED';
+
+export interface AuditLogQuery {
+  page: number;
+  limit: number;
+  userId?: string;
+  action?: string;
+  status?: AuditLogStatus;
+  resourceType?: string;
+  resourceId?: string;
+  startDate?: string;
+  endDate?: string;
+  ipAddress?: string;
+  userAgent?: string;
+  search?: string;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
+}


### PR DESCRIPTION
## Summary
- add AuditLogEntry models and AuditService interface
- implement SupabaseAuditAdapter and provider factory
- expose audit core and adapter modules
- refactor audit log API route to use provider
- test SupabaseAuditAdapter

## Testing
- `npx vitest run --coverage src/adapters/audit/__tests__/supabase-audit-adapter.test.ts`