### PR TITLE
Add basic SSO hook and UI components

### DIFF
--- a/src/hooks/sso/__tests__/use-sso.test.tsx
+++ b/src/hooks/sso/__tests__/use-sso.test.tsx
@@ -1,0 +1,35 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { SsoProvider } from '@/types/sso';
+import { SsoProvider as SsoServiceProvider, SsoService } from '@/lib/context/SsoContext';
+import { useSso } from '../use-sso';
+
+const mockService: SsoService = {
+  listProviders: vi.fn(async () => [{ id: '1', name: 'Test', type: 'saml' }]),
+  listConnections: vi.fn(async () => []),
+  connect: vi.fn(async () => ({ id: 'c1', providerId: '1', providerName: 'Test', createdAt: '' })),
+  disconnect: vi.fn(async () => {}),
+};
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <SsoServiceProvider ssoService={mockService}>{children}</SsoServiceProvider>;
+}
+
+describe('useSso hook', () => {
+  it('fetches providers', async () => {
+    const { result } = renderHook(() => useSso(), { wrapper });
+    await act(async () => {
+      await result.current.fetchProviders();
+    });
+    expect(result.current.providers).toEqual([{ id: '1', name: 'Test', type: 'saml' }]);
+  });
+
+  it('handles errors', async () => {
+    vi.mocked(mockService.listProviders).mockRejectedValueOnce(new Error('err'));
+    const { result } = renderHook(() => useSso(), { wrapper });
+    await act(async () => {
+      await result.current.fetchProviders();
+    });
+    expect(result.current.error).toBe('err');
+  });
+});

