### PR TITLE
Implement address management

### DIFF
--- a/app/api/addresses/[id]/__tests__/route.test.ts
+++ b/app/api/addresses/[id]/__tests__/route.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET, PUT, DELETE } from '../route';
+import { getApiAddressService } from '@/lib/api/address/factory';
+
+vi.mock('@/lib/api/address/factory', () => ({
+  getApiAddressService: vi.fn(),
+}));
+
+describe('[id] address API', () => {
+  const service = {
+    getAddress: vi.fn(async () => ({})),
+    updateAddress: vi.fn(async () => ({})),
+    deleteAddress: vi.fn(async () => {}),
+  } as any;
+
+  beforeEach(() => {
+    vi.mocked(getApiAddressService).mockReturnValue(service);
+    vi.clearAllMocks();
+  });
+
+  it('GET returns address', async () => {
+    const req = new NextRequest('http://test');
+    req.headers.set('x-user-id', 'u1');
+    const res = await GET(req as any, { params: { id: '1' } });
+    expect(res.status).toBe(200);
+    expect(service.getAddress).toHaveBeenCalledWith('1', 'u1');
+  });
+
+  it('PUT updates address', async () => {
+    const req = new NextRequest('http://test', { method: 'PUT', body: '{}' });
+    req.headers.set('x-user-id', 'u1');
+    (req as any).json = async () => ({ fullName: 'John' });
+    const res = await PUT(req as any, { params: { id: '1' } });
+    expect(res.status).toBe(200);
+    expect(service.updateAddress).toHaveBeenCalled();
+  });
+
+  it('DELETE deletes address', async () => {
+    const req = new NextRequest('http://test', { method: 'DELETE' });
+    req.headers.set('x-user-id', 'u1');
+    const res = await DELETE(req as any, { params: { id: '1' } });
+    expect(res.status).toBe(204);
+    expect(service.deleteAddress).toHaveBeenCalledWith('1', 'u1');
+  });
+});

--- a/app/api/addresses/[id]/route.ts
+++ b/app/api/addresses/[id]/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getApiAddressService } from '@/lib/api/address/factory';
+import { addressSchema } from '@/core/address/validation';
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const userId = req.headers.get('x-user-id');
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const service = getApiAddressService();
+  const address = await service.getAddress(params.id, userId);
+  return NextResponse.json({ address });
+}
+
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  const userId = req.headers.get('x-user-id');
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const data = await req.json();
+  const parse = addressSchema.partial().safeParse(data);
+  if (!parse.success) return NextResponse.json({ error: parse.error.message }, { status: 400 });
+  const service = getApiAddressService();
+  const updated = await service.updateAddress(params.id, parse.data, userId);
+  return NextResponse.json({ address: updated });
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  const userId = req.headers.get('x-user-id');
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const service = getApiAddressService();
+  await service.deleteAddress(params.id, userId);
+  return NextResponse.json({}, { status: 204 });
+}

--- a/app/api/addresses/__tests__/route.test.ts
+++ b/app/api/addresses/__tests__/route.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST, GET } from '../route';
+import { getApiAddressService } from '@/lib/api/address/factory';
+
+vi.mock('@/lib/api/address/factory', () => ({
+  getApiAddressService: vi.fn(),
+}));
+
+describe('addresses API', () => {
+  const service = {
+    getAddresses: vi.fn(async () => []),
+    createAddress: vi.fn(async (a: any) => a),
+  } as any;
+
+  beforeEach(() => {
+    vi.mocked(getApiAddressService).mockReturnValue(service);
+    vi.clearAllMocks();
+  });
+
+  it('GET returns addresses', async () => {
+    const req = new NextRequest('http://test');
+    req.headers.set('x-user-id', 'u1');
+    const res = await GET(req as any);
+    expect(res.status).toBe(200);
+    expect(service.getAddresses).toHaveBeenCalledWith('u1');
+  });
+
+  it('POST creates address', async () => {
+    const req = new NextRequest('http://test', { method: 'POST', body: JSON.stringify({ type: 'shipping', fullName: 'John', street1: '123', city: 'A', state: 'B', postalCode: '1', country: 'US' }) });
+    req.headers.set('x-user-id', 'u1');
+    (req as any).json = async () => ({ type: 'shipping', fullName: 'John', street1: '123', city: 'A', state: 'B', postalCode: '1', country: 'US' });
+    const res = await POST(req as any);
+    expect(res.status).toBe(201);
+    expect(service.createAddress).toHaveBeenCalled();
+  });
+});

