### PR TITLE
Add subscription management hooks and UI

### DIFF
--- a/src/hooks/subscription/__tests__/use-billing.test.ts
+++ b/src/hooks/subscription/__tests__/use-billing.test.ts
@@ -1,0 +1,43 @@
+import { renderHook, act } from '@testing-library/react';
+import { useBilling } from '../use-billing';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import { usePayment } from '@/hooks/user/usePayment';
+
+vi.mock('@/hooks/user/usePayment');
+
+describe('useBilling', () => {
+  const fetchPaymentMethods = vi.fn();
+  const fetchPaymentHistory = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (usePayment as unknown as vi.Mock).mockReturnValue({
+      paymentMethods: [],
+      activeSubscription: null,
+      paymentHistory: [],
+      isLoading: false,
+      error: null,
+      fetchPaymentMethods,
+      addPaymentMethod: vi.fn(),
+      removePaymentMethod: vi.fn(),
+      fetchSubscription: vi.fn(),
+      cancelSubscription: vi.fn(),
+      fetchPaymentHistory,
+    });
+  });
+
+  it('fetches billing data on mount', () => {
+    renderHook(() => useBilling());
+    expect(fetchPaymentMethods).toHaveBeenCalled();
+    expect(fetchPaymentHistory).toHaveBeenCalled();
+  });
+
+  it('exposes store actions', () => {
+    const { result } = renderHook(() => useBilling());
+    act(() => {
+      result.current.fetchPaymentMethods();
+    });
+    expect(fetchPaymentMethods).toHaveBeenCalledTimes(2); // called once on mount
+  });
+});

