### PR TITLE
Add basic audit log system scaffolding

### DIFF
--- a/src/core/audit/index.ts
+++ b/src/core/audit/index.ts
@@ -1,2 +1,3 @@
 export * from './interfaces';
 export * from './models';
+export * from './types';

--- a/src/core/audit/interfaces.ts
+++ b/src/core/audit/interfaces.ts
@@ -1,8 +1,22 @@
-import { PaginationMeta } from '@/lib/api/common/response-formatter';
-import { AuditLogEntry, AuditLogQuery } from './models';
+import type { AuditLog, AuditLogFilters } from './types';
 
 export interface AuditService {
-  getUserActionLogs(
-    query: AuditLogQuery
-  ): Promise<{ logs: AuditLogEntry[]; pagination: PaginationMeta }>;
+  /** Log an event to the audit log */
+  logEvent(
+    action: string,
+    entityType: string,
+    entityId: string,
+    metadata?: Record<string, unknown>
+  ): Promise<void>;
+
+  /** Retrieve audit logs with optional filtering and pagination */
+  getLogs(
+    filters: AuditLogFilters,
+    page: number,
+    pageSize: number
+  ): Promise<{ logs: AuditLog[]; total: number }>;
+
+  /** Export audit logs as a blob (e.g. CSV or Excel) */
+  exportLogs(filters: AuditLogFilters): Promise<Blob>;
 }
+

--- a/src/core/audit/types.ts
+++ b/src/core/audit/types.ts
@@ -1,0 +1,20 @@
+export interface AuditLog {
+  id: string;
+  action: string;
+  entityType: string;
+  entityId: string;
+  userId: string;
+  userAgent?: string;
+  ipAddress?: string;
+  metadata?: Record<string, unknown>;
+  timestamp: Date;
+}
+
+export interface AuditLogFilters {
+  action?: string;
+  entityType?: string;
+  userId?: string;
+  startDate?: Date;
+  endDate?: Date;
+  search?: string;
+}

--- a/src/hooks/audit/__tests__/use-audit-logs.test.tsx
+++ b/src/hooks/audit/__tests__/use-audit-logs.test.tsx
@@ -1,0 +1,52 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { UserManagementConfiguration } from '@/core/config';
+import type { AuditService } from '@/core/audit/interfaces';
+import { useAuditLogs } from '../use-audit-logs';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useAuditLogs', () => {
+  let service: AuditService;
+  beforeEach(() => {
+    UserManagementConfiguration.reset();
+    service = {
+      logEvent: vi.fn(),
+      getLogs: vi.fn().mockResolvedValue({ logs: [], total: 0 }),
+      exportLogs: vi.fn().mockResolvedValue(new Blob())
+    };
+    UserManagementConfiguration.configureServiceProviders({ auditService: service });
+  });
+
+  afterEach(() => {
+    UserManagementConfiguration.reset();
+  });
+
+  it('fetches logs from the service', async () => {
+    vi.mocked(service.getLogs).mockResolvedValueOnce({ logs: [{ id: '1', action: 'A', entityType: 'user', entityId: '1', userId: '1', timestamp: new Date() }], total: 1 });
+
+    const { result } = renderHook(() => useAuditLogs(), { wrapper: createWrapper() });
+
+    await waitFor(() => !result.current.isLoading);
+    expect(service.getLogs).toHaveBeenCalled();
+    expect(result.current.logs.length).toBe(1);
+    expect(result.current.total).toBe(1);
+  });
+
+  it('exports logs using the service', async () => {
+    const { result } = renderHook(() => useAuditLogs(), { wrapper: createWrapper() });
+    await waitFor(() => !result.current.isLoading);
+    await act(async () => {
+      await result.current.exportLogs();
+    });
+    expect(service.exportLogs).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/audit/use-audit-logs.ts
+++ b/src/hooks/audit/use-audit-logs.ts
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { UserManagementConfiguration } from '@/core/config';
+import type { AuditService } from '@/core/audit/interfaces';
+import type { AuditLog, AuditLogFilters } from '@/core/audit/types';
+
+export interface UseAuditLogsResult {
+  logs: AuditLog[];
+  total: number;
+  isLoading: boolean;
+  error: unknown;
+  page: number;
+  pageSize: number;
+  filters: AuditLogFilters;
+  setFilter: (key: keyof AuditLogFilters, value: unknown) => void;
+  setPage: (page: number) => void;
+  exportLogs: () => Promise<Blob>;
+}
+
+export function useAuditLogs(
+  initialFilters: AuditLogFilters = {},
+  initialPage = 1,
+  initialPageSize = 20
+): UseAuditLogsResult {
+  const service = UserManagementConfiguration.getServiceProvider<AuditService>('auditService');
+  if (!service) {
+    throw new Error('AuditService is not registered in the service provider registry');
+  }
+
+  const [filters, setFilters] = useState<AuditLogFilters>(initialFilters);
+  const [page, setPage] = useState(initialPage);
+  const [pageSize] = useState(initialPageSize);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['auditLogs', filters, page, pageSize],
+    queryFn: () => service.getLogs(filters, page, pageSize),
+    keepPreviousData: true
+  });
+
+  const setFilter = (key: keyof AuditLogFilters, value: unknown) => {
+    setFilters(prev => ({ ...prev, [key]: value }));
+    setPage(1);
+  };
+
+  const exportLogs = () => service.exportLogs(filters);
+
+  return {
+    logs: data?.logs ?? [],
+    total: data?.total ?? 0,
+    isLoading,
+    error,
+    page,
+    pageSize,
+    filters,
+    setFilter,
+    setPage,
+    exportLogs
+  };
+}