--- a/app/api/addresses/default/[id]/__tests__/route.test.ts
+++ b/app/api/addresses/default/[id]/__tests__/route.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST } from '../route';
+import { getApiAddressService } from '@/lib/api/address/factory';
+
+vi.mock('@/lib/api/address/factory', () => ({
+  getApiAddressService: vi.fn(),
+}));
+
+describe('default address API', () => {
+  const service = { setDefaultAddress: vi.fn(async () => {}) } as any;
+
+  beforeEach(() => {
+    vi.mocked(getApiAddressService).mockReturnValue(service);
+    vi.clearAllMocks();
+  });
+
+  it('sets default address', async () => {
+    const req = new NextRequest('http://test', { method: 'POST' });
+    req.headers.set('x-user-id', 'u1');
+    const res = await POST(req as any, { params: { id: '1' } });
+    expect(res.status).toBe(204);
+    expect(service.setDefaultAddress).toHaveBeenCalledWith('1', 'u1');
+  });
+});

--- a/app/api/addresses/default/[id]/route.ts
+++ b/app/api/addresses/default/[id]/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getApiAddressService } from '@/lib/api/address/factory';
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const userId = req.headers.get('x-user-id');
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const service = getApiAddressService();
+  await service.setDefaultAddress(params.id, userId);
+  return NextResponse.json({}, { status: 204 });
+}

--- a/app/api/addresses/route.ts
+++ b/app/api/addresses/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getApiAddressService } from '@/lib/api/address/factory';
+import { addressSchema } from '@/core/address/validation';
+
+export async function GET(req: NextRequest) {
+  const userId = req.headers.get('x-user-id');
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const service = getApiAddressService();
+  const addresses = await service.getAddresses(userId);
+  return NextResponse.json({ addresses });
+}
+
+export async function POST(req: NextRequest) {
+  const userId = req.headers.get('x-user-id');
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const data = await req.json();
+  const parse = addressSchema.safeParse(data);
+  if (!parse.success) return NextResponse.json({ error: parse.error.message }, { status: 400 });
+  const service = getApiAddressService();
+  const address = await service.createAddress({ ...parse.data, userId });
+  return NextResponse.json({ address }, { status: 201 });
+}

