### PR TITLE
Implement basic API key management scaffolding

### DIFF
--- a/src/core/api-keys/index.ts
+++ b/src/core/api-keys/index.ts
@@ -1,2 +1,3 @@
 export * from './interfaces';
 export * from './models';
+export * from './types';

--- a/src/core/api-keys/interfaces.ts
+++ b/src/core/api-keys/interfaces.ts
@@ -1,24 +1,13 @@
-/**
- * API Key Service Interface
- *
- * Defines the contract for API key management operations.
- */
-
-import { ApiKey, ApiKeyCreatePayload, ApiKeyCreateResult } from './models';
+import type { ApiKey } from './types';
 
 export interface ApiKeyService {
-  /**
-   * Get all API keys for a user.
-   */
-  listKeys(userId: string): Promise<ApiKey[]>;
-
-  /**
-   * Create a new API key for a user.
-   */
-  createKey(userId: string, data: ApiKeyCreatePayload): Promise<ApiKeyCreateResult>;
-
-  /**
-   * Revoke an existing API key.
-   */
-  revokeKey(userId: string, keyId: string): Promise<{ success: boolean; error?: string }>;
+  listApiKeys(): Promise<ApiKey[]>;
+  createApiKey(
+    name: string,
+    permissions: string[],
+    expiresInDays?: number
+  ): Promise<{ key: string } & ApiKey>;
+  revokeApiKey(id: string): Promise<void>;
+  regenerateApiKey(id: string): Promise<{ key: string } & ApiKey>;
+  validateApiKey(apiKey: string): Promise<boolean>;
 }

--- a/src/core/api-keys/types.ts
+++ b/src/core/api-keys/types.ts
@@ -1,0 +1,11 @@
+export interface ApiKey {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  keySecret?: string; // Only shown once on creation
+  permissions: string[];
+  lastUsedAt?: Date;
+  createdAt: Date;
+  expiresAt?: Date;
+  isActive: boolean;
+}

--- a/src/hooks/api-keys/__tests__/use-api-keys.test.tsx
+++ b/src/hooks/api-keys/__tests__/use-api-keys.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useApiKeys } from '../use-api-keys';
+import { UserManagementConfiguration } from '@/core/config';
+import type { ApiKeyService } from '@/core/api-keys/interfaces';
+import type { ApiKey } from '@/core/api-keys/types';
+
+const mockService: ApiKeyService = {
+  listApiKeys: vi.fn(),
+  createApiKey: vi.fn(),
+  revokeApiKey: vi.fn(),
+  regenerateApiKey: vi.fn(),
+  validateApiKey: vi.fn()
+};
+
+describe('useApiKeys', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    UserManagementConfiguration.reset();
+    UserManagementConfiguration.configureServiceProviders({ apiKeyService: mockService });
+  });
+
+  afterEach(() => {
+    UserManagementConfiguration.reset();
+  });
+
+  it('fetches api keys on mount', async () => {
+    const keys: ApiKey[] = [
+      { id: '1', name: 'Test', keyPrefix: 'pref', permissions: [], createdAt: new Date(), isActive: true }
+    ];
+    vi.mocked(mockService.listApiKeys).mockResolvedValue(keys);
+
+    const { result } = renderHook(() => useApiKeys());
+
+    expect(mockService.listApiKeys).toHaveBeenCalled();
+    await act(async () => {
+      await result.current.fetchApiKeys();
+    });
+    expect(result.current.apiKeys).toEqual(keys);
+  });
+
+  it('creates api key', async () => {
+    const newKey: ApiKey & { key: string } = {
+      id: '2',
+      name: 'New',
+      keyPrefix: 'pref',
+      keySecret: 'secret',
+      permissions: [],
+      createdAt: new Date(),
+      isActive: true,
+      key: 'secret'
+    };
+    vi.mocked(mockService.createApiKey).mockResolvedValue(newKey);
+    vi.mocked(mockService.listApiKeys).mockResolvedValue([]);
+    const { result } = renderHook(() => useApiKeys());
+    await act(async () => {
+      const res = await result.current.createApiKey('New', []);
+      expect(res).toEqual(newKey);
+    });
+    expect(mockService.createApiKey).toHaveBeenCalledWith('New', [], undefined);
+    expect(result.current.apiKeys).toContainEqual(newKey);
+  });
+});

