### PR TITLE
Add Supabase webhook adapter

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -17,6 +17,7 @@ export * from './gdpr';
 export * from './session';
 export * from './subscription';
 export * from './csrf';
+export * from './webhook';
 
 
 // Import and register the Supabase adapter factory by default

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -16,6 +16,7 @@ import { SessionDataProvider } from './session/interfaces';
 import { SsoDataProvider } from './sso/interfaces';
 import { SubscriptionDataProvider } from './subscription/interfaces';
 import { ApiKeyDataProvider } from './api-keys/interfaces';
+import { IWebhookDataProvider } from './webhook/IWebhookDataProvider';
 
 
 /**
@@ -75,6 +76,11 @@ export interface AdapterFactory {
    * Create an API key data provider
    */
   createApiKeyProvider(): ApiKeyDataProvider;
+
+  /**
+   * Create a webhook data provider
+   */
+  createWebhookProvider?(): IWebhookDataProvider;
 }
 
 /**

--- a/src/adapters/supabase-factory.ts
+++ b/src/adapters/supabase-factory.ts
@@ -16,6 +16,7 @@ import { SessionDataProvider } from './session/interfaces';
 import { SsoDataProvider } from './sso/interfaces';
 import { SubscriptionDataProvider } from './subscription/interfaces';
 import { ApiKeyDataProvider } from './api-keys/interfaces';
+import { IWebhookDataProvider } from './webhook/IWebhookDataProvider';
 
 
 // Import domain-specific factories
@@ -28,6 +29,7 @@ import { createSupabaseSessionProvider } from './session/factory';
 import createSupabaseSsoProvider from './sso/supabase/factory';
 import createSupabaseSubscriptionProvider from './subscription/factory';
 import createSupabaseApiKeyProvider from './api-keys/supabase/factory';
+import { createSupabaseWebhookProvider } from './webhook';
 
 
 /**
@@ -118,6 +120,13 @@ export class SupabaseAdapterFactory implements AdapterFactory {
    */
   createApiKeyProvider(): ApiKeyDataProvider {
     return createSupabaseApiKeyProvider(this.options);
+  }
+
+  /**
+   * Create a Supabase webhook provider
+   */
+  createWebhookProvider(): IWebhookDataProvider {
+    return createSupabaseWebhookProvider(this.options);
   }
   }
 }

