### PR TITLE
Implement session management hook and UI components

### DIFF
--- a/src/hooks/session/__tests__/use-session.test.tsx
+++ b/src/hooks/session/__tests__/use-session.test.tsx
@@ -1,0 +1,81 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { SessionProvider } from '@/lib/context/SessionContext';
+import type { SessionService } from '@/core/session/interfaces';
+import { useSession } from '../use-session';
+
+const mockService: SessionService = {
+  listUserSessions: vi.fn(),
+  revokeUserSession: vi.fn(),
+};
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <SessionProvider sessionService={mockService}>{children}</SessionProvider>
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useSession', () => {
+  it('fetches sessions successfully', async () => {
+    (mockService.listUserSessions as any).mockResolvedValue([
+      { id: '1', is_current: true },
+      { id: '2', is_current: false },
+    ]);
+    const { result } = renderHook(() => useSession(), { wrapper });
+    await act(async () => {
+      await result.current.fetchSessions();
+    });
+    expect(mockService.listUserSessions).toHaveBeenCalled();
+    expect(result.current.sessions.length).toBe(2);
+    expect(result.current.currentSession?.id).toBe('1');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('handles fetch error', async () => {
+    (mockService.listUserSessions as any).mockRejectedValue(new Error('fail'));
+    const { result } = renderHook(() => useSession(), { wrapper });
+    await act(async () => {
+      await result.current.fetchSessions();
+    });
+    expect(result.current.sessions).toEqual([]);
+    expect(result.current.error).toBe('fail');
+  });
+
+  it('terminates a session', async () => {
+    (mockService.revokeUserSession as any).mockResolvedValue(undefined);
+    const { result } = renderHook(() => useSession(), { wrapper });
+    result.current['sessions'] = [ { id: '1', is_current: false } as any ];
+    await act(async () => {
+      await result.current.terminateSession('1');
+    });
+    expect(mockService.revokeUserSession).toHaveBeenCalledWith('me', '1');
+    expect(result.current.sessions).toEqual([]);
+  });
+
+  it('handles terminate error', async () => {
+    (mockService.revokeUserSession as any).mockRejectedValue(new Error('oops'));
+    const { result } = renderHook(() => useSession(), { wrapper });
+    await act(async () => {
+      await result.current.terminateSession('1');
+    });
+    expect(result.current.error).toBe('oops');
+  });
+
+  it('terminates all other sessions', async () => {
+    (mockService.revokeUserSession as any).mockResolvedValue(undefined);
+    const { result } = renderHook(() => useSession(), { wrapper });
+    result.current['sessions'] = [
+      { id: '1', is_current: true } as any,
+      { id: '2', is_current: false } as any,
+    ];
+    result.current['currentSession'] = { id: '1', is_current: true } as any;
+    await act(async () => {
+      await result.current.terminateAllOtherSessions();
+    });
+    expect(mockService.revokeUserSession).toHaveBeenCalledWith('me', '2');
+    expect(result.current.sessions).toEqual([{ id: '1', is_current: true } as any]);
+  });
+});

