### PR TITLE
Implement subscription core and adapter layer

### DIFF
--- a/app/api/subscription/route.ts
+++ b/app/api/subscription/route.ts
@@ -1,5 +1,6 @@
 import { stripe, createCustomer, createSubscription } from '@/lib/payments/stripe';
 import { getServiceSupabase } from '@/lib/database/supabase';
+import { SupabaseSubscriptionAdapter } from '@/adapters/subscription/supabase-adapter';
 import { z } from 'zod';
 import { NextResponse } from 'next/server';
 
@@ -8,6 +9,10 @@ const SubscriptionSchema = z.object({ plan: z.string() });
 export async function GET(request: Request) {
   // Assume auth header is present and valid
   const supabase = getServiceSupabase();
+  const provider = new SupabaseSubscriptionAdapter(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
   const authHeader = request.headers.get('authorization');
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
@@ -18,14 +23,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: userError?.message || 'Invalid token' }, { status: 401 });
   }
   // Fetch subscription from DB
-  const { data: subscription, error: subError } = await supabase
-    .from('subscriptions')
-    .select('*')
-    .eq('user_id', user.id)
-    .maybeSingle();
-  if (subError) {
-    return NextResponse.json({ error: 'Failed to fetch subscription' }, { status: 500 });
-  }
+  const subscription = await provider.getUserSubscription(user.id);
   if (!subscription) {
     return NextResponse.json({ subscription: null });
   }
