### PR TITLE
Implement CSRF hook and headless components

### DIFF
--- a/src/hooks/csrf/__tests__/use-csrf.test.ts
+++ b/src/hooks/csrf/__tests__/use-csrf.test.ts
@@ -1,0 +1,50 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useCsrf } from '../use-csrf';
+import { CsrfProvider } from '@/ui/headless/csrf/CsrfProvider';
+import type { CsrfService } from '@/core/csrf/interfaces';
+
+function createWrapper(service: CsrfService) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <CsrfProvider csrfService={service}>{children}</CsrfProvider>
+  );
+}
+
+describe('useCsrf', () => {
+  it('fetches token on mount', async () => {
+    const service: CsrfService = { generateToken: vi.fn(async () => ({ token: 'tok' })) };
+    const { result } = renderHook(() => useCsrf(), { wrapper: createWrapper(service) });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(service.generateToken).toHaveBeenCalled();
+    expect(result.current.token).toBe('tok');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('handles errors', async () => {
+    const service: CsrfService = { generateToken: vi.fn(async () => { throw new Error('fail'); }) };
+    const { result } = renderHook(() => useCsrf(), { wrapper: createWrapper(service) });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.token).toBeNull();
+    expect(result.current.error).toBe('fail');
+  });
+
+  it('validates token', async () => {
+    const service: CsrfService = { generateToken: vi.fn(async () => ({ token: 'abc' })) };
+    const { result } = renderHook(() => useCsrf(), { wrapper: createWrapper(service) });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.validateToken('abc')).toBe(true);
+    expect(result.current.validateToken('xyz')).toBe(false);
+  });
+});

--- a/src/hooks/csrf/use-csrf.ts
+++ b/src/hooks/csrf/use-csrf.ts
@@ -1,0 +1,38 @@
+import { useCsrfService } from '@/ui/headless/csrf/CsrfProvider';
+import { useState, useEffect } from 'react';
+
+export function useCsrf() {
+  const csrfService = useCsrfService();
+  const [token, setToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchToken = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { token: newToken } = await csrfService.generateToken();
+      setToken(newToken);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to fetch CSRF token';
+      setError(message);
+      setToken(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const validateToken = (t: string) => token === t;
+
+  useEffect(() => {
+    fetchToken();
+  }, []);
+
+  return {
+    token,
+    loading,
+    error,
+    fetchToken,
+    validateToken
+  };
+}

--- a/src/services/csrf/__tests__/browser-csrf.service.test.ts
+++ b/src/services/csrf/__tests__/browser-csrf.service.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { BrowserCsrfService } from '../browser-csrf.service';
+
+declare const global: any;
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('BrowserCsrfService', () => {
+  it('fetches token from endpoint', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ csrfToken: 'abc' })
+    });
+
+    const service = new BrowserCsrfService('/csrf');
+    const result = await service.generateToken();
+
+    expect(global.fetch).toHaveBeenCalledWith('/csrf', { credentials: 'include' });
+    expect(result).toEqual({ token: 'abc' });
+  });
+
+  it('throws on failed request', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500, statusText: 'err' });
+    const service = new BrowserCsrfService('/csrf');
+    await expect(service.generateToken()).rejects.toThrow('Failed to fetch CSRF token');
+  });
+});

--- a/src/services/csrf/browser-csrf.service.ts
+++ b/src/services/csrf/browser-csrf.service.ts
@@ -1,0 +1,17 @@
+import { CsrfService } from '@/core/csrf/interfaces';
+
+export class BrowserCsrfService implements CsrfService {
+  constructor(private endpoint = '/api/csrf') {}
+
+  async generateToken() {
+    const res = await fetch(this.endpoint, { credentials: 'include' });
+    if (!res.ok) {
+      throw new Error('Failed to fetch CSRF token');
+    }
+    const data = await res.json();
+    if (!data.csrfToken) {
+      throw new Error('Invalid CSRF token response');
+    }
+    return { token: data.csrfToken as string };
+  }
+}

--- a/src/services/csrf/index.ts
+++ b/src/services/csrf/index.ts
@@ -1,6 +1,7 @@
 import { CsrfService } from '@/core/csrf/interfaces';
 import { DefaultCsrfService } from './default-csrf.service';
 import type { CsrfDataProvider } from '@/adapters/csrf/interfaces';
+export { BrowserCsrfService } from './browser-csrf.service';
 
 export interface CsrfServiceConfig {
   csrfDataProvider: CsrfDataProvider;

--- a/src/ui/headless/csrf/CsrfInput.tsx
+++ b/src/ui/headless/csrf/CsrfInput.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useCsrf } from '@/hooks/csrf/use-csrf';
+
+export interface CsrfInputProps {
+  fieldName?: string;
+}
+
+export function CsrfInput({ fieldName = 'csrfToken' }: CsrfInputProps) {
+  const { token } = useCsrf();
+  return <input type="hidden" name={fieldName} value={token ?? ''} />;
+}
+
+export default CsrfInput;

--- a/src/ui/headless/csrf/CsrfProvider.tsx
+++ b/src/ui/headless/csrf/CsrfProvider.tsx
@@ -1,0 +1,23 @@
+import React, { createContext, useContext } from 'react';
+import type { CsrfService } from '@/core/csrf/interfaces';
+
+interface CsrfProviderProps {
+  csrfService: CsrfService;
+  children: React.ReactNode;
+}
+
+const CsrfContext = createContext<CsrfService | null>(null);
+
+export const CsrfProvider: React.FC<CsrfProviderProps> = ({ csrfService, children }) => (
+  <CsrfContext.Provider value={csrfService}>{children}</CsrfContext.Provider>
+);
+
+export function useCsrfService(): CsrfService {
+  const context = useContext(CsrfContext);
+  if (!context) {
+    throw new Error('useCsrfService must be used within a CsrfProvider');
+  }
+  return context;
+}
+
+export default CsrfProvider;


### PR DESCRIPTION
## Summary
- add browser-based CSRF service
- create CsrfProvider and CsrfInput components
- add `useCsrf` hook to manage CSRF tokens
- include unit tests

## Testing
- `vitest run --coverage` *(fails: `vitest` not found)*