### PR TITLE
Add core webhook interfaces

### DIFF
--- a/src/core/webhooks/IWebhookDataProvider.ts
+++ b/src/core/webhooks/IWebhookDataProvider.ts
@@ -1,0 +1,42 @@
+/**
+ * Webhook Data Provider Interface
+ *
+ * Defines the contract for persistence operations related to webhooks.
+ */
+import type {
+  Webhook,
+  WebhookCreatePayload,
+  WebhookUpdatePayload,
+  WebhookDelivery
+} from './models';
+
+export interface IWebhookDataProvider {
+  /** List all webhooks for a user */
+  listWebhooks(userId: string): Promise<Webhook[]>;
+
+  /** Get a specific webhook owned by the user */
+  getWebhook(userId: string, webhookId: string): Promise<Webhook | null>;
+
+  /** Create a new webhook */
+  createWebhook(userId: string, data: WebhookCreatePayload): Promise<{
+    success: boolean;
+    webhook?: Webhook;
+    error?: string;
+  }>;
+
+  /** Update an existing webhook */
+  updateWebhook(
+    userId: string,
+    webhookId: string,
+    data: WebhookUpdatePayload
+  ): Promise<{ success: boolean; webhook?: Webhook; error?: string }>;
+
+  /** Delete a webhook */
+  deleteWebhook(userId: string, webhookId: string): Promise<{ success: boolean; error?: string }>;
+
+  /** List delivery history for a webhook */
+  listDeliveries(userId: string, webhookId: string, limit?: number): Promise<WebhookDelivery[]>;
+
+  /** Record a webhook delivery attempt */
+  recordDelivery(delivery: WebhookDelivery): Promise<void>;
+}

--- a/src/core/webhooks/IWebhookService.ts
+++ b/src/core/webhooks/IWebhookService.ts
@@ -1,0 +1,37 @@
+/**
+ * Webhook Service Interface
+ *
+ * Provides high level business logic for managing webhooks and sending events.
+ */
+import type { Webhook, WebhookCreatePayload, WebhookUpdatePayload, WebhookDelivery } from './models';
+
+export interface IWebhookService {
+  /** Create a new webhook for the given user */
+  createWebhook(userId: string, data: WebhookCreatePayload): Promise<{
+    success: boolean;
+    webhook?: Webhook;
+    error?: string;
+  }>;
+
+  /** Return all webhooks belonging to the user */
+  getWebhooks(userId: string): Promise<Webhook[]>;
+
+  /** Get a single webhook by id */
+  getWebhook(userId: string, webhookId: string): Promise<Webhook | null>;
+
+  /** Update a webhook */
+  updateWebhook(
+    userId: string,
+    webhookId: string,
+    data: WebhookUpdatePayload
+  ): Promise<{ success: boolean; webhook?: Webhook; error?: string }>;
+
+  /** Remove a webhook */
+  deleteWebhook(userId: string, webhookId: string): Promise<{ success: boolean; error?: string }>;
+
+  /** Get delivery history for a webhook */
+  getWebhookDeliveries(userId: string, webhookId: string, limit?: number): Promise<WebhookDelivery[]>;
+
+  /** Trigger an event for all matching webhooks */
+  triggerEvent(eventType: string, payload: unknown, userId?: string): Promise<WebhookDelivery[]>;
+}

--- a/src/core/webhooks/__tests__/models.test.ts
+++ b/src/core/webhooks/__tests__/models.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { webhookCreateSchema, webhookUpdateSchema } from '../models';
+
+describe('webhook schemas', () => {
+  it('validates create payload', () => {
+    const result = webhookCreateSchema.parse({
+      name: 'My Hook',
+      url: 'https://example.com',
+      events: ['user.created']
+    });
+    expect(result.isActive).toBe(true);
+  });
+
+  it('rejects invalid create payload', () => {
+    expect(() =>
+      webhookCreateSchema.parse({ name: '', url: 'bad', events: [] })
+    ).toThrow();
+  });
+
+  it('allows partial update payload', () => {
+    const payload = webhookUpdateSchema.parse({ name: 'New', isActive: false });
+    expect(payload.name).toBe('New');
+    expect(payload.isActive).toBe(false);
+  });
+});

--- a/src/core/webhooks/index.ts
+++ b/src/core/webhooks/index.ts
@@ -1,0 +1,3 @@
+export * from './IWebhookDataProvider';
+export * from './IWebhookService';
+export * from './models';

