### PR TITLE
Add SSO architecture modules

### DIFF
--- a/app/api/sso/__tests__/route.test.ts
+++ b/app/api/sso/__tests__/route.test.ts
@@ -1,21 +1,55 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GET, POST } from '../route';
+import { getApiSsoService } from '@/lib/api/sso/factory';
 
-const mockRequest = (body: any) => new Request('http://localhost', { method: 'POST', body: JSON.stringify(body) });
+vi.mock('@/lib/api/sso/factory', () => ({
+  getApiSsoService: vi.fn(),
+}));
+
+const mockRequest = (body: any) =>
+  new Request('http://localhost/api/sso', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
 
 describe('/api/sso', () => {
+  const mockService = {
+    getProviders: vi.fn(),
+    upsertProvider: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiSsoService as unknown as vi.Mock).mockReturnValue(mockService);
+    mockService.getProviders.mockResolvedValue([]);
+    mockService.upsertProvider.mockResolvedValue({
+      id: '1',
+      organizationId: 'org1',
+      providerType: 'saml',
+      providerName: 'google',
+      config: {},
+      isActive: true,
+    });
+  });
   it('GET returns providers array', async () => {
-    const res = await GET();
+    const res = await GET(new Request('http://localhost/api/sso?organizationId=org1'));
     const json = await res.json();
     expect(Array.isArray(json.providers)).toBe(true);
+    expect(mockService.getProviders).toHaveBeenCalledWith('org1');
   });
 
   it('POST returns success for valid input', async () => {
-    const req = mockRequest({ provider: 'google', config: { clientId: 'abc' } });
+    const req = mockRequest({
+      organizationId: 'org1',
+      providerType: 'saml',
+      providerName: 'google',
+      config: { clientId: 'abc' },
+    });
     const res = await POST(req);
     const json = await res.json();
     expect(json.success).toBe(true);
-    expect(json.provider.provider).toBe('google');
+    expect(json.provider.providerName).toBe('google');
   });
 
   it('POST returns 400 for invalid input', async () => {

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -10,6 +10,7 @@ export * from './auth';
 export * from './user';
 export * from './team';
 export * from './permission';
+export * from './sso';
 export * from './notification';
 
 // Import and register the Supabase adapter factory by default

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -11,6 +11,7 @@ import { AuthDataProvider } from './auth/interfaces';
 import { UserDataProvider } from './user/interfaces';
 import { TeamDataProvider } from './team/interfaces';
 import { PermissionDataProvider } from './permission/interfaces';
+import { SsoDataProvider } from './sso/interfaces';
 
 /**
  * Interface for adapter factory options
@@ -43,6 +44,11 @@ export interface AdapterFactory {
    * Create a permission data provider
    */
   createPermissionProvider(): PermissionDataProvider;
+
+  /**
+   * Create an SSO data provider
+   */
+  createSsoProvider(): SsoDataProvider;
 }
 
 /**

--- a/src/adapters/sso/factory.ts
+++ b/src/adapters/sso/factory.ts
@@ -1,0 +1,30 @@
+/**
+ * SSO Provider Factory
+ *
+ * Provides factory functions for creating SSO data providers.
+ */
+
+import { SsoDataProvider } from './interfaces';
+import { SupabaseSsoProvider } from './supabase-adapter';
+
+export function createSupabaseSsoProvider(
+  supabaseUrl: string,
+  supabaseKey: string
+): SsoDataProvider {
+  return new SupabaseSsoProvider(supabaseUrl, supabaseKey);
+}
+
+export function createSsoProvider(config: {
+  type: 'supabase' | string;
+  options: Record<string, any>;
+}): SsoDataProvider {
+  switch (config.type) {
+    case 'supabase':
+      return createSupabaseSsoProvider(
+        config.options.supabaseUrl,
+        config.options.supabaseKey
+      );
+    default:
+      throw new Error(`Unsupported SSO provider type: ${config.type}`);
+  }
+}

--- a/src/adapters/sso/index.ts
+++ b/src/adapters/sso/index.ts
@@ -1,0 +1,3 @@
+export * from './interfaces';
+export * from './factory';
+export * from './supabase-adapter';

--- a/src/adapters/sso/interfaces.ts
+++ b/src/adapters/sso/interfaces.ts
@@ -1,0 +1,20 @@
+/**
+ * SSO Data Provider Interface
+ *
+ * This interface abstracts the database/API layer for SSO operations,
+ * following the adapter pattern from the architecture guidelines.
+ */
+
+import { SsoProvider, SsoProviderPayload } from '../../core/sso/models';
+
+export interface SsoDataProvider {
+  /**
+   * List active SSO providers for an organization
+   */
+  listProviders(organizationId: string): Promise<SsoProvider[]>;
+
+  /**
+   * Create or update an SSO provider
+   */
+  upsertProvider(payload: SsoProviderPayload): Promise<SsoProvider>;
+}

--- a/src/adapters/sso/supabase-adapter.ts
+++ b/src/adapters/sso/supabase-adapter.ts
@@ -1,0 +1,73 @@
+/**
+ * Supabase SSO Data Provider Implementation
+ *
+ * This class implements the SsoDataProvider interface using Supabase
+ * as the underlying storage mechanism.
+ */
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { SsoProvider, SsoProviderPayload } from '../../core/sso/models';
+import { SsoDataProvider } from './interfaces';
+
+export class SupabaseSsoProvider implements SsoDataProvider {
+  private supabase: SupabaseClient;
+
+  constructor(supabaseUrl: string, supabaseKey: string) {
+    this.supabase = createClient(supabaseUrl, supabaseKey);
+  }
+
+  async listProviders(organizationId: string): Promise<SsoProvider[]> {
+    const { data, error } = await this.supabase
+      .from('sso_providers')
+      .select('*')
+      .eq('organization_id', organizationId)
+      .eq('is_active', true);
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    return (data || []).map(this.mapRecordToProvider);
+  }
+
+  async upsertProvider(payload: SsoProviderPayload): Promise<SsoProvider> {
+    const { data, error } = await this.supabase
+      .from('sso_providers')
+      .upsert(
+        {
+          organization_id: payload.organizationId,
+          provider_type: payload.providerType,
+          provider_name: payload.providerName,
+          config: payload.config,
+          is_active: true,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'organization_id,provider_type,provider_name' }
+      )
+      .select()
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    if (!data) {
+      throw new Error('Failed to upsert SSO provider');
+    }
+
+    return this.mapRecordToProvider(data);
+  }
+
+  private mapRecordToProvider(record: any): SsoProvider {
+    return {
+      id: record.id,
+      organizationId: record.organization_id,
+      providerType: record.provider_type,
+      providerName: record.provider_name,
+      config: record.config || {},
+      isActive: record.is_active,
+      createdAt: record.created_at,
+      updatedAt: record.updated_at,
+    };
+  }
+}

--- a/src/adapters/sso/supabase/factory.ts
+++ b/src/adapters/sso/supabase/factory.ts
@@ -1,0 +1,16 @@
+/**
+ * Supabase SSO Adapter Factory
+ */
+
+import { SsoDataProvider } from '../interfaces';
+import { SupabaseSsoProvider } from '../supabase-adapter';
+
+export function createSupabaseSsoProvider(options: {
+  supabaseUrl: string;
+  supabaseKey: string;
+  [key: string]: any;
+}): SsoDataProvider {
+  return new SupabaseSsoProvider(options.supabaseUrl, options.supabaseKey);
+}
+
+export default createSupabaseSsoProvider;

--- a/src/adapters/supabase-factory.ts
+++ b/src/adapters/supabase-factory.ts
@@ -10,12 +10,14 @@ import { AuthDataProvider } from './auth/interfaces';
 import { UserDataProvider } from './user/interfaces';
 import { TeamDataProvider } from './team/interfaces';
 import { PermissionDataProvider } from './permission/interfaces';
+import { SsoDataProvider } from './sso/interfaces';
 
 // Import domain-specific factories
 import createSupabaseAuthProvider from './auth/supabase/factory';
 import createSupabaseUserProvider from './user/supabase/factory';
 import createSupabaseTeamProvider from './team/supabase/factory';
 import createSupabasePermissionProvider from './permission/supabase/factory';
+import createSupabaseSsoProvider from './sso/supabase/factory';
 
 /**
  * Factory for creating Supabase adapters
@@ -69,6 +71,13 @@ export class SupabaseAdapterFactory implements AdapterFactory {
    */
   createPermissionProvider(): PermissionDataProvider {
     return createSupabasePermissionProvider(this.options);
+  }
+
+  /**
+   * Create a Supabase SSO provider
+   */
+  createSsoProvider(): SsoDataProvider {
+    return createSupabaseSsoProvider(this.options);
   }
 }
 

--- a/src/core/initialization/initialize-adapters.ts
+++ b/src/core/initialization/initialize-adapters.ts
@@ -10,6 +10,7 @@ import { DefaultAuthService } from '@/services/auth/default-auth-service';
 import { DefaultUserService } from '@/services/user/default-user-service';
 import { DefaultTeamService } from '@/services/team/default-team-service';
 import { DefaultPermissionService } from '@/services/permission/default-permission-service';
+import { DefaultSsoService } from '@/services/sso/default-sso.service';
 import { UserManagementConfiguration } from '@/core/config';
 import { isServer } from '../platform';
 
@@ -72,23 +73,27 @@ export function initializeAdapters(
     const userAdapter = factory.createUserProvider();
     const teamAdapter = factory.createTeamProvider();
     const permissionAdapter = factory.createPermissionProvider();
+    const ssoAdapter = factory.createSsoProvider();
     
     // Create service instances with the adapters
     const authService = new DefaultAuthService(authAdapter);
     const userService = new DefaultUserService(userAdapter);
     const teamService = new DefaultTeamService(teamAdapter);
     const permissionService = new DefaultPermissionService(permissionAdapter);
+    const ssoService = new DefaultSsoService(ssoAdapter);
     
     return {
       authService,
       userService,
       teamService,
       permissionService,
+      ssoService,
       adapters: {
         authAdapter,
         userAdapter,
         teamAdapter,
-        permissionAdapter
+        permissionAdapter,
+        ssoAdapter
       }
     };
   } catch (error) {
@@ -114,6 +119,7 @@ export function initializeUserManagement(config = {}, options = {}) {
       userService: services.userService,
       teamService: services.teamService,
       permissionService: services.permissionService,
+      ssoService: services.ssoService,
       ...options.serviceProviders
     },
     options: {

--- a/src/core/sso/index.ts
+++ b/src/core/sso/index.ts
@@ -1,0 +1,2 @@
+export * from './interfaces';
+export * from './models';

--- a/src/core/sso/interfaces.ts
+++ b/src/core/sso/interfaces.ts
@@ -1,0 +1,22 @@
+/**
+ * SSO Service Interface
+ *
+ * This file defines the core interfaces for the SSO domain.
+ */
+
+import { SsoProvider, SsoProviderPayload } from './models';
+
+/**
+ * SSO service interface used by the API layer and hooks
+ */
+export interface SsoService {
+  /**
+   * Get all active SSO providers for an organization
+   */
+  getProviders(organizationId: string): Promise<SsoProvider[]>;
+
+  /**
+   * Create or update an SSO provider for an organization
+   */
+  upsertProvider(payload: SsoProviderPayload): Promise<SsoProvider>;
+}

--- a/src/core/sso/models.ts
+++ b/src/core/sso/models.ts
@@ -1,0 +1,55 @@
+/**
+ * SSO Domain Models
+ *
+ * This file defines the core entity models for the SSO domain.
+ * These models represent SSO providers and related payloads.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Supported SSO provider types
+ */
+export type SsoProviderType = 'saml' | 'oidc';
+
+/**
+ * SSO provider entity
+ */
+export interface SsoProvider {
+  /** Unique identifier */
+  id: string;
+  /** Organization the provider belongs to */
+  organizationId: string;
+  /** Provider type (e.g. saml or oidc) */
+  providerType: SsoProviderType;
+  /** Name of the provider */
+  providerName: string;
+  /** Provider configuration stored as JSON */
+  config: Record<string, any>;
+  /** Whether the provider is active */
+  isActive: boolean;
+  /** Creation timestamp */
+  createdAt?: string;
+  /** Update timestamp */
+  updatedAt?: string;
+}
+
+/**
+ * Payload for creating/updating an SSO provider
+ */
+export interface SsoProviderPayload {
+  organizationId: string;
+  providerType: SsoProviderType;
+  providerName: string;
+  config: Record<string, any>;
+}
+
+// Validation schema used by API routes
+export const ssoProviderSchema = z.object({
+  organizationId: z.string().uuid(),
+  providerType: z.enum(['saml', 'oidc']),
+  providerName: z.string().min(1),
+  config: z.record(z.any()),
+});
+
+export type SsoProviderData = z.infer<typeof ssoProviderSchema>;

--- a/src/services/sso/default-sso.service.ts
+++ b/src/services/sso/default-sso.service.ts
@@ -1,0 +1,19 @@
+/**
+ * Default SSO Service Implementation
+ */
+
+import { SsoService } from '@/core/sso/interfaces';
+import { SsoDataProvider } from '@/adapters/sso/interfaces';
+import { SsoProvider, SsoProviderPayload } from '@/core/sso/models';
+
+export class DefaultSsoService implements SsoService {
+  constructor(private readonly provider: SsoDataProvider) {}
+
+  async getProviders(organizationId: string): Promise<SsoProvider[]> {
+    return this.provider.listProviders(organizationId);
+  }
+
+  async upsertProvider(payload: SsoProviderPayload): Promise<SsoProvider> {
+    return this.provider.upsertProvider(payload);
+  }
+}

--- a/src/services/sso/index.ts
+++ b/src/services/sso/index.ts
@@ -1,0 +1,21 @@
+/**
+ * SSO Service Factory
+ */
+
+import { AxiosInstance } from 'axios';
+import { SsoService } from '@/core/sso/interfaces';
+import { DefaultSsoService } from './default-sso.service';
+import { SsoDataProvider } from '@/adapters/sso/interfaces';
+
+export interface SsoServiceConfig {
+  apiClient: AxiosInstance;
+  ssoDataProvider: SsoDataProvider;
+}
+
+export function createSsoService(config: SsoServiceConfig): SsoService {
+  return new DefaultSsoService(config.ssoDataProvider);
+}
+
+export default {
+  createSsoService,
+};


### PR DESCRIPTION
## Summary
- implement core SSO models and interfaces
- add adapter interfaces and Supabase implementation
- extend adapter factory and registry for SSO
- create default SSO service
- refactor SSO API route to use new service
- update tests

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined, etc.)*