### PR TITLE
Add TOTP two-factor components

### DIFF
--- a/src/ui/headless/two-factor/TwoFactorDisable.tsx
+++ b/src/ui/headless/two-factor/TwoFactorDisable.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { useMFA } from '@/hooks/auth/useMFA';
+
+export interface TwoFactorDisableRenderProps {
+  code: string;
+  setCode: (code: string) => void;
+  submit: () => Promise<void>;
+  loading: boolean;
+  error?: string;
+}
+
+export interface TwoFactorDisableProps {
+  onSuccess?: () => void;
+  onCancel?: () => void;
+  children: (props: TwoFactorDisableRenderProps) => React.ReactNode;
+}
+
+export function TwoFactorDisable({ onSuccess, onCancel, children }: TwoFactorDisableProps) {
+  const { disableMFA, isLoading, error } = useMFA();
+  const [code, setCode] = useState('');
+
+  const submit = async () => {
+    const res = await disableMFA(code);
+    if (res.success) {
+      onSuccess?.();
+    }
+  };
+
+  return <>{children({ code, setCode, submit, loading: isLoading, error: error || undefined })}</>;
+}
+
+export default TwoFactorDisable;

--- a/src/ui/headless/two-factor/TwoFactorSetup.tsx
+++ b/src/ui/headless/two-factor/TwoFactorSetup.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { useMFA } from '@/hooks/auth/useMFA';
+
+export interface TwoFactorSetupRenderProps {
+  step: 'initial' | 'verify' | 'complete';
+  secret?: string;
+  qrCode?: string;
+  backupCodes?: string[];
+  start: () => Promise<void>;
+  verify: (code: string) => Promise<void>;
+  cancel: () => void;
+  loading: boolean;
+  error?: string;
+}
+
+export interface TwoFactorSetupProps {
+  onComplete?: (codes: string[]) => void;
+  onCancel?: () => void;
+  children: (props: TwoFactorSetupRenderProps) => React.ReactNode;
+}
+
+export function TwoFactorSetup({ onComplete, onCancel, children }: TwoFactorSetupProps) {
+  const { setupMFA, verifyMFA, isLoading, error } = useMFA();
+  const [step, setStep] = useState<'initial' | 'verify' | 'complete'>('initial');
+  const [secret, setSecret] = useState<string | undefined>();
+  const [qrCode, setQrCode] = useState<string | undefined>();
+  const [backupCodes, setBackupCodes] = useState<string[] | undefined>();
+
+  const start = async () => {
+    const res = await setupMFA();
+    if (res.success) {
+      setSecret(res.secret);
+      setQrCode(res.qrCode);
+      setStep('verify');
+    }
+  };
+
+  const verify = async (code: string) => {
+    const res = await verifyMFA(code);
+    if (res.success) {
+      setBackupCodes(res.backupCodes);
+      setStep('complete');
+      onComplete?.(res.backupCodes ?? []);
+    }
+  };
+
+  const cancel = () => {
+    onCancel?.();
+  };
+
+  return (
+    <>{children({ step, secret, qrCode, backupCodes, start, verify, cancel, loading: isLoading, error: error || undefined })}</>
+  );
+}
+
+export default TwoFactorSetup;

--- a/src/ui/headless/two-factor/TwoFactorVerify.tsx
+++ b/src/ui/headless/two-factor/TwoFactorVerify.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { useMFA } from '@/hooks/auth/useMFA';
+
+export interface TwoFactorVerifyRenderProps {
+  code: string;
+  setCode: (code: string) => void;
+  submit: () => Promise<void>;
+  loading: boolean;
+  error?: string;
+}
+
+export interface TwoFactorVerifyProps {
+  onSuccess?: () => void;
+  children: (props: TwoFactorVerifyRenderProps) => React.ReactNode;
+}
+
+export function TwoFactorVerify({ onSuccess, children }: TwoFactorVerifyProps) {
+  const { verifyMFA, isLoading, error } = useMFA();
+  const [code, setCode] = useState('');
+
+  const submit = async () => {
+    const res = await verifyMFA(code);
+    if (res.success) {
+      onSuccess?.();
+    }
+  };
+
+  return <>{children({ code, setCode, submit, loading: isLoading, error: error || undefined })}</>;
+}
+
+export default TwoFactorVerify;

--- a/src/ui/headless/two-factor/__tests__/TwoFactorDisable.test.tsx
+++ b/src/ui/headless/two-factor/__tests__/TwoFactorDisable.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { TwoFactorDisable } from '../TwoFactorDisable';
+
+vi.mock('@/hooks/auth/useMFA', () => ({
+  useMFA: vi.fn()
+}));
+
+import { useMFA } from '@/hooks/auth/useMFA';
+
+describe('TwoFactorDisable', () => {
+  it('calls disableMFA with code', async () => {
+    const disable = vi.fn().mockResolvedValue({ success: true });
+    (useMFA as unknown as vi.Mock).mockReturnValue({ disableMFA: disable, isLoading: false, error: null });
+    const onSuccess = vi.fn();
+    let handlers: any;
+    render(
+      <TwoFactorDisable onSuccess={onSuccess}>
+        {(props) => { handlers = props; return <div />; }}
+      </TwoFactorDisable>
+    );
+    await act(async () => { handlers.setCode('000000'); });
+    await act(async () => { await handlers.submit(); });
+    expect(disable).toHaveBeenCalledWith('000000');
+    expect(onSuccess).toHaveBeenCalled();
+  });
+});