--- a/src/hooks/api-keys/use-api-keys.ts
+++ b/src/hooks/api-keys/use-api-keys.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useState } from 'react';
+import { UserManagementConfiguration } from '@/core/config';
+import type { ApiKeyService } from '@/core/api-keys/interfaces';
+import type { ApiKey } from '@/core/api-keys/types';
+
+export function useApiKeys() {
+  const apiKeyService =
+    UserManagementConfiguration.getServiceProvider<ApiKeyService>('apiKeyService');
+
+  if (!apiKeyService) {
+    throw new Error('ApiKeyService is not registered in the service provider registry');
+  }
+
+  const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchApiKeys = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const keys = await apiKeyService.listApiKeys();
+      setApiKeys(keys);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [apiKeyService]);
+
+  useEffect(() => {
+    fetchApiKeys();
+  }, [fetchApiKeys]);
+
+  const createApiKey = useCallback(
+    async (name: string, permissions: string[], expiresInDays?: number) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const key = await apiKeyService.createApiKey(
+          name,
+          permissions,
+          expiresInDays
+        );
+        setApiKeys((prev) => [...prev, key]);
+        return key;
+      } catch (err) {
+        setError((err as Error).message);
+        throw err;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [apiKeyService]
+  );
+
+  const revokeApiKey = useCallback(
+    async (id: string) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        await apiKeyService.revokeApiKey(id);
+        setApiKeys((prev) => prev.filter((k) => k.id !== id));
+      } catch (err) {
+        setError((err as Error).message);
+        throw err;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [apiKeyService]
+  );
+
+  const regenerateApiKey = useCallback(
+    async (id: string) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const key = await apiKeyService.regenerateApiKey(id);
+        setApiKeys((prev) => prev.map((k) => (k.id === id ? key : k)));
+        return key;
+      } catch (err) {
+        setError((err as Error).message);
+        throw err;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [apiKeyService]
+  );
+
+  const validateApiKey = useCallback(
+    async (apiKey: string) => {
+      try {
+        return await apiKeyService.validateApiKey(apiKey);
+      } catch (err) {
+        return false;
+      }
+    },
+    [apiKeyService]
+  );
+
+  return {
+    apiKeys,
+    isLoading,
+    error,
+    fetchApiKeys,
+    createApiKey,
+    revokeApiKey,
+    regenerateApiKey,
+    validateApiKey
+  };
+}

--- a/src/ui/headless/api-keys/ApiKeyDetail.tsx
+++ b/src/ui/headless/api-keys/ApiKeyDetail.tsx
@@ -1,0 +1,22 @@
+import type { ApiKey } from '@/core/api-keys/types';
+import { useApiKeys } from '@/hooks/api-keys/use-api-keys';
+
+export interface ApiKeyDetailRenderProps {
+  apiKey: ApiKey;
+  regenerate: () => Promise<{ key: string } & ApiKey>;
+  revoke: () => Promise<void>;
+}
+
+export interface ApiKeyDetailProps {
+  apiKey: ApiKey;
+  children: (props: ApiKeyDetailRenderProps) => React.ReactNode;
+}
+
+export function ApiKeyDetail({ apiKey, children }: ApiKeyDetailProps) {
+  const { regenerateApiKey, revokeApiKey } = useApiKeys();
+
+  const regenerate = () => regenerateApiKey(apiKey.id);
+  const revoke = () => revokeApiKey(apiKey.id);
+
+  return <>{children({ apiKey, regenerate, revoke })}</>;
+}

--- a/src/ui/headless/api-keys/ApiKeyForm.tsx
+++ b/src/ui/headless/api-keys/ApiKeyForm.tsx
@@ -1,0 +1,58 @@
+import { FormEvent, useState } from 'react';
+import { useApiKeys } from '@/hooks/api-keys/use-api-keys';
+import type { ApiKey } from '@/core/api-keys/types';
+
+export interface ApiKeyFormRenderProps {
+  name: string;
+  setName: (v: string) => void;
+  permissions: string[];
+  togglePermission: (p: string) => void;
+  expiresInDays?: number;
+  setExpiresInDays: (d?: number) => void;
+  handleSubmit: (e: FormEvent) => Promise<void>;
+  isSubmitting: boolean;
+  error: string | null;
+  createdKey?: ({ key: string } & ApiKey) | null;
+}
+
+export interface ApiKeyFormProps {
+  defaultPermissions?: string[];
+  children: (props: ApiKeyFormRenderProps) => React.ReactNode;
+}
+
+export function ApiKeyForm({ children, defaultPermissions = [] }: ApiKeyFormProps) {
+  const { createApiKey } = useApiKeys();
+  const [name, setName] = useState('');
+  const [permissions, setPermissions] = useState<string[]>(defaultPermissions);
+  const [expiresInDays, setExpiresInDays] = useState<number | undefined>(undefined);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [createdKey, setCreatedKey] = useState<({ key: string } & ApiKey) | null>(null);
+
+  const togglePermission = (p: string) => {
+    setPermissions((prev) =>
+      prev.includes(p) ? prev.filter((x) => x !== p) : [...prev, p]
+    );
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const key = await createApiKey(name, permissions, expiresInDays);
+      setCreatedKey(key);
+      setName('');
+      setPermissions(defaultPermissions);
+      setExpiresInDays(undefined);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>{children({ name, setName, permissions, togglePermission, expiresInDays, setExpiresInDays, handleSubmit, isSubmitting, error, createdKey })}</>
+  );
+}