--- a/src/core/address/__tests__/validation.test.ts
+++ b/src/core/address/__tests__/validation.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { addressSchema } from '../validation';
+
+describe('addressSchema', () => {
+  it('validates required fields', () => {
+    const result = addressSchema.safeParse({ type: 'shipping', fullName: '', street1: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('passes valid data', () => {
+    const result = addressSchema.safeParse({ type: 'billing', fullName: 'John', street1: '123', city: 'A', state: 'B', postalCode: '1', country: 'US' });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/core/address/index.ts
+++ b/src/core/address/index.ts
@@ -1,2 +1,3 @@
 export * from './interfaces';
 export * from './models';
+export * from './types';

--- a/src/core/address/interfaces.ts
+++ b/src/core/address/interfaces.ts
@@ -1,8 +1,18 @@
 import { CompanyAddress, AddressCreatePayload, AddressUpdatePayload, AddressResult } from './models';
+import type { Address } from './types';
 
-export interface AddressService {
+export interface CompanyAddressService {
   createAddress(companyId: string, address: AddressCreatePayload): Promise<AddressResult>;
   getAddresses(companyId: string): Promise<CompanyAddress[]>;
   updateAddress(companyId: string, addressId: string, update: AddressUpdatePayload): Promise<AddressResult>;
   deleteAddress(companyId: string, addressId: string): Promise<{ success: boolean; error?: string }>;
+}
+
+export interface AddressService {
+  getAddresses(userId: string): Promise<Address[]>;
+  getAddress(id: string, userId: string): Promise<Address>;
+  createAddress(address: Omit<Address, 'id' | 'createdAt' | 'updatedAt'>): Promise<Address>;
+  updateAddress(id: string, updates: Partial<Address>, userId: string): Promise<Address>;
+  deleteAddress(id: string, userId: string): Promise<void>;
+  setDefaultAddress(id: string, userId: string): Promise<void>;
 }

--- a/src/core/address/types.ts
+++ b/src/core/address/types.ts
@@ -1,0 +1,17 @@
+export interface Address {
+  id: string;
+  userId: string;
+  type: 'billing' | 'shipping' | 'both';
+  isDefault: boolean;
+  fullName: string;
+  company?: string;
+  street1: string;
+  street2?: string;
+  city: string;
+  state: string;
+  postalCode: string;
+  country: string;
+  phone?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/core/address/validation.ts
+++ b/src/core/address/validation.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const addressSchema = z.object({
+  type: z.enum(['billing', 'shipping', 'both']),
+  fullName: z.string().min(1, 'Full name is required'),
+  street1: z.string().min(1, 'Street address is required'),
+  street2: z.string().optional(),
+  city: z.string().min(1, 'City is required'),
+  state: z.string().min(1, 'State is required'),
+  postalCode: z.string().min(1, 'Postal code is required'),
+  country: z.string().min(1, 'Country is required'),
+  phone: z.string().optional(),
+  isDefault: z.boolean().optional(),
+  company: z.string().optional(),
+  userId: z.string().optional(),
+});

--- a/src/hooks/address/__tests__/use-addresses.test.tsx
+++ b/src/hooks/address/__tests__/use-addresses.test.tsx
@@ -1,0 +1,39 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useAddresses } from '../use-addresses';
+import { UserManagementConfiguration } from '@/core/config';
+import type { AddressService } from '@/core/address/interfaces';
+
+const mockService: AddressService = {
+  getAddresses: vi.fn(async () => []),
+  getAddress: vi.fn(),
+  createAddress: vi.fn(async (a) => ({ ...a, id: '1', createdAt: new Date(), updatedAt: new Date() } as any)),
+  updateAddress: vi.fn(async (id, updates) => ({ id, userId: 'u1', ...updates } as any)),
+  deleteAddress: vi.fn(async () => {}),
+  setDefaultAddress: vi.fn(async () => {}),
+};
+
+describe('useAddresses', () => {
+  beforeEach(() => {
+    UserManagementConfiguration.reset();
+    UserManagementConfiguration.configureServiceProviders({ addressService: mockService });
+    vi.clearAllMocks();
+  });
+
+  it('fetches addresses on mount', async () => {
+    const { result } = renderHook(() => useAddresses());
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(mockService.getAddresses).toHaveBeenCalled();
+  });
+
+  it('adds address', async () => {
+    const { result } = renderHook(() => useAddresses());
+    await act(async () => {
+      await result.current.addAddress({ userId: 'u1', type: 'shipping', isDefault: false, fullName: 'John', street1: '123', city: 'A', state: 'B', postalCode: '1', country: 'US' });
+    });
+    expect(mockService.createAddress).toHaveBeenCalled();
+    expect(result.current.addresses.length).toBe(1);
+  });
+});

--- a/src/hooks/address/use-addresses.ts
+++ b/src/hooks/address/use-addresses.ts
@@ -1,0 +1,100 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useAuth } from '@/hooks/auth/useAuth';
+import { AddressService } from '@/core/address/interfaces';
+import type { Address } from '@/core/address/types';
+import { UserManagementConfiguration } from '@/core/config';
+
+export function useAddresses() {
+  const addressService = UserManagementConfiguration.getServiceProvider<AddressService>('addressService');
+  if (!addressService) {
+    throw new Error('AddressService is not registered in the service provider registry');
+  }
+
+  const { user } = useAuth();
+  const currentUserId = user?.id || '';
+
+  const [addresses, setAddresses] = useState<Address[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAddresses = useCallback(async () => {
+    if (!currentUserId) return;
+    try {
+      setLoading(true);
+      const userAddresses = await addressService.getAddresses(currentUserId);
+      setAddresses(userAddresses);
+    } catch (err) {
+      setError('Failed to fetch addresses');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }, [addressService, currentUserId]);
+
+  const addAddress = async (address: Omit<Address, 'id' | 'createdAt' | 'updatedAt'>) => {
+    try {
+      setLoading(true);
+      const newAddress = await addressService.createAddress(address);
+      setAddresses(prev => [...prev, newAddress]);
+    } catch (err) {
+      setError('Failed to add address');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateAddress = async (id: string, updates: Partial<Address>) => {
+    try {
+      setLoading(true);
+      const updated = await addressService.updateAddress(id, updates, currentUserId);
+      setAddresses(prev => prev.map(a => (a.id === id ? updated : a)));
+    } catch (err) {
+      setError('Failed to update address');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const deleteAddress = async (id: string) => {
+    try {
+      setLoading(true);
+      await addressService.deleteAddress(id, currentUserId);
+      setAddresses(prev => prev.filter(a => a.id !== id));
+    } catch (err) {
+      setError('Failed to delete address');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const setDefaultAddress = async (id: string) => {
+    try {
+      setLoading(true);
+      await addressService.setDefaultAddress(id, currentUserId);
+      setAddresses(prev => prev.map(a => ({ ...a, isDefault: a.id === id })));
+    } catch (err) {
+      setError('Failed to set default address');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAddresses();
+  }, [fetchAddresses]);
+
+  return {
+    addresses,
+    loading,
+    error,
+    refresh: fetchAddresses,
+    addAddress,
+    updateAddress,
+    deleteAddress,
+    setDefaultAddress
+  };
+}

--- a/src/lib/api/address/factory.ts
+++ b/src/lib/api/address/factory.ts
@@ -5,20 +5,20 @@
  * It ensures consistent configuration and dependency injection across all API endpoints.
  */
 
-import { AddressService } from '@/core/address/interfaces';
+import { CompanyAddressService } from '@/core/address/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
 import { createAddressProvider } from '@/adapters/address/factory';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
 // Singleton instance for API routes
-let addressServiceInstance: AddressService | null = null;
+let addressServiceInstance: CompanyAddressService | null = null;
 
 /**
  * Get the configured address service instance for API routes
  * 
  * @returns Configured AddressService instance
  */
-export function getApiAddressService(): AddressService {
+export function getApiAddressService(): CompanyAddressService {
   if (!addressServiceInstance) {
     // Get Supabase configuration from the existing service
     const supabase = getServiceSupabase();
@@ -33,7 +33,7 @@ export function getApiAddressService(): AddressService {
     });
     
     // Create address service with the data provider
-    addressServiceInstance = UserManagementConfiguration.getServiceProvider('addressService') as AddressService;
+    addressServiceInstance = UserManagementConfiguration.getServiceProvider('addressService') as CompanyAddressService;
     
     // If no address service is registered, throw an error
     if (!addressServiceInstance) {

--- a/src/ui/headless/address/AddressForm.tsx
+++ b/src/ui/headless/address/AddressForm.tsx
@@ -1,0 +1,70 @@
+import type { Address } from '@/core/address/types';
+import React, { useState } from 'react';
+
+export interface AddressFormProps {
+  initialValues?: Partial<Address>;
+  onSubmit: (address: Omit<Address, 'id' | 'createdAt' | 'updatedAt'>) => Promise<void>;
+  onCancel: () => void;
+  loading?: boolean;
+  renderField?: (field: {
+    name: keyof Address;
+    value: string;
+    onChange: (v: string) => void;
+    label: string;
+    error?: string;
+  }) => React.ReactNode;
+}
+
+export function AddressForm({ initialValues = {}, onSubmit, onCancel, loading, renderField }: AddressFormProps) {
+  const [values, setValues] = useState<Omit<Address, 'id' | 'createdAt' | 'updatedAt'>>({
+    userId: initialValues.userId || '',
+    type: initialValues.type || 'shipping',
+    isDefault: initialValues.isDefault ?? false,
+    fullName: initialValues.fullName || '',
+    company: initialValues.company,
+    street1: initialValues.street1 || '',
+    street2: initialValues.street2,
+    city: initialValues.city || '',
+    state: initialValues.state || '',
+    postalCode: initialValues.postalCode || '',
+    country: initialValues.country || '',
+    phone: initialValues.phone
+  });
+
+  const handleChange = (name: keyof Address, value: string) => {
+    setValues(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await onSubmit(values);
+  };
+
+  const field = (name: keyof Address, label: string) => {
+    const value = (values as any)[name] as string;
+    const onChange = (v: string) => handleChange(name, v);
+    return renderField ? renderField({ name, value, onChange, label }) : (
+      <div>
+        <label>{label}</label>
+        <input value={value} onChange={e => onChange(e.target.value)} />
+      </div>
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {field('fullName', 'Full Name')}
+      {field('street1', 'Street Address 1')}
+      {field('street2', 'Street Address 2')}
+      {field('city', 'City')}
+      {field('state', 'State')}
+      {field('postalCode', 'Postal Code')}
+      {field('country', 'Country')}
+      {field('phone', 'Phone')}
+      <div>
+        <button type="submit" disabled={loading}>Submit</button>
+        <button type="button" onClick={onCancel}>Cancel</button>
+      </div>
+    </form>
+  );
+}

--- a/src/ui/headless/address/AddressList.tsx
+++ b/src/ui/headless/address/AddressList.tsx
@@ -1,0 +1,41 @@
+import type { Address } from '@/core/address/types';
+import React from 'react';
+
+export interface AddressListProps {
+  addresses: Address[];
+  onEdit: (address: Address) => void;
+  onDelete: (id: string) => void;
+  onSetDefault: (id: string) => void;
+  loading?: boolean;
+  renderItem?: (
+    address: Address,
+    actions: { onEdit: (address: Address) => void; onDelete: (id: string) => void; onSetDefault: (id: string) => void }
+  ) => React.ReactNode;
+}
+
+export function AddressList({ addresses, onEdit, onDelete, onSetDefault, loading, renderItem }: AddressListProps) {
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      {addresses.map(addr => (
+        <div key={addr.id}>
+          {renderItem ? (
+            renderItem(addr, { onEdit, onDelete, onSetDefault })
+          ) : (
+            <div>
+              <p>{addr.fullName}</p>
+              <button onClick={() => onEdit(addr)}>Edit</button>
+              <button onClick={() => onDelete(addr.id)}>Delete</button>
+              {!addr.isDefault && (
+                <button onClick={() => onSetDefault(addr.id)}>Set Default</button>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/ui/headless/address/AddressSelector.tsx
+++ b/src/ui/headless/address/AddressSelector.tsx
@@ -1,0 +1,27 @@
+import type { Address } from '@/core/address/types';
+import React from 'react';
+
+interface AddressSelectorProps {
+  addresses: Address[];
+  selectedId?: string;
+  onSelect: (address: Address) => void;
+  onCreateNew: () => void;
+}
+
+export function AddressSelector({ addresses, selectedId, onSelect, onCreateNew }: AddressSelectorProps) {
+  return (
+    <div>
+      <select value={selectedId} onChange={e => {
+        const id = e.target.value;
+        const address = addresses.find(a => a.id === id);
+        if (address) onSelect(address);
+      }}>
+        <option value="">Select address</option>
+        {addresses.map(addr => (
+          <option key={addr.id} value={addr.id}>{addr.fullName}</option>
+        ))}
+      </select>
+      <button type="button" onClick={onCreateNew}>Add New</button>
+    </div>
+  );
+}

--- a/src/ui/headless/address/__tests__/AddressList.test.tsx
+++ b/src/ui/headless/address/__tests__/AddressList.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AddressList } from '../AddressList';
+import type { Address } from '@/core/address/types';
+
+describe('AddressList', () => {
+  const addresses: Address[] = [
+    { id: '1', userId: 'u1', type: 'shipping', isDefault: false, fullName: 'John', street1: '123', city: 'A', state: 'B', postalCode: '1', country: 'US', createdAt: new Date(), updatedAt: new Date() },
+  ];
+
+  it('calls handlers', () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    const onSetDefault = vi.fn();
+
+    render(<AddressList addresses={addresses} onEdit={onEdit} onDelete={onDelete} onSetDefault={onSetDefault} />);
+
+    fireEvent.click(screen.getByText('Edit'));
+    expect(onEdit).toHaveBeenCalled();
+    fireEvent.click(screen.getByText('Delete'));
+    expect(onDelete).toHaveBeenCalled();
+    fireEvent.click(screen.getByText('Set Default'));
+    expect(onSetDefault).toHaveBeenCalled();
+  });
+});

--- a/src/ui/styled/address/AddressForm.tsx
+++ b/src/ui/styled/address/AddressForm.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { AddressForm as HeadlessAddressForm } from '@/ui/headless/address/AddressForm';
+import type { AddressFormProps } from '@/ui/headless/address/AddressForm';
+
+export function StyledAddressForm(props: AddressFormProps) {
+  return (
+    <div className="max-w-md">
+      <HeadlessAddressForm
+        {...props}
+        renderField={({ label, value, onChange }) => (
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">{label}</label>
+            <input
+              value={value}
+              onChange={e => onChange(e.target.value)}
+              className="w-full p-2 border rounded"
+            />
+          </div>
+        )}
+      />
+    </div>
+  );
+}

--- a/src/ui/styled/address/AddressList.tsx
+++ b/src/ui/styled/address/AddressList.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { AddressList as HeadlessAddressList } from '@/ui/headless/address/AddressList';
+import type { AddressListProps } from '@/ui/headless/address/AddressList';
+
+export function StyledAddressList(props: AddressListProps) {
+  return (
+    <div className="space-y-4">
+      <HeadlessAddressList
+        {...props}
+        renderItem={(address, { onEdit, onDelete, onSetDefault }) => (
+          <div className="border p-4 rounded-lg">
+            <div className="font-medium">{address.fullName}</div>
+            <div>{address.street1}</div>
+            <div>{address.city}, {address.state} {address.postalCode}</div>
+            <div>{address.country}</div>
+            <div className="mt-2 space-x-2">
+              <button onClick={() => onEdit(address)} className="text-blue-500">Edit</button>
+              <button onClick={() => onDelete(address.id)} className="text-red-500">Delete</button>
+              {!address.isDefault && (
+                <button onClick={() => onSetDefault(address.id)} className="text-green-500">Set Default</button>
+              )}
+            </div>
+          </div>
+        )}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `Address` model and validation
- define `AddressService` and `CompanyAddressService`
- implement `useAddresses` hook
- add headless and styled address UI components
- create API routes for address CRUD and default selection
- add unit tests for validation, hook, components and API

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*