--- a/src/hooks/session/use-session.ts
+++ b/src/hooks/session/use-session.ts
@@ -1,0 +1,72 @@
+import { useState, useCallback } from 'react';
+import type { SessionInfo as Session } from '@/core/session/models';
+import { useSessionService } from '@/lib/context/SessionContext';
+
+export function useSession() {
+  const sessionService = useSessionService();
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [currentSession, setCurrentSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSessions = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await sessionService.listUserSessions('me');
+      setSessions(data);
+      setCurrentSession(data.find(s => (s as any).is_current) || null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to fetch sessions';
+      setError(message);
+      setSessions([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionService]);
+
+  const terminateSession = useCallback(async (id: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      await sessionService.revokeUserSession('me', id);
+      setSessions(prev => prev.filter(s => s.id !== id));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to terminate session';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionService]);
+
+  const terminateAllOtherSessions = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const currentId = currentSession?.id;
+      for (const s of sessions) {
+        if (s.id !== currentId) {
+          await sessionService.revokeUserSession('me', s.id);
+        }
+      }
+      setSessions(currentId ? sessions.filter(s => s.id === currentId) : []);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to terminate sessions';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionService, sessions, currentSession]);
+
+  return {
+    sessions,
+    currentSession,
+    loading,
+    error,
+    fetchSessions,
+    terminateSession,
+    terminateAllOtherSessions
+  };
+}
+
+export default useSession;

--- a/src/lib/context/SessionContext.tsx
+++ b/src/lib/context/SessionContext.tsx
@@ -1,0 +1,27 @@
+import React, { createContext, useContext } from 'react';
+import type { SessionService } from '@/core/session/interfaces';
+
+interface SessionContextValue {
+  sessionService: SessionService;
+}
+
+const SessionContext = createContext<SessionContextValue | undefined>(undefined);
+
+export interface SessionProviderProps {
+  sessionService: SessionService;
+  children: React.ReactNode;
+}
+
+export const SessionProvider: React.FC<SessionProviderProps> = ({ sessionService, children }) => (
+  <SessionContext.Provider value={{ sessionService }}>{children}</SessionContext.Provider>
+);
+
+export function useSessionService(): SessionService {
+  const context = useContext(SessionContext);
+  if (!context) {
+    throw new Error('useSessionService must be used within a SessionProvider');
+  }
+  return context.sessionService;
+}
+
+export default SessionProvider;

--- a/src/services/session/default-session.service.ts
+++ b/src/services/session/default-session.service.ts
@@ -1,0 +1,22 @@
+import { SessionService } from '@/core/session/interfaces';
+import type { SessionInfo } from '@/core/session/models';
+import type { AxiosInstance } from 'axios';
+import type { SessionDataProvider } from '@/adapters/session/interfaces';
+
+export class DefaultSessionService implements SessionService {
+  constructor(
+    private apiClient: AxiosInstance,
+    // Data provider kept for future use
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    private _provider?: SessionDataProvider
+  ) {}
+
+  async listUserSessions(_userId: string): Promise<SessionInfo[]> {
+    const response = await this.apiClient.get('/api/session');
+    return response.data.sessions || [];
+  }
+
+  async revokeUserSession(_userId: string, sessionId: string): Promise<void> {
+    await this.apiClient.delete(`/api/session/${sessionId}`);
+  }
+}

--- a/src/services/session/index.ts
+++ b/src/services/session/index.ts
@@ -1,0 +1,15 @@
+import { DefaultSessionService } from './default-session.service';
+import type { SessionService } from '@/core/session/interfaces';
+import type { AxiosInstance } from 'axios';
+import type { SessionDataProvider } from '@/adapters/session/interfaces';
+
+export interface SessionServiceConfig {
+  apiClient: AxiosInstance;
+  sessionDataProvider?: SessionDataProvider;
+}
+
+export function createSessionService(config: SessionServiceConfig): SessionService {
+  return new DefaultSessionService(config.apiClient, config.sessionDataProvider);
+}
+
+export default { createSessionService };

--- a/src/ui/headless/session/SessionList.tsx
+++ b/src/ui/headless/session/SessionList.tsx
@@ -1,0 +1,21 @@
+import type { SessionInfo } from '@/core/session/models';
+import React from 'react';
+
+export interface SessionListRenderProps {
+  sessions: SessionInfo[];
+  currentSessionId?: string;
+  loading: boolean;
+  error?: string | null;
+  onTerminate: (id: string) => void;
+  onTerminateAll: () => void;
+}
+
+export interface SessionListProps extends SessionListRenderProps {
+  render: (props: SessionListRenderProps) => React.ReactNode;
+}
+
+export function SessionList({ render, ...props }: SessionListProps) {
+  return <>{render(props)}</>;
+}
+
+export default SessionList;

--- a/src/ui/headless/session/SessionManager.tsx
+++ b/src/ui/headless/session/SessionManager.tsx
@@ -1,0 +1,46 @@
+'use client';
+import React, { useEffect } from 'react';
+import { useSession } from '@/hooks/session/use-session';
+import type { SessionInfo } from '@/core/session/models';
+
+export interface SessionManagerRenderProps {
+  sessions: SessionInfo[];
+  currentSession: SessionInfo | null;
+  loading: boolean;
+  error?: string | null;
+  fetchSessions: () => Promise<void>;
+  terminate: (id: string) => Promise<void>;
+  terminateOthers: () => Promise<void>;
+}
+
+export interface SessionManagerProps {
+  render: (props: SessionManagerRenderProps) => React.ReactNode;
+}
+
+export function SessionManager({ render }: SessionManagerProps) {
+  const {
+    sessions,
+    currentSession,
+    loading,
+    error,
+    fetchSessions,
+    terminateSession,
+    terminateAllOtherSessions,
+  } = useSession();
+
+  useEffect(() => { fetchSessions(); }, [fetchSessions]);
+
+  return (
+    <>{render({
+      sessions,
+      currentSession,
+      loading,
+      error,
+      fetchSessions,
+      terminate: terminateSession,
+      terminateOthers: terminateAllOtherSessions,
+    })}</>
+  );
+}
+
+export default SessionManager;

--- a/src/ui/styled/session/SessionCard.tsx
+++ b/src/ui/styled/session/SessionCard.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import type { SessionInfo } from '@/core/session/models';
+
+export interface SessionCardProps {
+  session: SessionInfo;
+  isCurrent?: boolean;
+  onTerminate?: (id: string) => void;
+}
+
+export function SessionCard({ session, isCurrent, onTerminate }: SessionCardProps) {
+  return (
+    <div className="border rounded p-2 flex items-center justify-between">
+      <div>
+        <div className="font-medium">{session.user_agent || 'Unknown'}</div>
+        <div className="text-xs text-gray-500">{session.ip_address || '-'} | {session.last_active_at ? new Date(session.last_active_at).toLocaleString() : '-'}</div>
+      </div>
+      {isCurrent ? (
+        <span className="text-sm text-gray-500">Current</span>
+      ) : (
+        <button className="text-sm text-red-600 hover:underline" onClick={() => onTerminate?.(session.id)}>
+          Revoke
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default SessionCard;

--- a/src/ui/styled/session/SessionList.tsx
+++ b/src/ui/styled/session/SessionList.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { SessionList as HeadlessSessionList } from '@/ui/headless/session/SessionList';
+import type { SessionInfo } from '@/core/session/models';
+
+export interface StyledSessionListProps {
+  sessions: SessionInfo[];
+  currentSessionId?: string;
+  loading: boolean;
+  error?: string | null;
+  onTerminate: (id: string) => void;
+  onTerminateAll: () => void;
+}
+
+export function SessionList(props: StyledSessionListProps) {
+  return (
+    <HeadlessSessionList
+      {...props}
+      render={({ sessions, currentSessionId, loading, error, onTerminate, onTerminateAll }) => (
+        <div className="rounded border p-4 max-w-lg mx-auto bg-white shadow">
+          <h3 className="text-lg font-semibold mb-2">Active Sessions</h3>
+          {loading ? (
+            <div className="text-gray-500">Loading sessions...</div>
+          ) : error ? (
+            <div className="text-red-600">{error}</div>
+          ) : sessions.length === 0 ? (
+            <div className="text-gray-500">No active sessions found.</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200 text-sm">
+                <thead>
+                  <tr>
+                    <th className="px-4 py-2 text-left">Device</th>
+                    <th className="px-4 py-2 text-left">IP</th>
+                    <th className="px-4 py-2 text-left">Last Active</th>
+                    <th className="px-4 py-2 text-left">Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sessions.map(session => (
+                    <tr key={session.id} className={session.id === currentSessionId ? 'bg-blue-50' : ''}>
+                      <td className="px-4 py-2">
+                        {session.user_agent || 'Unknown'}
+                        {session.id === currentSessionId && (
+                          <span className="ml-2 text-xs text-blue-600 font-semibold">(Current)</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-2">{session.ip_address || '-'}</td>
+                      <td className="px-4 py-2">{session.last_active_at ? new Date(session.last_active_at).toLocaleString() : '-'}</td>
+                      <td className="px-4 py-2">
+                        {session.id === currentSessionId ? (
+                          <span className="text-gray-400">Active</span>
+                        ) : (
+                          <button
+                            className="text-red-600 hover:underline"
+                            onClick={() => onTerminate(session.id)}
+                          >
+                            Revoke
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {sessions.length > 1 && (
+                <div className="mt-4 text-right">
+                  <button className="text-sm text-red-600 hover:underline" onClick={onTerminateAll}>
+                    Terminate Other Sessions
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    />
+  );
+}
+
+export default SessionList;

--- a/src/ui/styled/session/SessionManager.tsx
+++ b/src/ui/styled/session/SessionManager.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { SessionManager as HeadlessSessionManager } from '@/ui/headless/session/SessionManager';
+import SessionList from './SessionList';
+
+export function SessionManager() {
+  return (
+    <HeadlessSessionManager
+      render={({ sessions, currentSession, loading, error, terminate, terminateOthers }) => (
+        <SessionList
+          sessions={sessions}
+          currentSessionId={currentSession?.id}
+          loading={loading}
+          error={error}
+          onTerminate={terminate}
+          onTerminateAll={terminateOthers}
+        />
+      )}
+    />
+  );
+}
+
+export default SessionManager;


### PR DESCRIPTION
## Summary
- add SessionContext for providing session service
- implement session management hook with terminate helpers
- create session service with axios API calls
- add headless SessionManager and SessionList components
- provide styled components for session UI
- test useSession hook

## Testing
- `npm run test:coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*