--- a/src/adapters/webhook/IWebhookDataProvider.ts
+++ b/src/adapters/webhook/IWebhookDataProvider.ts
@@ -1,0 +1,32 @@
+export interface Webhook {
+  id: string;
+  userId: string;
+  url: string;
+  events: string[];
+  secret: string;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WebhookCreatePayload {
+  url: string;
+  events: string[];
+  secret: string;
+  isActive?: boolean;
+}
+
+export interface WebhookUpdatePayload {
+  url?: string;
+  events?: string[];
+  secret?: string;
+  isActive?: boolean;
+}
+
+export interface IWebhookDataProvider {
+  listWebhooks(userId: string): Promise<Webhook[]>;
+  getWebhook(id: string): Promise<Webhook | null>;
+  createWebhook(userId: string, data: WebhookCreatePayload): Promise<Webhook>;
+  updateWebhook(id: string, data: WebhookUpdatePayload): Promise<Webhook | null>;
+  deleteWebhook(id: string): Promise<void>;
+}

--- a/src/adapters/webhook/SupabaseWebhookProvider.ts
+++ b/src/adapters/webhook/SupabaseWebhookProvider.ts
@@ -1,0 +1,94 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import {
+  IWebhookDataProvider,
+  Webhook,
+  WebhookCreatePayload,
+  WebhookUpdatePayload
+} from './IWebhookDataProvider';
+
+export class SupabaseWebhookProvider implements IWebhookDataProvider {
+  private supabase: SupabaseClient;
+
+  constructor(private supabaseUrl: string, private supabaseKey: string) {
+    this.supabase = createClient(this.supabaseUrl, this.supabaseKey);
+  }
+
+  async listWebhooks(userId: string): Promise<Webhook[]> {
+    const { data, error } = await this.supabase
+      .from('webhooks')
+      .select('*')
+      .eq('user_id', userId);
+
+    if (error || !data) return [];
+    return data.map(r => this.mapRecord(r));
+  }
+
+  async getWebhook(id: string): Promise<Webhook | null> {
+    const { data, error } = await this.supabase
+      .from('webhooks')
+      .select('*')
+      .eq('id', id)
+      .maybeSingle();
+    if (error || !data) return null;
+    return this.mapRecord(data);
+  }
+
+  async createWebhook(userId: string, payload: WebhookCreatePayload): Promise<Webhook> {
+    const { data, error } = await this.supabase
+      .from('webhooks')
+      .insert({
+        user_id: userId,
+        url: payload.url,
+        events: payload.events,
+        secret: payload.secret,
+        is_active: payload.isActive ?? true,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString()
+      })
+      .select('*')
+      .single();
+
+    if (error || !data) {
+      throw new Error(error?.message || 'Failed to create webhook');
+    }
+    return this.mapRecord(data);
+  }
+
+  async updateWebhook(id: string, payload: WebhookUpdatePayload): Promise<Webhook | null> {
+    const { data, error } = await this.supabase
+      .from('webhooks')
+      .update({
+        url: payload.url,
+        events: payload.events,
+        secret: payload.secret,
+        is_active: payload.isActive,
+        updated_at: new Date().toISOString()
+      })
+      .eq('id', id)
+      .select('*')
+      .maybeSingle();
+
+    if (error || !data) return null;
+    return this.mapRecord(data);
+  }
+
+  async deleteWebhook(id: string): Promise<void> {
+    const { error } = await this.supabase.from('webhooks').delete().eq('id', id);
+    if (error) {
+      throw new Error(error.message);
+    }
+  }
+
+  private mapRecord(record: any): Webhook {
+    return {
+      id: record.id,
+      userId: record.user_id,
+      url: record.url,
+      events: record.events,
+      secret: record.secret,
+      isActive: record.is_active,
+      createdAt: record.created_at,
+      updatedAt: record.updated_at
+    };
+  }
+}

--- a/src/adapters/webhook/__tests__/supabase-webhook-provider.test.ts
+++ b/src/adapters/webhook/__tests__/supabase-webhook-provider.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SupabaseWebhookProvider } from '../SupabaseWebhookProvider';
+import { setTableMockData, resetSupabaseMock } from '@/tests/mocks/supabase';
+
+const SUPABASE_URL = 'http://localhost';
+const SUPABASE_KEY = 'anon';
+
+const webhookRecord = {
+  id: 'wh-1',
+  user_id: 'user-1',
+  url: 'https://example.com',
+  events: ['user.created'],
+  secret: 'secret',
+  is_active: true,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z'
+};
+
+describe('SupabaseWebhookProvider', () => {
+  beforeEach(() => {
+    resetSupabaseMock();
+    setTableMockData('webhooks', { data: [webhookRecord], error: null });
+  });
+
+  it('lists webhooks for a user', async () => {
+    const provider = new SupabaseWebhookProvider(SUPABASE_URL, SUPABASE_KEY);
+    const hooks = await provider.listWebhooks('user-1');
+    expect(hooks[0]?.id).toBe('wh-1');
+  });
+
+  it('fetches a webhook by id', async () => {
+    const provider = new SupabaseWebhookProvider(SUPABASE_URL, SUPABASE_KEY);
+    const hook = await provider.getWebhook('wh-1');
+    expect(hook?.id).toBe('wh-1');
+  });
+
+  it('creates a webhook', async () => {
+    setTableMockData('webhooks', { data: webhookRecord, error: null });
+    const provider = new SupabaseWebhookProvider(SUPABASE_URL, SUPABASE_KEY);
+    const result = await provider.createWebhook('user-1', {
+      url: 'https://example.com',
+      events: ['user.created'],
+      secret: 'secret'
+    });
+    expect(result.id).toBe('wh-1');
+  });
+
+  it('updates a webhook', async () => {
+    setTableMockData('webhooks', { data: { ...webhookRecord, url: 'https://new.url' }, error: null });
+    const provider = new SupabaseWebhookProvider(SUPABASE_URL, SUPABASE_KEY);
+    const result = await provider.updateWebhook('wh-1', { url: 'https://new.url' });
+    expect(result?.url).toBe('https://new.url');
+  });
+
+  it('deletes a webhook', async () => {
+    setTableMockData('webhooks', { data: null, error: null });
+    const provider = new SupabaseWebhookProvider(SUPABASE_URL, SUPABASE_KEY);
+    await expect(provider.deleteWebhook('wh-1')).resolves.not.toThrow();
+  });
+});

--- a/src/adapters/webhook/index.ts
+++ b/src/adapters/webhook/index.ts
@@ -1,0 +1,27 @@
+export * from './IWebhookDataProvider';
+export * from './SupabaseWebhookProvider';
+
+import { IWebhookDataProvider } from './IWebhookDataProvider';
+import { SupabaseWebhookProvider } from './SupabaseWebhookProvider';
+
+export function createSupabaseWebhookProvider(options: {
+  supabaseUrl: string;
+  supabaseKey: string;
+  [key: string]: any;
+}): IWebhookDataProvider {
+  return new SupabaseWebhookProvider(options.supabaseUrl, options.supabaseKey);
+}
+
+export function createWebhookProvider(config: {
+  type: 'supabase' | string;
+  options: Record<string, any>;
+}): IWebhookDataProvider {
+  switch (config.type) {
+    case 'supabase':
+      return createSupabaseWebhookProvider(config.options);
+    default:
+      throw new Error(`Unsupported webhook provider type: ${config.type}`);
+  }
+}
+
+export default createSupabaseWebhookProvider;


### PR DESCRIPTION
## Summary
- implement `SupabaseWebhookProvider` with CRUD operations
- expose factory helpers for webhook adapters
- register webhook provider in adapter registry and Supabase factory
- add unit tests for the provider

## Testing
- `npx vitest run --coverage` *(fails: many unrelated tests fail)*