--- a/src/hooks/subscription/__tests__/use-subscription.test.ts
+++ b/src/hooks/subscription/__tests__/use-subscription.test.ts
@@ -1,0 +1,49 @@
+import { renderHook, act } from '@testing-library/react';
+import { useSubscription } from '../use-subscription';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import { useSubscriptionStore } from '@/lib/stores/subscription.store';
+import { useAuth } from '@/hooks/auth/useAuth';
+
+vi.mock('@/lib/stores/subscription.store');
+vi.mock('@/hooks/auth/useAuth');
+
+describe('useSubscription', () => {
+  const fetchUserSubscription = vi.fn();
+  const fetchPlans = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useSubscriptionStore as unknown as vi.Mock).mockReturnValue({
+      plans: [],
+      userSubscription: null,
+      isLoading: false,
+      error: null,
+      fetchPlans,
+      fetchUserSubscription,
+      subscribe: vi.fn(),
+      cancelSubscription: vi.fn(),
+      updateSubscription: vi.fn(),
+      isSubscribed: vi.fn(() => false),
+      hasFeature: vi.fn(() => false),
+      getTier: vi.fn(() => 'free'),
+      getRemainingTrialDays: vi.fn(() => null),
+      clearError: vi.fn(),
+    });
+    (useAuth as unknown as vi.Mock).mockReturnValue({ user: { id: '123' } });
+  });
+
+  it('fetches subscription on mount', () => {
+    renderHook(() => useSubscription());
+    expect(fetchUserSubscription).toHaveBeenCalledWith('123');
+  });
+
+  it('exposes store values', () => {
+    const { result } = renderHook(() => useSubscription());
+    expect(result.current.isLoading).toBe(false);
+    act(() => {
+      result.current.fetchPlans();
+    });
+    expect(fetchPlans).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/subscription/use-billing.ts
+++ b/src/hooks/subscription/use-billing.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { usePayment } from '@/hooks/user/usePayment';
+
+/**
+ * Hook exposing billing related state and actions
+ * built on top of the payment store.
+ */
+export function useBilling() {
+  const {
+    paymentMethods,
+    activeSubscription,
+    paymentHistory,
+    isLoading,
+    error,
+    fetchPaymentMethods,
+    addPaymentMethod,
+    removePaymentMethod,
+    fetchSubscription,
+    cancelSubscription,
+    fetchPaymentHistory,
+  } = usePayment();
+
+  // Fetch payment methods and history on mount
+  useEffect(() => {
+    fetchPaymentMethods();
+    fetchPaymentHistory();
+  }, [fetchPaymentMethods, fetchPaymentHistory]);
+
+  return {
+    paymentMethods,
+    activeSubscription,
+    paymentHistory,
+    isLoading,
+    error,
+    fetchPaymentMethods,
+    addPaymentMethod,
+    removePaymentMethod,
+    fetchSubscription,
+    cancelSubscription,
+    fetchPaymentHistory,
+  };
+}

--- a/src/hooks/subscription/use-subscription.ts
+++ b/src/hooks/subscription/use-subscription.ts
@@ -1,0 +1,51 @@
+import { useEffect } from 'react';
+import { useAuth } from '@/hooks/auth/useAuth';
+import { useSubscriptionStore } from '@/lib/stores/subscription.store';
+
+/**
+ * Hook exposing subscription management state and actions
+ * wrapped around the Subscription store.
+ */
+export function useSubscription() {
+  const {
+    plans,
+    userSubscription,
+    isLoading,
+    error,
+    fetchPlans,
+    fetchUserSubscription,
+    subscribe,
+    cancelSubscription,
+    updateSubscription,
+    isSubscribed,
+    hasFeature,
+    getTier,
+    getRemainingTrialDays,
+    clearError,
+  } = useSubscriptionStore();
+
+  // Automatically fetch subscription for current user on mount
+  const { user } = useAuth();
+  useEffect(() => {
+    if (user?.id) {
+      fetchUserSubscription(user.id);
+    }
+  }, [user?.id, fetchUserSubscription]);
+
+  return {
+    plans,
+    userSubscription,
+    isLoading,
+    error,
+    fetchPlans,
+    fetchUserSubscription,
+    subscribe,
+    cancelSubscription,
+    updateSubscription,
+    isSubscribed,
+    hasFeature,
+    getTier,
+    getRemainingTrialDays,
+    clearError,
+  };
+}

--- a/src/ui/headless/subscription/BillingForm.tsx
+++ b/src/ui/headless/subscription/BillingForm.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { useBilling } from '@/hooks/subscription/use-billing';
+
+export interface BillingFormProps {
+  onSubmit?: (paymentMethodId: string) => Promise<void>;
+  render: (props: {
+    paymentMethods: ReturnType<typeof useBilling>['paymentMethods'];
+    isSubmitting: boolean;
+    submit: (paymentMethodId: string) => Promise<void>;
+    error: string | null;
+  }) => ReactNode;
+}
+
+export function BillingForm({ onSubmit, render }: BillingFormProps) {
+  const { paymentMethods, addPaymentMethod, error } = useBilling();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const submit = async (paymentMethodId: string) => {
+    setIsSubmitting(true);
+    try {
+      if (onSubmit) await onSubmit(paymentMethodId);
+      else await addPaymentMethod({ id: paymentMethodId, type: 'card' });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return <>{render({ paymentMethods, isSubmitting, submit, error })}</>;
+}

--- a/src/ui/headless/subscription/PlanSelector.tsx
+++ b/src/ui/headless/subscription/PlanSelector.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import type { ReactNode } from 'react';
+import { useAuth } from '@/hooks/auth/useAuth';
+import { useSubscription } from '@/hooks/subscription/use-subscription';
+import type { SubscriptionPlan } from '@/types/subscription';
+
+export interface PlanSelectorProps {
+  render: (props: {
+    plans: SubscriptionPlan[];
+    isLoading: boolean;
+    error: string | null;
+    selectPlan: (planId: string) => Promise<void>;
+  }) => ReactNode;
+}
+
+export function PlanSelector({ render }: PlanSelectorProps) {
+  const { user } = useAuth();
+  const { plans, isLoading, error, fetchPlans, subscribe } = useSubscription();
+
+  useEffect(() => {
+    fetchPlans();
+  }, [fetchPlans]);
+
+  const selectPlan = async (planId: string) => {
+    if (!user?.id) return;
+    await subscribe(user.id, planId);
+  };
+
+  return <>{render({ plans, isLoading, error, selectPlan })}</>;
+}

--- a/src/ui/headless/subscription/SubscriptionManager.tsx
+++ b/src/ui/headless/subscription/SubscriptionManager.tsx
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import type { ReactNode } from 'react';
+import { useAuth } from '@/hooks/auth/useAuth';
+import { useSubscription } from '@/hooks/subscription/use-subscription';
+import type { UserSubscription } from '@/types/subscription';
+
+export interface SubscriptionManagerProps {
+  render: (props: {
+    subscription: UserSubscription | null;
+    isLoading: boolean;
+    error: string | null;
+    cancel: () => Promise<void>;
+    refresh: () => Promise<void>;
+  }) => ReactNode;
+}
+
+export function SubscriptionManager({ render }: SubscriptionManagerProps) {
+  const { user } = useAuth();
+  const {
+    userSubscription,
+    isLoading,
+    error,
+    fetchUserSubscription,
+    cancelSubscription,
+  } = useSubscription();
+
+  useEffect(() => {
+    if (user?.id) {
+      fetchUserSubscription(user.id);
+    }
+  }, [user?.id, fetchUserSubscription]);
+
+  const refresh = async () => {
+    if (user?.id) {
+      await fetchUserSubscription(user.id);
+    }
+  };
+
+  const cancel = async () => {
+    if (!userSubscription) return;
+    await cancelSubscription(userSubscription.id, false);
+  };
+
+  return <>{render({ subscription: userSubscription, isLoading, error, cancel, refresh })}</>;
+}

--- a/src/ui/styled/subscription/BillingForm.tsx
+++ b/src/ui/styled/subscription/BillingForm.tsx
@@ -1,0 +1,28 @@
+import { BillingForm as HeadlessBillingForm, type BillingFormProps } from '@/ui/headless/subscription/BillingForm';
+import { Input } from '@/ui/primitives/input';
+import { Button } from '@/ui/primitives/button';
+import { Alert } from '@/ui/primitives/alert';
+
+export type StyledBillingFormProps = Omit<BillingFormProps, 'render'>;
+
+export function BillingForm(props: StyledBillingFormProps) {
+  return (
+    <HeadlessBillingForm
+      {...props}
+      render={({ paymentMethods, isSubmitting, submit, error }) => (
+        <div className="space-y-4">
+          {error && <Alert variant="destructive">{error}</Alert>}
+          <Input placeholder="Payment method id" id="pm" />
+          <Button disabled={isSubmitting} onClick={() => submit('pm')}>Submit</Button>
+          {paymentMethods.length > 0 && (
+            <ul className="list-disc pl-4 text-sm">
+              {paymentMethods.map((p) => (
+                <li key={p.id}>{p.id}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    />
+  );
+}

--- a/src/ui/styled/subscription/InvoiceList.tsx
+++ b/src/ui/styled/subscription/InvoiceList.tsx
@@ -1,0 +1,29 @@
+import { useBilling } from '@/hooks/subscription/use-billing';
+import { Card, CardContent, CardHeader, CardTitle } from '@/ui/primitives/card';
+import { Alert } from '@/ui/primitives/alert';
+
+export function InvoiceList() {
+  const { paymentHistory, isLoading, error } = useBilling();
+
+  if (isLoading) return <div>Loading invoices...</div>;
+  if (error) return <Alert variant="destructive">{error}</Alert>;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Invoices</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {paymentHistory.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No invoices yet.</p>
+        ) : (
+          <ul className="list-disc pl-4 space-y-1 text-sm">
+            {paymentHistory.map((inv) => (
+              <li key={inv.id}>{inv.description} - ${inv.amount}</li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/ui/styled/subscription/PlanCard.tsx
+++ b/src/ui/styled/subscription/PlanCard.tsx
@@ -1,0 +1,29 @@
+import { Button } from '@/ui/primitives/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/ui/primitives/card';
+import type { SubscriptionPlan } from '@/types/subscription';
+
+export interface PlanCardProps {
+  plan: SubscriptionPlan;
+  onSelect: (planId: string) => void;
+}
+
+export function PlanCard({ plan, onSelect }: PlanCardProps) {
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle>{plan.name}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <p className="text-sm text-muted-foreground">${plan.price} / {plan.period}</p>
+        <ul className="list-disc pl-4 text-sm space-y-1">
+          {plan.features.map((f) => (
+            <li key={f}>{f}</li>
+          ))}
+        </ul>
+        <Button className="w-full mt-4" onClick={() => onSelect(plan.id)}>
+          Choose
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/ui/styled/subscription/PlanSelector.tsx
+++ b/src/ui/styled/subscription/PlanSelector.tsx
@@ -1,0 +1,24 @@
+import { PlanSelector as HeadlessPlanSelector, type PlanSelectorProps } from '@/ui/headless/subscription/PlanSelector';
+import { PlanCard } from './PlanCard';
+import { Alert } from '@/ui/primitives/alert';
+
+export type StyledPlanSelectorProps = Omit<PlanSelectorProps, 'render'>;
+
+export function PlanSelector(props: StyledPlanSelectorProps) {
+  return (
+    <HeadlessPlanSelector
+      {...props}
+      render={({ plans, isLoading, error, selectPlan }) => {
+        if (isLoading) return <div>Loading plans...</div>;
+        if (error) return <Alert variant="destructive">{error}</Alert>;
+        return (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {plans.map((plan) => (
+              <PlanCard key={plan.id} plan={plan} onSelect={selectPlan} />
+            ))}
+          </div>
+        );
+      }}
+    />
+  );
+}

--- a/src/ui/styled/subscription/SubscriptionManager.tsx
+++ b/src/ui/styled/subscription/SubscriptionManager.tsx
@@ -1,0 +1,35 @@
+import { SubscriptionManager as HeadlessSubscriptionManager, type SubscriptionManagerProps } from '@/ui/headless/subscription/SubscriptionManager';
+import { Button } from '@/ui/primitives/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/ui/primitives/card';
+import { Alert } from '@/ui/primitives/alert';
+
+export type StyledSubscriptionManagerProps = Omit<SubscriptionManagerProps, 'render'>;
+
+export function SubscriptionManager(props: StyledSubscriptionManagerProps) {
+  return (
+    <HeadlessSubscriptionManager
+      {...props}
+      render={({ subscription, isLoading, error, cancel, refresh }) => {
+        if (isLoading) return <div>Loading...</div>;
+        if (error) return <Alert variant="destructive">{error}</Alert>;
+        return (
+          <Card>
+            <CardHeader>
+              <CardTitle>Subscription</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {subscription ? (
+                <>
+                  <p className="text-sm">Plan: {subscription.planId}</p>
+                  <Button onClick={cancel}>Cancel</Button>
+                </>
+              ) : (
+                <Button onClick={refresh}>Refresh</Button>
+              )}
+            </CardContent>
+          </Card>
+        );
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add `useSubscription` and `useBilling` hooks
- add tests for new hooks
- implement headless subscription components
- add styled subscription UI components

## Testing
- `npx vitest run --coverage src/hooks/subscription/__tests__/use-subscription.test.ts src/hooks/subscription/__tests__/use-billing.test.ts`
- `npm run lint` *(fails: many unrelated warnings and errors)*