--- a/src/ui/headless/api-keys/ApiKeyList.tsx
+++ b/src/ui/headless/api-keys/ApiKeyList.tsx
@@ -1,0 +1,23 @@
+import type { ApiKey } from '@/core/api-keys/types';
+import { useApiKeys } from '@/hooks/api-keys/use-api-keys';
+
+export interface ApiKeyListRenderProps {
+  apiKeys: ApiKey[];
+  isLoading: boolean;
+  error: string | null;
+  revoke: (id: string) => Promise<void>;
+  regenerate: (id: string) => Promise<{ key: string } & ApiKey>;
+  refresh: () => Promise<void>;
+}
+
+export interface ApiKeyListProps {
+  children: (props: ApiKeyListRenderProps) => React.ReactNode;
+}
+
+export function ApiKeyList({ children }: ApiKeyListProps) {
+  const { apiKeys, isLoading, error, revokeApiKey, regenerateApiKey, fetchApiKeys } = useApiKeys();
+
+  return (
+    <>{children({ apiKeys, isLoading, error, revoke: revokeApiKey, regenerate: regenerateApiKey, refresh: fetchApiKeys })}</>
+  );
+}

--- a/src/ui/headless/api-keys/__tests__/ApiKeyList.test.tsx
+++ b/src/ui/headless/api-keys/__tests__/ApiKeyList.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { ApiKeyList } from '../ApiKeyList';
+import { useApiKeys } from '@/hooks/api-keys/use-api-keys';
+
+vi.mock('@/hooks/api-keys/use-api-keys', () => ({ useApiKeys: vi.fn() }));
+
+describe('ApiKeyList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useApiKeys as unknown as vi.Mock).mockReturnValue({
+      apiKeys: [{ id: '1', name: 'Key', keyPrefix: 'pref', permissions: [], createdAt: new Date(), isActive: true }],
+      isLoading: false,
+      error: null,
+      revokeApiKey: vi.fn(),
+      regenerateApiKey: vi.fn(),
+      fetchApiKeys: vi.fn()
+    });
+  });
+
+  it('provides api keys to children', () => {
+    let props: any;
+    render(
+      <ApiKeyList>
+        {(p) => {
+          props = p;
+          return <div />;
+        }}
+      </ApiKeyList>
+    );
+    expect(props.apiKeys.length).toBe(1);
+  });
+});

--- a/src/ui/headless/api-keys/index.ts
+++ b/src/ui/headless/api-keys/index.ts
@@ -1,0 +1,3 @@
+export * from './ApiKeyList';
+export * from './ApiKeyForm';
+export * from './ApiKeyDetail';