--- a/src/ui/headless/two-factor/__tests__/TwoFactorSetup.test.tsx
+++ b/src/ui/headless/two-factor/__tests__/TwoFactorSetup.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { TwoFactorSetup } from '../TwoFactorSetup';
+
+vi.mock('@/hooks/auth/useMFA', () => ({
+  useMFA: vi.fn()
+}));
+
+import { useMFA } from '@/hooks/auth/useMFA';
+
+describe('TwoFactorSetup', () => {
+  it('calls setup and verify functions', async () => {
+    const setup = vi.fn().mockResolvedValue({ success: true, secret: 's', qrCode: 'q' });
+    const verify = vi.fn().mockResolvedValue({ success: true, backupCodes: ['a'] });
+    (useMFA as unknown as vi.Mock).mockReturnValue({ setupMFA: setup, verifyMFA: verify, isLoading: false, error: null });
+    const onComplete = vi.fn();
+    let handlers: any;
+    render(
+      <TwoFactorSetup onComplete={onComplete}>
+        {(props) => {
+          handlers = props; return <div />;
+        }}
+      </TwoFactorSetup>
+    );
+    await act(async () => { await handlers.start(); });
+    expect(setup).toHaveBeenCalled();
+    await act(async () => { await handlers.verify('123456'); });
+    expect(verify).toHaveBeenCalledWith('123456');
+    expect(onComplete).toHaveBeenCalledWith(['a']);
+  });
+});

--- a/src/ui/headless/two-factor/__tests__/TwoFactorVerify.test.tsx
+++ b/src/ui/headless/two-factor/__tests__/TwoFactorVerify.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { TwoFactorVerify } from '../TwoFactorVerify';
+
+vi.mock('@/hooks/auth/useMFA', () => ({
+  useMFA: vi.fn()
+}));
+
+import { useMFA } from '@/hooks/auth/useMFA';
+
+describe('TwoFactorVerify', () => {
+  it('submits code for verification', async () => {
+    const verify = vi.fn().mockResolvedValue({ success: true });
+    (useMFA as unknown as vi.Mock).mockReturnValue({ verifyMFA: verify, isLoading: false, error: null });
+    const onSuccess = vi.fn();
+    let handlers: any;
+    render(
+      <TwoFactorVerify onSuccess={onSuccess}>
+        {(props) => { handlers = props; return <div />; }}
+      </TwoFactorVerify>
+    );
+    await act(async () => { handlers.setCode('111111'); });
+    await act(async () => { await handlers.submit(); });
+    expect(verify).toHaveBeenCalledWith('111111');
+    expect(onSuccess).toHaveBeenCalled();
+  });
+});