@@ -43,6 +41,10 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   const supabase = getServiceSupabase();
+  const provider = new SupabaseSubscriptionAdapter(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
   const authHeader = request.headers.get('authorization');
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
@@ -59,13 +61,9 @@ export async function POST(request: Request) {
   }
   // Check if user already has a Stripe customer
   let customerId = null;
-  const { data: existingSub } = await supabase
-    .from('subscriptions')
-    .select('customer_id')
-    .eq('user_id', user.id)
-    .maybeSingle();
-  if (existingSub && existingSub.customer_id) {
-    customerId = existingSub.customer_id;
+  const existing = await provider.getUserSubscription(user.id);
+  if (existing && (existing as any).customer_id) {
+    customerId = (existing as any).customer_id;
   } else {
     // Create Stripe customer
     const customer = await createCustomer({
@@ -88,17 +86,12 @@ export async function POST(request: Request) {
   } catch (e: any) {
     return NextResponse.json({ error: e.message || 'Stripe error' }, { status: 400 });
   }
-  // Upsert subscription in DB
-  await supabase.from('subscriptions').upsert({
-    user_id: user.id,
-    customer_id: customerId,
-    stripe_subscription_id: stripeSub.id,
-    plan: priceId,
+  await provider.upsertSubscription({
+    userId: user.id,
+    planId: priceId,
+    id: existing?.id,
     status: stripeSub.status,
-    current_period_end: stripeSub.current_period_end ? new Date(stripeSub.current_period_end * 1000).toISOString() : null,
-    cancel_at_period_end: stripeSub.cancel_at_period_end,
-    trial_end: stripeSub.trial_end ? new Date(stripeSub.trial_end * 1000).toISOString() : null,
-    updated_at: new Date().toISOString(),
+    startDate: new Date().toISOString(),
   });
   return NextResponse.json({ success: true, subscription: stripeSub });
 } 

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -11,6 +11,7 @@ export * from './user';
 export * from './team';
 export * from './permission';
 export * from './notification';
+export * from './subscription';
 
 // Import and register the Supabase adapter factory by default
 import { AdapterRegistry } from './registry';

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -11,6 +11,7 @@ import { AuthDataProvider } from './auth/interfaces';
 import { UserDataProvider } from './user/interfaces';
 import { TeamDataProvider } from './team/interfaces';
 import { PermissionDataProvider } from './permission/interfaces';
+import { SubscriptionDataProvider } from './subscription/interfaces';
 
 /**
  * Interface for adapter factory options
@@ -38,11 +39,16 @@ export interface AdapterFactory {
    * Create a team data provider
    */
   createTeamProvider(): TeamDataProvider;
-  
+
   /**
    * Create a permission data provider
    */
   createPermissionProvider(): PermissionDataProvider;
+
+  /**
+   * Create a subscription data provider
+   */
+  createSubscriptionProvider(): SubscriptionDataProvider;
 }
 
 /**

--- a/src/adapters/subscription/__tests__/supabase-adapter.test.ts
+++ b/src/adapters/subscription/__tests__/supabase-adapter.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SupabaseSubscriptionAdapter } from '../supabase-adapter';
+import { setTableMockData, resetSupabaseMock } from '@/tests/mocks/supabase';
+
+const SUPABASE_URL = 'http://localhost';
+const SUPABASE_KEY = 'anon';
+
+const subRecord = {
+  id: 'sub-1',
+  user_id: 'user-1',
+  plan_id: 'plan-1',
+  status: 'active',
+  start_date: '2024-01-01T00:00:00Z',
+};
+
+const planRecord = { id: 'plan-1', name: 'Pro', tier: 'premium', price: 10, period: 'monthly', features: [], is_public: true, trial_days: 0 };
+
+describe('SupabaseSubscriptionAdapter', () => {
+  beforeEach(() => {
+    resetSupabaseMock();
+    setTableMockData('subscriptions', { data: [subRecord], error: null });
+    setTableMockData('subscription_plans', { data: [planRecord], error: null });
+  });
+
+  it('retrieves a user subscription', async () => {
+    const provider = new SupabaseSubscriptionAdapter(SUPABASE_URL, SUPABASE_KEY);
+    const result = await provider.getUserSubscription('user-1');
+    expect(result?.id).toBe('sub-1');
+    expect(result?.planId).toBe('plan-1');
+  });
+
+  it('lists plans', async () => {
+    const provider = new SupabaseSubscriptionAdapter(SUPABASE_URL, SUPABASE_KEY);
+    const plans = await provider.getPlans();
+    expect(plans[0]?.id).toBe('plan-1');
+  });
+});

--- a/src/adapters/subscription/factory.ts
+++ b/src/adapters/subscription/factory.ts
@@ -1,0 +1,18 @@
+import { SubscriptionDataProvider } from './interfaces';
+import { SupabaseSubscriptionAdapter } from './supabase-adapter';
+
+export function createSupabaseSubscriptionProvider(options: { supabaseUrl: string; supabaseKey: string }): SubscriptionDataProvider {
+  return new SupabaseSubscriptionAdapter(options.supabaseUrl, options.supabaseKey);
+}
+
+export function createSubscriptionProvider(config: { type: 'supabase' | string; options: Record<string, any> }): SubscriptionDataProvider {
+  switch (config.type) {
+    case 'supabase':
+      return createSupabaseSubscriptionProvider({
+        supabaseUrl: config.options.supabaseUrl,
+        supabaseKey: config.options.supabaseKey,
+      });
+    default:
+      throw new Error(`Unsupported subscription provider type: ${config.type}`);
+  }
+}

--- a/src/adapters/subscription/index.ts
+++ b/src/adapters/subscription/index.ts
@@ -1,0 +1,3 @@
+export * from './interfaces';
+export * from './factory';
+export * from './supabase-adapter';

--- a/src/adapters/subscription/interfaces.ts
+++ b/src/adapters/subscription/interfaces.ts
@@ -1,0 +1,15 @@
+/**
+ * Subscription Data Provider Interface
+ */
+import type { SubscriptionPlan, UserSubscription } from '../../core/subscription/models';
+
+export interface SubscriptionDataProvider {
+  /** Fetch available subscription plans */
+  getPlans(): Promise<SubscriptionPlan[]>;
+
+  /** Fetch subscription for a user */
+  getUserSubscription(userId: string): Promise<UserSubscription | null>;
+
+  /** Upsert subscription record */
+  upsertSubscription(subscription: Partial<UserSubscription> & { userId: string; planId: string }): Promise<UserSubscription>;
+}

--- a/src/adapters/subscription/supabase-adapter.ts
+++ b/src/adapters/subscription/supabase-adapter.ts
@@ -1,0 +1,84 @@
+/**
+ * Supabase implementation of the SubscriptionDataProvider
+ */
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { SubscriptionDataProvider } from './interfaces';
+import type { SubscriptionPlan, UserSubscription } from '../../core/subscription/models';
+
+export class SupabaseSubscriptionAdapter implements SubscriptionDataProvider {
+  private supabase: SupabaseClient;
+
+  constructor(private supabaseUrl: string, private supabaseKey: string) {
+    this.supabase = createClient(this.supabaseUrl, this.supabaseKey);
+  }
+
+  async getPlans(): Promise<SubscriptionPlan[]> {
+    const { data, error } = await this.supabase.from('subscription_plans').select('*').eq('is_active', true);
+    if (error || !data) return [];
+    return data.map((p: any) => this.mapPlan(p));
+  }
+
+  async getUserSubscription(userId: string): Promise<UserSubscription | null> {
+    const { data, error } = await this.supabase
+      .from('subscriptions')
+      .select('*')
+      .eq('user_id', userId)
+      .maybeSingle();
+    if (error || !data) return null;
+    return this.mapSubscription(data);
+  }
+
+  async upsertSubscription(sub: Partial<UserSubscription> & { userId: string; planId: string }): Promise<UserSubscription> {
+    const { data, error } = await this.supabase
+      .from('subscriptions')
+      .upsert({
+        id: sub.id,
+        user_id: sub.userId,
+        plan_id: sub.planId,
+        status: sub.status,
+        start_date: sub.startDate,
+        end_date: sub.endDate,
+        renewal_date: sub.renewalDate,
+        canceled_at: sub.canceledAt,
+        payment_method: sub.paymentMethod,
+        metadata: sub.metadata,
+        updated_at: new Date().toISOString(),
+      })
+      .select('*')
+      .single();
+    if (error || !data) {
+      throw new Error(error?.message || 'Failed to upsert subscription');
+    }
+    return this.mapSubscription(data);
+  }
+
+  private mapPlan(p: any): SubscriptionPlan {
+    return {
+      id: p.id,
+      name: p.name,
+      tier: p.tier,
+      price: p.price,
+      period: p.period,
+      features: p.features || [],
+      isPublic: p.is_public ?? true,
+      trialDays: p.trial_days ?? 0,
+      metadata: p.metadata || {},
+    } as SubscriptionPlan;
+  }
+
+  private mapSubscription(s: any): UserSubscription {
+    return {
+      id: s.id,
+      userId: s.user_id,
+      planId: s.plan_id,
+      status: s.status,
+      startDate: s.start_date,
+      endDate: s.end_date,
+      renewalDate: s.renewal_date,
+      canceledAt: s.canceled_at,
+      paymentMethod: s.payment_method,
+      paymentProviderData: s.payment_provider_data,
+      metadata: s.metadata,
+    } as UserSubscription;
+  }
+}

--- a/src/adapters/supabase-factory.ts
+++ b/src/adapters/supabase-factory.ts
@@ -10,12 +10,14 @@ import { AuthDataProvider } from './auth/interfaces';
 import { UserDataProvider } from './user/interfaces';
 import { TeamDataProvider } from './team/interfaces';
 import { PermissionDataProvider } from './permission/interfaces';
+import { SubscriptionDataProvider } from './subscription/interfaces';
 
 // Import domain-specific factories
 import createSupabaseAuthProvider from './auth/supabase/factory';
 import createSupabaseUserProvider from './user/supabase/factory';
 import createSupabaseTeamProvider from './team/supabase/factory';
 import createSupabasePermissionProvider from './permission/supabase/factory';
+import createSupabaseSubscriptionProvider from './subscription/factory';
 
 /**
  * Factory for creating Supabase adapters
@@ -69,6 +71,13 @@ export class SupabaseAdapterFactory implements AdapterFactory {
    */
   createPermissionProvider(): PermissionDataProvider {
     return createSupabasePermissionProvider(this.options);
+  }
+
+  /**
+   * Create a Supabase subscription provider
+   */
+  createSubscriptionProvider(): SubscriptionDataProvider {
+    return createSupabaseSubscriptionProvider(this.options);
   }
 }
 

--- a/src/core/subscription/index.ts
+++ b/src/core/subscription/index.ts
@@ -1,0 +1,4 @@
+// Subscription Domain Index
+
+export * from './interfaces';
+export * from './models';

--- a/src/core/subscription/interfaces.ts
+++ b/src/core/subscription/interfaces.ts
@@ -1,0 +1,32 @@
+/**
+ * Subscription Service Interface
+ */
+import type { SubscriptionPlan, UserSubscription } from './models';
+
+export interface SubscriptionService {
+  /**
+   * Fetch all available subscription plans
+   */
+  getPlans(): Promise<SubscriptionPlan[]>;
+
+  /**
+   * Get a subscription for a user
+   * @param userId User identifier
+   */
+  getUserSubscription(userId: string): Promise<UserSubscription | null>;
+
+  /**
+   * Create a new subscription for a user
+   */
+  createSubscription(userId: string, planId: string): Promise<UserSubscription>;
+
+  /**
+   * Cancel an existing subscription
+   */
+  cancelSubscription(subscriptionId: string, immediate?: boolean): Promise<void>;
+
+  /**
+   * Update a subscription's plan
+   */
+  updateSubscription(subscriptionId: string, planId: string): Promise<UserSubscription>;
+}

--- a/src/core/subscription/models.ts
+++ b/src/core/subscription/models.ts
@@ -1,0 +1,22 @@
+/**
+ * Subscription Domain Models
+ */
+import {
+  SubscriptionPlan,
+  UserSubscription,
+  SubscriptionTier,
+  SubscriptionStatus,
+  SubscriptionPeriod,
+  subscriptionPlanSchema,
+  userSubscriptionSchema,
+} from '@/types/subscription';
+
+export {
+  SubscriptionPlan,
+  UserSubscription,
+  SubscriptionTier,
+  SubscriptionStatus,
+  SubscriptionPeriod,
+  subscriptionPlanSchema,
+  userSubscriptionSchema,
+};


### PR DESCRIPTION
## Summary
- add subscription core models and interfaces
- implement Supabase subscription adapter and factory
- register subscription provider in adapter registry
- refactor subscription API route to use new adapter
- add tests for Supabase subscription adapter

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*