--- a/src/ui/headless/audit/AuditLogFilter.tsx
+++ b/src/ui/headless/audit/AuditLogFilter.tsx
@@ -1,0 +1,20 @@
+import type { AuditLogFilters } from '@/core/audit/types';
+
+export interface AuditLogFilterProps {
+  filters: AuditLogFilters;
+  onChange: (key: keyof AuditLogFilters, value: unknown) => void;
+}
+
+export function AuditLogFilter({ filters, onChange }: AuditLogFilterProps) {
+  return (
+    <div className="flex gap-2 mb-2">
+      <input
+        aria-label="Search"
+        value={filters.search ?? ''}
+        onChange={e => onChange('search', e.target.value)}
+        className="border p-1 rounded"
+      />
+    </div>
+  );
+}
+

--- a/src/ui/headless/audit/AuditLogList.tsx
+++ b/src/ui/headless/audit/AuditLogList.tsx
@@ -1,0 +1,39 @@
+import type { AuditLog } from '@/core/audit/types';
+
+export interface AuditLogListProps {
+  logs: AuditLog[];
+  isLoading?: boolean;
+  error?: unknown;
+  onSelect?: (log: AuditLog) => void;
+}
+
+export function AuditLogList({ logs, isLoading, error, onSelect }: AuditLogListProps) {
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+  if (error) {
+    return <div>Failed to load logs</div>;
+  }
+  return (
+    <table className="min-w-full text-sm">
+      <thead>
+        <tr>
+          <th>Action</th>
+          <th>Entity</th>
+          <th>User</th>
+          <th>Date</th>
+        </tr>
+      </thead>
+      <tbody>
+        {logs.map(log => (
+          <tr key={log.id} onClick={() => onSelect?.(log)} className="cursor-pointer">
+            <td>{log.action}</td>
+            <td>{log.entityType}</td>
+            <td>{log.userId}</td>
+            <td>{log.timestamp.toISOString()}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/ui/styled/audit/AuditLogFilter.tsx
+++ b/src/ui/styled/audit/AuditLogFilter.tsx
@@ -1,0 +1,16 @@
+import { AuditLogFilter as HeadlessFilter } from '@/ui/headless/audit/AuditLogFilter';
+import type { AuditLogFilters } from '@/core/audit/types';
+
+export interface AuditLogFilterProps {
+  filters: AuditLogFilters;
+  onChange: (key: keyof AuditLogFilters, value: unknown) => void;
+}
+
+export function AuditLogFilter(props: AuditLogFilterProps) {
+  return (
+    <div className="p-2 border rounded">
+      <HeadlessFilter {...props} />
+    </div>
+  );
+}
+

--- a/src/ui/styled/audit/AuditLogList.tsx
+++ b/src/ui/styled/audit/AuditLogList.tsx
@@ -1,0 +1,23 @@
+import { AuditLogList as HeadlessList } from '@/ui/headless/audit/AuditLogList';
+import { AuditLogFilter as HeadlessFilter } from '@/ui/headless/audit/AuditLogFilter';
+import { useAuditLogs } from '@/hooks/audit/use-audit-logs';
+
+export function AuditLogList() {
+  const { logs, isLoading, error, filters, setFilter, page, total, setPage, exportLogs } = useAuditLogs();
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <HeadlessFilter filters={filters} onChange={setFilter} />
+        <button className="border rounded px-2" onClick={() => exportLogs()}>Export</button>
+      </div>
+      <HeadlessList logs={logs} isLoading={isLoading} error={error} />
+      <div className="flex justify-end gap-2 text-sm">
+        <button disabled={page === 1} onClick={() => setPage(page - 1)}>Prev</button>
+        <span>{page}</span>
+        <button disabled={logs.length + (page - 1) * 20 >= total} onClick={() => setPage(page + 1)}>Next</button>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- create `AuditLog` and `AuditLogFilters` types
- update `AuditService` interface with logEvent, getLogs and exportLogs
- add hook `useAuditLogs` for fetching/exporting audit logs
- add headless components `AuditLogList` and `AuditLogFilter`
- add styled components wiring the headless versions
- include unit tests for `useAuditLogs`

## Testing
- `npx vitest run src/hooks/audit/__tests__/use-audit-logs.test.tsx --coverage`