--- a/src/ui/styled/two-factor/BackupCodesList.tsx
+++ b/src/ui/styled/two-factor/BackupCodesList.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { useState } from 'react';
+import { Button } from '@/ui/primitives/button';
+
+export interface BackupCodesListProps {
+  codes: string[];
+}
+
+export function BackupCodesList({ codes }: BackupCodesListProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(codes.join('\n'));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const download = () => {
+    const blob = new Blob([codes.join('\n')], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'backup-codes.txt';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-2 gap-2">
+        {codes.map((c) => (
+          <div key={c} className="font-mono text-sm p-2 bg-muted rounded">
+            {c}
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <Button variant="outline" size="sm" onClick={copy}>
+          {copied ? 'Copied' : 'Copy'}
+        </Button>
+        <Button variant="outline" size="sm" onClick={download}>
+          Download
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default BackupCodesList;

--- a/src/ui/styled/two-factor/QRCodeDisplay.tsx
+++ b/src/ui/styled/two-factor/QRCodeDisplay.tsx
@@ -1,0 +1,29 @@
+'use client';
+import { Button } from '@/ui/primitives/button';
+
+export interface QRCodeDisplayProps {
+  qrCode?: string;
+  secret?: string;
+  onCopySecret?: () => void;
+}
+
+export function QRCodeDisplay({ qrCode, secret, onCopySecret }: QRCodeDisplayProps) {
+  return (
+    <div className="flex flex-col items-center gap-2">
+      {qrCode && <img src={qrCode} alt="QR Code" className="w-40 h-40" />}
+      {secret && (
+        <div className="text-center">
+          <p className="text-sm text-muted-foreground">Secret Key</p>
+          <code className="px-2 py-1 bg-muted rounded text-sm">{secret}</code>
+          <div>
+            <Button variant="link" size="sm" onClick={onCopySecret}>
+              Copy
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default QRCodeDisplay;

--- a/src/ui/styled/two-factor/TwoFactorDisable.tsx
+++ b/src/ui/styled/two-factor/TwoFactorDisable.tsx
@@ -1,0 +1,33 @@
+'use client';
+import { useState } from 'react';
+import { Input } from '@/ui/primitives/input';
+import { Button } from '@/ui/primitives/button';
+import { Card } from '@/ui/primitives/card';
+import { TwoFactorDisable as HeadlessTwoFactorDisable } from '@/ui/headless/two-factor/TwoFactorDisable';
+
+export function TwoFactorDisable({ onSuccess, onCancel }: { onSuccess?: () => void; onCancel?: () => void }) {
+  const [code, setCode] = useState('');
+  return (
+    <HeadlessTwoFactorDisable onSuccess={onSuccess} onCancel={onCancel}>
+      {({ code: value, setCode: setValue, submit, loading, error }) => (
+        <Card className="p-4 space-y-4 w-full max-w-sm">
+          <Input
+            placeholder="000000"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            maxLength={6}
+          />
+          {error && <p className="text-destructive text-sm">{error}</p>}
+          <div className="flex gap-2">
+            <Button onClick={submit} disabled={loading || value.length !== 6}>
+              Disable
+            </Button>
+            <Button variant="outline" onClick={onCancel}>Cancel</Button>
+          </div>
+        </Card>
+      )}
+    </HeadlessTwoFactorDisable>
+  );
+}
+
+export default TwoFactorDisable;

--- a/src/ui/styled/two-factor/TwoFactorSetup.tsx
+++ b/src/ui/styled/two-factor/TwoFactorSetup.tsx
@@ -1,0 +1,50 @@
+'use client';
+import { useState } from 'react';
+import { Input } from '@/ui/primitives/input';
+import { Button } from '@/ui/primitives/button';
+import { Card } from '@/ui/primitives/card';
+import { TwoFactorSetup as HeadlessTwoFactorSetup } from '@/ui/headless/two-factor/TwoFactorSetup';
+import QRCodeDisplay from './QRCodeDisplay';
+import BackupCodesList from './BackupCodesList';
+
+export function TwoFactorSetup() {
+  const [code, setCode] = useState('');
+  return (
+    <HeadlessTwoFactorSetup
+      onComplete={() => setCode('')}
+    >
+      {({ step, secret, qrCode, backupCodes, start, verify, cancel, loading, error }) => (
+        <Card className="p-4 space-y-4 w-full max-w-md">
+          {step === 'initial' && (
+            <Button onClick={start} disabled={loading} className="w-full">
+              Enable Two-Factor Authentication
+            </Button>
+          )}
+          {step === 'verify' && (
+            <div className="space-y-4">
+              <QRCodeDisplay qrCode={qrCode} secret={secret} />
+              <Input
+                placeholder="000000"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                maxLength={6}
+              />
+              <div className="flex gap-2">
+                <Button onClick={() => verify(code)} disabled={loading || code.length !== 6}>
+                  Verify
+                </Button>
+                <Button variant="outline" onClick={cancel}>
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          )}
+          {step === 'complete' && backupCodes && <BackupCodesList codes={backupCodes} />}
+          {error && <p className="text-destructive text-sm">{error}</p>}
+        </Card>
+      )}
+    </HeadlessTwoFactorSetup>
+  );
+}
+
+export default TwoFactorSetup;

--- a/src/ui/styled/two-factor/TwoFactorVerify.tsx
+++ b/src/ui/styled/two-factor/TwoFactorVerify.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { useState } from 'react';
+import { Input } from '@/ui/primitives/input';
+import { Button } from '@/ui/primitives/button';
+import { Card } from '@/ui/primitives/card';
+import { TwoFactorVerify as HeadlessTwoFactorVerify } from '@/ui/headless/two-factor/TwoFactorVerify';
+
+export function TwoFactorVerify({ onSuccess }: { onSuccess?: () => void }) {
+  const [code, setCode] = useState('');
+  return (
+    <HeadlessTwoFactorVerify onSuccess={onSuccess}>
+      {({ code: value, setCode: setValue, submit, loading, error }) => (
+        <Card className="p-4 space-y-4 w-full max-w-sm">
+          <Input
+            placeholder="000000"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            maxLength={6}
+          />
+          {error && <p className="text-destructive text-sm">{error}</p>}
+          <Button onClick={submit} disabled={loading || value.length !== 6} className="w-full">
+            Verify
+          </Button>
+        </Card>
+      )}
+    </HeadlessTwoFactorVerify>
+  );
+}
+
+export default TwoFactorVerify;


### PR DESCRIPTION
## Summary
- add new headless components for TOTP setup, verify and disable
- provide styled wrappers with QR code and backup code display
- include unit tests for new headless components

## Testing
- `npx vitest run --coverage src/ui/headless/two-factor/__tests__`