--- a/src/hooks/sso/use-sso.ts
+++ b/src/hooks/sso/use-sso.ts
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { useSsoService } from '@/lib/context/SsoContext';
+import type { SsoProvider, SsoConnection } from '@/types/sso';
+
+export function useSso() {
+  const ssoService = useSsoService();
+  const [providers, setProviders] = useState<SsoProvider[]>([]);
+  const [connectedProviders, setConnectedProviders] = useState<SsoConnection[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchProviders = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await ssoService.listProviders();
+      setProviders(list);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch providers');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchConnections = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await ssoService.listConnections();
+      setConnectedProviders(list);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch connections');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const connectProvider = async (providerId: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      await ssoService.connect(providerId);
+      await fetchConnections();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to connect provider');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const disconnectProvider = async (connectionId: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      await ssoService.disconnect(connectionId);
+      setConnectedProviders(prev => prev.filter(c => c.id !== connectionId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to disconnect provider');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    providers,
+    connectedProviders,
+    loading,
+    error,
+    fetchProviders,
+    fetchConnections,
+    connectProvider,
+    disconnectProvider
+  };
+}
+
+export default useSso;

--- a/src/lib/context/SsoContext.tsx
+++ b/src/lib/context/SsoContext.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext } from 'react';
+import type { SsoProvider, SsoConnection } from '@/types/sso';
+
+export interface SsoService {
+  listProviders: () => Promise<SsoProvider[]>;
+  listConnections: () => Promise<SsoConnection[]>;
+  connect: (providerId: string) => Promise<SsoConnection>;
+  disconnect: (connectionId: string) => Promise<void>;
+}
+
+interface SsoContextValue {
+  ssoService: SsoService;
+}
+
+const SsoContext = createContext<SsoContextValue | undefined>(undefined);
+
+export interface SsoProviderProps {
+  ssoService: SsoService;
+  children: React.ReactNode;
+}
+
+export const SsoProvider: React.FC<SsoProviderProps> = ({ ssoService, children }) => {
+  return <SsoContext.Provider value={{ ssoService }}>{children}</SsoContext.Provider>;
+};
+
+export function useSsoService(): SsoService {
+  const context = useContext(SsoContext);
+  if (!context) {
+    throw new Error('useSsoService must be used within a SsoProvider');
+  }
+  return context.ssoService;
+}
+
+export default SsoProvider;

--- a/src/types/sso.ts
+++ b/src/types/sso.ts
@@ -1,0 +1,12 @@
+export interface SsoProvider {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export interface SsoConnection {
+  id: string;
+  providerId: string;
+  providerName: string;
+  createdAt: string;
+}

--- a/src/ui/headless/sso/SsoConnectionList.tsx
+++ b/src/ui/headless/sso/SsoConnectionList.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import type { SsoConnection } from '@/types/sso';
+
+export interface SsoConnectionListProps {
+  connections: SsoConnection[];
+  render: (connection: SsoConnection) => React.ReactNode;
+}
+
+export function SsoConnectionList({ connections, render }: SsoConnectionListProps) {
+  return <>{connections.map(c => render(c))}</>;
+}
+
+export default SsoConnectionList;

--- a/src/ui/headless/sso/SsoLogin.tsx
+++ b/src/ui/headless/sso/SsoLogin.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import type { SsoProvider } from '@/types/sso';
+
+export interface SsoLoginProps {
+  providers: SsoProvider[];
+  onLogin: (providerId: string) => void;
+  render: (props: { providers: SsoProvider[]; login: (providerId: string) => void }) => React.ReactNode;
+}
+
+export function SsoLogin({ providers, onLogin, render }: SsoLoginProps) {
+  const login = (id: string) => onLogin(id);
+  return <>{render({ providers, login })}</>;
+}
+
+export default SsoLogin;

--- a/src/ui/headless/sso/SsoProviderList.tsx
+++ b/src/ui/headless/sso/SsoProviderList.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import type { SsoProvider } from '@/types/sso';
+
+export interface SsoProviderListProps {
+  providers: SsoProvider[];
+  render: (provider: SsoProvider) => React.ReactNode;
+}
+
+export function SsoProviderList({ providers, render }: SsoProviderListProps) {
+  return <>{providers.map(p => render(p))}</>;
+}
+
+export default SsoProviderList;

--- a/src/ui/styled/sso/SsoConnectionList.tsx
+++ b/src/ui/styled/sso/SsoConnectionList.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import type { SsoConnection } from '@/types/sso';
+import { SsoConnectionList as HeadlessList } from '@/ui/headless/sso/SsoConnectionList';
+
+export interface StyledSsoConnectionListProps {
+  connections: SsoConnection[];
+  onDisconnect?: (connectionId: string) => void;
+}
+
+export function SsoConnectionList({ connections, onDisconnect }: StyledSsoConnectionListProps) {
+  return (
+    <HeadlessList
+      connections={connections}
+      render={(c) => (
+        <div className="flex items-center justify-between border p-2 rounded-md mb-2" key={c.id}>
+          <span>{c.providerName}</span>
+          <button onClick={() => onDisconnect?.(c.id)} className="text-sm text-red-600">Disconnect</button>
+        </div>
+      )}
+    />
+  );
+}
+
+export default SsoConnectionList;

--- a/src/ui/styled/sso/SsoLogin.tsx
+++ b/src/ui/styled/sso/SsoLogin.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import type { SsoProvider } from '@/types/sso';
+import { SsoLogin as HeadlessLogin } from '@/ui/headless/sso/SsoLogin';
+import { SsoProviderButton } from './SsoProviderButton';
+
+export interface StyledSsoLoginProps {
+  providers: SsoProvider[];
+  onLogin: (providerId: string) => void;
+}
+
+export function SsoLogin({ providers, onLogin }: StyledSsoLoginProps) {
+  return (
+    <HeadlessLogin
+      providers={providers}
+      onLogin={onLogin}
+      render={({ providers, login }) => (
+        <div className="flex flex-col gap-2">
+          {providers.map((p) => (
+            <SsoProviderButton key={p.id} provider={p} onClick={() => login(p.id)} />
+          ))}
+        </div>
+      )}
+    />
+  );
+}
+
+export default SsoLogin;

--- a/src/ui/styled/sso/SsoProviderButton.tsx
+++ b/src/ui/styled/sso/SsoProviderButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import type { SsoProvider } from '@/types/sso';
+
+export interface SsoProviderButtonProps {
+  provider: SsoProvider;
+  onClick: () => void;
+}
+
+export function SsoProviderButton({ provider, onClick }: SsoProviderButtonProps) {
+  return (
+    <button onClick={onClick} className="px-3 py-2 border rounded-md hover:bg-gray-100">
+      {provider.name}
+    </button>
+  );
+}
+
+export default SsoProviderButton;

--- a/src/ui/styled/sso/SsoProviderList.tsx
+++ b/src/ui/styled/sso/SsoProviderList.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import type { SsoProvider } from '@/types/sso';
+import { SsoProviderList as HeadlessList } from '@/ui/headless/sso/SsoProviderList';
+import { SsoProviderButton } from './SsoProviderButton';
+
+export interface StyledSsoProviderListProps {
+  providers: SsoProvider[];
+  onSelect?: (providerId: string) => void;
+}
+
+export function SsoProviderList({ providers, onSelect }: StyledSsoProviderListProps) {
+  return (
+    <HeadlessList
+      providers={providers}
+      render={(p) => (
+        <SsoProviderButton provider={p} onClick={() => onSelect?.(p.id)} />
+      )}
+    />
+  );
+}
+
+export default SsoProviderList;


### PR DESCRIPTION
## Summary
- implement `useSso` hook for managing SSO connections
- add `SsoContext` with minimal `SsoService` interface
- add SSO type definitions
- create headless components for SSO provider list, connection list and login
- create styled versions of the SSO UI components
- add unit test for the new hook

## Testing
- `npx vitest run --coverage src/hooks/sso/__tests__/use-sso.test.ts`