--- a/src/core/webhooks/models/index.ts
+++ b/src/core/webhooks/models/index.ts
@@ -1,0 +1,2 @@
+export * from './webhook';
+export * from './webhook-delivery';

--- a/src/core/webhooks/models/webhook-delivery.ts
+++ b/src/core/webhooks/models/webhook-delivery.ts
@@ -1,0 +1,21 @@
+/**
+ * Webhook delivery record
+ */
+export interface WebhookDelivery {
+  /** Unique delivery identifier */
+  id: string;
+  /** Related webhook id */
+  webhookId: string;
+  /** Event type that triggered the delivery */
+  eventType: string;
+  /** Payload sent */
+  payload: unknown;
+  /** HTTP status code returned by target */
+  statusCode?: number;
+  /** Response body */
+  response?: string;
+  /** Error message if delivery failed */
+  error?: string;
+  /** Timestamp when delivery occurred */
+  createdAt: string;
+}

--- a/src/core/webhooks/models/webhook.ts
+++ b/src/core/webhooks/models/webhook.ts
@@ -1,0 +1,45 @@
+/**
+ * Webhook entity and payload definitions
+ */
+import { z } from 'zod';
+
+/** Basic webhook record */
+export interface Webhook {
+  /** Unique identifier */
+  id: string;
+  /** Owner of the webhook */
+  userId: string;
+  /** Friendly name */
+  name: string;
+  /** Target URL */
+  url: string;
+  /** Events this webhook subscribes to */
+  events: string[];
+  /** Secret used for signing */
+  secret: string;
+  /** Whether the webhook is active */
+  isActive: boolean;
+  /** Creation timestamp */
+  createdAt: string;
+  /** Last update timestamp */
+  updatedAt?: string;
+}
+
+/** Payload for creating a webhook */
+export const webhookCreateSchema = z.object({
+  name: z.string().min(1, { message: 'Name is required' }),
+  url: z.string().url({ message: 'Valid URL is required' }),
+  events: z.array(z.string()).min(1, { message: 'At least one event is required' }),
+  isActive: z.boolean().optional().default(true)
+});
+export type WebhookCreatePayload = z.infer<typeof webhookCreateSchema>;
+
+/** Payload for updating a webhook */
+export const webhookUpdateSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  url: z.string().url().optional(),
+  events: z.array(z.string()).min(1).optional(),
+  isActive: z.boolean().optional(),
+  regenerateSecret: z.boolean().optional()
+});
+export type WebhookUpdatePayload = z.infer<typeof webhookUpdateSchema>;

--- a/src/lib/api/webhooks/factory.ts
+++ b/src/lib/api/webhooks/factory.ts
@@ -5,20 +5,20 @@
  * It ensures consistent configuration and dependency injection across all API endpoints.
  */
 
-import { WebhookService } from '@/core/webhook/interfaces';
+import { IWebhookService } from '@/core/webhooks';
 import { UserManagementConfiguration } from '@/core/config';
 import { createWebhookProvider } from '@/adapters/webhook/factory';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
 // Singleton instance for API routes
-let webhookServiceInstance: WebhookService | null = null;
+let webhookServiceInstance: IWebhookService | null = null;
 
 /**
  * Get the configured webhook service instance for API routes
  * 
- * @returns Configured WebhookService instance
+ * @returns Configured IWebhookService instance
  */
-export function getApiWebhookService(): WebhookService {
+export function getApiWebhookService(): IWebhookService {
   if (!webhookServiceInstance) {
     // Get Supabase configuration from the existing service
     const supabase = getServiceSupabase();
@@ -33,7 +33,7 @@ export function getApiWebhookService(): WebhookService {
     });
     
     // Create webhook service with the data provider
-    webhookServiceInstance = UserManagementConfiguration.getServiceProvider('webhookService') as WebhookService;
+    webhookServiceInstance = UserManagementConfiguration.getServiceProvider('webhookService') as IWebhookService;
     
     // If no webhook service is registered, throw an error
     if (!webhookServiceInstance) {


### PR DESCRIPTION
## Summary
- define Webhook models under `src/core/webhooks/models`
- add `IWebhookDataProvider` and `IWebhookService` interfaces
- export webhook types via `src/core/webhooks/index.ts`
- update API webhook factory to import new interface
- include basic schema tests

## Testing
- `npm run test:coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*