--- a/src/ui/styled/api-keys/ApiKeyDetail.tsx
+++ b/src/ui/styled/api-keys/ApiKeyDetail.tsx
@@ -1,0 +1,43 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/ui/primitives/card';
+import { Button } from '@/ui/primitives/button';
+import { Badge } from '@/ui/primitives/badge';
+import { CopyButton } from '@/ui/primitives/copy-button';
+import { ApiKeyDetail as HeadlessApiKeyDetail } from '@/ui/headless/api-keys/ApiKeyDetail';
+import type { ApiKey } from '@/core/api-keys/types';
+
+export function ApiKeyDetail({ apiKey }: { apiKey: ApiKey }) {
+  return (
+    <HeadlessApiKeyDetail apiKey={apiKey}>
+      {({ apiKey, regenerate, revoke }) => (
+        <Card>
+          <CardHeader>
+            <CardTitle>{apiKey.name}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <div className="flex items-center space-x-2">
+              <span className="font-mono text-sm">{apiKey.keyPrefix}...</span>
+              <Badge variant={apiKey.isActive ? 'default' : 'destructive'}>
+                {apiKey.isActive ? 'Active' : 'Revoked'}
+              </Badge>
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {apiKey.permissions.map((p) => (
+                <Badge key={p} variant="secondary">
+                  {p}
+                </Badge>
+              ))}
+            </div>
+            <div className="flex space-x-2">
+              <Button size="sm" variant="outline" onClick={regenerate}>
+                Regenerate
+              </Button>
+              <Button size="sm" variant="destructive" onClick={revoke}>
+                Revoke
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </HeadlessApiKeyDetail>
+  );
+}

--- a/src/ui/styled/api-keys/ApiKeyForm.tsx
+++ b/src/ui/styled/api-keys/ApiKeyForm.tsx
@@ -1,0 +1,70 @@
+import { Input } from '@/ui/primitives/input';
+import { Button } from '@/ui/primitives/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/ui/primitives/card';
+import { Checkbox } from '@/ui/primitives/checkbox';
+import { ApiKeyForm as HeadlessApiKeyForm } from '@/ui/headless/api-keys/ApiKeyForm';
+
+export interface ApiKeyFormProps {
+  availablePermissions: string[];
+  onCreated?: (key: string) => void;
+}
+
+export function ApiKeyForm({ availablePermissions, onCreated }: ApiKeyFormProps) {
+  return (
+    <HeadlessApiKeyForm>
+      {({
+        name,
+        setName,
+        permissions,
+        togglePermission,
+        expiresInDays,
+        setExpiresInDays,
+        handleSubmit,
+        isSubmitting,
+        error,
+        createdKey
+      }) => (
+        <Card>
+          <CardHeader>
+            <CardTitle>Create API Key</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {error && (
+              <p className="text-destructive text-sm" role="alert">
+                {error}
+              </p>
+            )}
+            {createdKey && (
+              <div className="bg-muted p-2 rounded text-sm flex items-center justify-between">
+                <span className="font-mono break-all">{createdKey.keySecret}</span>
+                <Button size="sm" variant="ghost" onClick={() => navigator.clipboard.writeText(createdKey.keySecret || '')}>Copy</Button>
+              </div>
+            )}
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium mb-1">Name</label>
+                <Input value={name} onChange={(e) => setName(e.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <p className="text-sm font-medium">Permissions</p>
+                {availablePermissions.map((p) => (
+                  <label key={p} className="flex items-center space-x-2 text-sm">
+                    <Checkbox checked={permissions.includes(p)} onCheckedChange={() => togglePermission(p)} />
+                    <span>{p}</span>
+                  </label>
+                ))}
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Expires in days</label>
+                <Input type="number" value={expiresInDays ?? ''} onChange={(e) => setExpiresInDays(e.target.value ? Number(e.target.value) : undefined)} />
+              </div>
+              <Button type="submit" disabled={isSubmitting} className="w-full">
+                {isSubmitting ? 'Creating...' : 'Create API Key'}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      )}
+    </HeadlessApiKeyForm>
+  );
+}

--- a/src/ui/styled/api-keys/ApiKeyList.tsx
+++ b/src/ui/styled/api-keys/ApiKeyList.tsx
@@ -1,0 +1,50 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/ui/primitives/card';
+import { Button } from '@/ui/primitives/button';
+import { Badge } from '@/ui/primitives/badge';
+
+export function ApiKeyList() {
+  return (
+    <HeadlessApiKeyList>
+      {({ apiKeys, isLoading, error, revoke, regenerate }) => (
+        <div className="space-y-4">
+          {isLoading && <p>Loading...</p>}
+          {error && (
+            <p className="text-destructive text-sm" role="alert">
+              {error}
+            </p>
+          )}
+          {apiKeys.map((key) => (
+            <Card key={key.id} className="flex flex-col md:flex-row md:items-center md:justify-between">
+              <CardHeader>
+                <CardTitle>{key.name}</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <div className="flex items-center space-x-2">
+                  <span className="font-mono text-sm">{key.keyPrefix}...</span>
+                  <Badge variant={key.isActive ? 'default' : 'destructive'}>
+                    {key.isActive ? 'Active' : 'Revoked'}
+                  </Badge>
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  {key.permissions.map((p) => (
+                    <Badge key={p} variant="secondary">
+                      {p}
+                    </Badge>
+                  ))}
+                </div>
+                <div className="flex space-x-2">
+                  <Button size="sm" variant="outline" onClick={() => regenerate(key.id)}>
+                    Regenerate
+                  </Button>
+                  <Button size="sm" variant="destructive" onClick={() => revoke(key.id)}>
+                    Revoke
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </HeadlessApiKeyList>
+  );
+}

--- a/src/ui/styled/api-keys/index.ts
+++ b/src/ui/styled/api-keys/index.ts
@@ -1,0 +1,3 @@
+export * from './ApiKeyList';
+export * from './ApiKeyForm';
+export * from './ApiKeyDetail';


### PR DESCRIPTION
## Summary
- add ApiKey model interface and service interface
- create hook for api key management
- add headless API key components with tests
- add styled API key components

## Testing
- `npm run lint` *(fails: many warnings and some errors)*
- `npm run test:coverage` *(fails: test suite errors)*
