### PR TITLE
Refactor webhook sender to use new interfaces

### DIFF
--- a/src/lib/webhooks/__tests__/webhook-sender.test.ts
+++ b/src/lib/webhooks/__tests__/webhook-sender.test.ts
@@ -1,11 +1,11 @@
-import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { sendWebhookEvent, getWebhookDeliveries } from '../webhook-sender';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createWebhookSender } from '../webhook-sender';
+import type { IWebhookDataProvider } from '@/core/webhooks';
 import crypto from 'crypto';
 
 // Mock fetch
-global.fetch = vi.fn();
+(global.fetch as any) = vi.fn();
 
-// Mock crypto
 vi.mock('crypto', () => ({
   createHmac: vi.fn().mockReturnValue({
     update: vi.fn().mockReturnThis(),
@@ -13,310 +13,79 @@ vi.mock('crypto', () => ({
   })
 }));
 
-// Mock dependencies
-vi.mock('@/lib/database/supabase', () => ({
-  getServiceSupabase: vi.fn()
-}));
+describe('webhook sender', () => {
+  let provider: IWebhookDataProvider & Record<string, any>;
+  let sendWebhookEvent: ReturnType<typeof createWebhookSender>['sendWebhookEvent'];
+  let getWebhookDeliveries: ReturnType<typeof createWebhookSender>['getWebhookDeliveries'];
 
-// Import the mocked supabase directly
-import { getServiceSupabase } from '@/lib/database/supabase';
-
-describe('Webhook Sender', () => {
-  let supabaseMock: any;
-  
   beforeEach(() => {
-    // Reset fetch mock
     (global.fetch as any).mockReset();
-    
-    // Create a more flexible mock for Supabase that properly handles chaining
-    supabaseMock = {
-      from: vi.fn().mockReturnThis(),
-      select: vi.fn().mockReturnThis(),
-      insert: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockReturnThis(),
-      contains: vi.fn().mockReturnThis(),
-      order: vi.fn().mockReturnThis(),
-      limit: vi.fn().mockReturnThis()
-    };
-    
-    // Set up the mocked implementation
-    (getServiceSupabase as any).mockReturnValue(supabaseMock);
+    provider = {
+      listWebhooks: vi.fn(),
+      getWebhook: vi.fn(),
+      createWebhook: vi.fn(),
+      updateWebhook: vi.fn(),
+      deleteWebhook: vi.fn(),
+      listDeliveries: vi.fn(),
+      recordDelivery: vi.fn()
+    } as unknown as IWebhookDataProvider & Record<string, any>;
+
+    ({ sendWebhookEvent, getWebhookDeliveries } = createWebhookSender(provider));
   });
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('sendWebhookEvent', () => {
-    it('should fetch webhooks subscribed to the event type', async () => {
-      // Configure the mock for this specific test case
-      // The last method in the chain should return the resolved value
-      supabaseMock.eq.mockResolvedValueOnce({ data: [], error: null });
-
-      await sendWebhookEvent('user_created', { id: 'user-1' });
-      
-      expect(supabaseMock.from).toHaveBeenCalledWith('webhooks');
-      expect(supabaseMock.select).toHaveBeenCalledWith('id, url, secret');
-      expect(supabaseMock.contains).toHaveBeenCalledWith('events', ['user_created']);
-      expect(supabaseMock.eq).toHaveBeenCalledWith('is_active', true);
-    });
-
-    it('should filter webhooks by user ID when provided', async () => {
-      // The last method in the chain should return the resolved value
-      supabaseMock.eq.mockResolvedValueOnce({ data: [], error: null });
-
-      await sendWebhookEvent('user_created', { id: 'user-1' }, 'test-user-id');
-      
-      expect(supabaseMock.from).toHaveBeenCalledWith('webhooks');
-      expect(supabaseMock.eq).toHaveBeenCalledWith('user_id', 'test-user-id');
-    });
-
-    it('should send a webhook to each configured endpoint', async () => {
-      // Mock successful fetch of webhooks
-      const mockWebhooks = [
-        { id: 'webhook-1', url: 'https://endpoint1.com', secret: 'secret1' },
-        { id: 'webhook-2', url: 'https://endpoint2.com', secret: 'secret2' }
-      ];
-      
-      // For the query, the last eq() call should return the resolved value
-      supabaseMock.eq.mockResolvedValueOnce({ data: mockWebhooks, error: null });
-      
-      // For the insert calls, they will return success
-      supabaseMock.insert.mockResolvedValue({ error: null });
-      
-      // Mock successful HTTP responses
-      (global.fetch as any)
-        .mockResolvedValueOnce({
-          ok: true,
-          status: 200,
-          text: async () => '{"received":true}'
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          status: 201,
-          text: async () => 'Accepted'
-        });
-
-      const eventType = 'user_created';
-      const payload = { id: 'user-1', name: 'Test User' };
-      
-      const results = await sendWebhookEvent(eventType, payload);
-      
-      // Should have two successful results
-      expect(results.length).toBe(2);
-      expect(results[0].success).toBe(true);
-      expect(results[1].success).toBe(true);
-      
-      // Should have made two fetch calls
-      expect(global.fetch).toHaveBeenCalledTimes(2);
-      
-      // Verify first fetch call
-      expect(global.fetch).toHaveBeenCalledWith('https://endpoint1.com', expect.objectContaining({
-        method: 'POST',
-        headers: expect.objectContaining({
-          'Content-Type': 'application/json',
-          'X-Webhook-Signature': 'mocked-signature',
-          'X-Webhook-Event': eventType
-        })
-      }));
-      
-      // Verify payload content in first fetch call
-      const [, options1] = (global.fetch as any).mock.calls[0];
-      const body1 = JSON.parse(options1.body);
-      expect(body1).toEqual({
-        event: eventType,
-        data: payload
-      });
-      
-      // Verify second fetch call
-      expect(global.fetch).toHaveBeenCalledWith('https://endpoint2.com', expect.any(Object));
-    });
-
-    it('should sign the payload with the webhook secret', async () => {
-      // Mock successful fetch of one webhook
-      supabaseMock.eq.mockResolvedValueOnce({
-        data: [{ id: 'webhook-1', url: 'https://endpoint.com', secret: 'test-secret' }],
-        error: null
-      });
-      
-      // For the insert call
-      supabaseMock.insert.mockResolvedValue({ error: null });
-      
-      // Mock successful HTTP response
-      (global.fetch as any).mockResolvedValue({
-        ok: true,
-        status: 200,
-        text: async () => '{"received":true}'
-      });
-
-      await sendWebhookEvent('user_created', { id: 'user-1' });
-      
-      // Verify signature generation
-      expect(crypto.createHmac).toHaveBeenCalledWith('sha256', 'test-secret');
-    });
-
-    it('should record delivery success in the database', async () => {
-      // Mock successful fetch of one webhook
-      supabaseMock.eq.mockResolvedValueOnce({
-        data: [{ id: 'webhook-1', url: 'https://endpoint.com', secret: 'test-secret' }],
-        error: null
-      });
-      
-      // Mock successful HTTP response
-      (global.fetch as any).mockResolvedValue({
-        ok: true,
-        status: 200,
-        text: async () => '{"received":true}'
-      });
-      
-      // Mock successful insert
-      supabaseMock.insert.mockResolvedValue({ error: null });
-
-      await sendWebhookEvent('user_created', { id: 'user-1' });
-      
-      // Verify record creation
-      expect(supabaseMock.from).toHaveBeenCalledWith('webhook_deliveries');
-      expect(supabaseMock.insert).toHaveBeenCalledWith(expect.objectContaining({
-        webhook_id: 'webhook-1',
-        event_type: 'user_created',
-        status_code: 200,
-        response: '{"received":true}'
-      }));
-    });
-
-    it('should handle webhook delivery failures', async () => {
-      // Mock successful fetch of one webhook
-      supabaseMock.eq.mockResolvedValueOnce({
-        data: [{ id: 'webhook-1', url: 'https://endpoint.com', secret: 'test-secret' }],
-        error: null
-      });
-      
-      // Mock failed HTTP response
-      (global.fetch as any).mockResolvedValue({
-        ok: false,
-        status: 500,
-        text: async () => 'Internal Server Error'
-      });
-      
-      // Mock successful insert
-      supabaseMock.insert.mockResolvedValue({ error: null });
-
-      const results = await sendWebhookEvent('user_created', { id: 'user-1' });
-      
-      // Should have one failed result
-      expect(results.length).toBe(1);
-      expect(results[0].success).toBe(false);
-      expect(results[0].statusCode).toBe(500);
-      
-      // Verify error is recorded
-      expect(supabaseMock.insert).toHaveBeenCalledWith(expect.objectContaining({
-        webhook_id: 'webhook-1',
-        event_type: 'user_created',
-        status_code: 500,
-        response: 'Internal Server Error',
-        error: 'Failed with status: 500'
-      }));
-    });
-
-    it('should handle network errors during webhook delivery', async () => {
-      // Mock successful fetch of one webhook
-      supabaseMock.eq.mockResolvedValueOnce({
-        data: [{ id: 'webhook-1', url: 'https://endpoint.com', secret: 'test-secret' }],
-        error: null
-      });
-      
-      // Mock network error
-      const networkError = new Error('Network error');
-      (global.fetch as any).mockRejectedValue(networkError);
-      
-      // Mock successful insert
-      supabaseMock.insert.mockResolvedValue({ error: null });
-
-      const results = await sendWebhookEvent('user_created', { id: 'user-1' });
-      
-      // Should have one failed result
-      expect(results.length).toBe(1);
-      expect(results[0].success).toBe(false);
-      expect(results[0].error).toBe('Network error');
-      
-      // Verify error is recorded
-      expect(supabaseMock.insert).toHaveBeenCalledWith(expect.objectContaining({
-        webhook_id: 'webhook-1',
-        event_type: 'user_created',
-        error: 'Network error'
-      }));
-    });
-
-    it('should return empty array if no webhooks found', async () => {
-      // Mock no webhooks found
-      supabaseMock.eq.mockResolvedValueOnce({ data: null, error: null });
-
-      const results = await sendWebhookEvent('user_created', { id: 'user-1' });
-      
-      expect(results).toEqual([]);
-    });
-
-    it('should return empty array if database error occurs', async () => {
-      // Mock database error
-      supabaseMock.eq.mockResolvedValueOnce({ 
-        data: null,
-        error: { message: 'Database error' } 
-      });
-
-      const results = await sendWebhookEvent('user_created', { id: 'user-1' });
-      
-      expect(results).toEqual([]);
-    });
+  it('fetches webhooks for the user', async () => {
+    provider.listWebhooks.mockResolvedValueOnce([]);
+    await sendWebhookEvent('user.created', {}, 'user-1');
+    expect(provider.listWebhooks).toHaveBeenCalledWith('user-1');
   });
 
-  describe('getWebhookDeliveries', () => {
-    it('should fetch delivery history for a webhook', async () => {
-      // Mock delivery history
-      const mockDeliveries = [
-        {
-          id: 'delivery-1',
-          event_type: 'user_created',
-          status_code: 200,
-          created_at: '2023-01-01T00:00:00Z'
-        }
-      ];
-      
-      // The last method in the chain should return the resolved value
-      supabaseMock.limit.mockResolvedValueOnce({ data: mockDeliveries, error: null });
+  it('sends events to matching webhooks', async () => {
+    provider.listWebhooks.mockResolvedValueOnce([
+      { id: 'w1', url: 'https://a.com', secret: 's', events: ['user.created'], isActive: true },
+      { id: 'w2', url: 'https://b.com', secret: 's2', events: ['other'], isActive: true }
+    ]);
+    provider.recordDelivery.mockResolvedValue(undefined);
+    (global.fetch as any).mockResolvedValue({ ok: true, status: 200, text: async () => 'ok' });
 
-      const webhookId = 'webhook-1';
-      const deliveries = await getWebhookDeliveries(webhookId);
-      
-      expect(deliveries).toEqual(mockDeliveries);
-      
-      // Verify database query
-      expect(supabaseMock.from).toHaveBeenCalledWith('webhook_deliveries');
-      expect(supabaseMock.select).toHaveBeenCalledWith('id, event_type, status_code, created_at, error');
-      expect(supabaseMock.eq).toHaveBeenCalledWith('webhook_id', webhookId);
-      expect(supabaseMock.order).toHaveBeenCalledWith('created_at', { ascending: false });
-      expect(supabaseMock.limit).toHaveBeenCalledWith(10); // default limit
-    });
+    const results = await sendWebhookEvent('user.created', { id: 1 }, 'user');
 
-    it('should respect custom limit', async () => {
-      // Mock delivery history (empty for simplicity)
-      supabaseMock.limit.mockResolvedValueOnce({ data: [], error: null });
-
-      await getWebhookDeliveries('webhook-1', 20);
-      
-      // Verify limit used
-      expect(supabaseMock.limit).toHaveBeenCalledWith(20);
-    });
-
-    it('should return empty array if database error occurs', async () => {
-      // Mock database error
-      supabaseMock.limit.mockResolvedValueOnce({ 
-        data: null,
-        error: { message: 'Database error' } 
-      });
-
-      const deliveries = await getWebhookDeliveries('webhook-1');
-      
-      expect(deliveries).toEqual([]);
-    });
+    expect((global.fetch as any)).toHaveBeenCalledTimes(1);
+    expect(results[0].webhookId).toBe('w1');
   });
-}); 
+
+  it('records failures', async () => {
+    provider.listWebhooks.mockResolvedValueOnce([
+      { id: 'w1', url: 'https://a.com', secret: 's', events: ['user.created'], isActive: true }
+    ]);
+    provider.recordDelivery.mockResolvedValue(undefined);
+    (global.fetch as any).mockRejectedValue(new Error('fail'));
+
+    const results = await sendWebhookEvent('user.created', {}, 'user');
+
+    expect(results[0].success).toBe(false);
+    expect(provider.recordDelivery).toHaveBeenCalled();
+  });
+
+  it('signs payload with secret', async () => {
+    provider.listWebhooks.mockResolvedValueOnce([
+      { id: 'w1', url: 'https://a.com', secret: 'secret', events: ['e'], isActive: true }
+    ]);
+    provider.recordDelivery.mockResolvedValue(undefined);
+    (global.fetch as any).mockResolvedValue({ ok: true, status: 200, text: async () => '' });
+
+    await sendWebhookEvent('e', {}, 'user');
+
+    expect(crypto.createHmac).toHaveBeenCalledWith('sha256', 'secret');
+  });
+
+  it('gets deliveries via provider', async () => {
+    provider.listDeliveries.mockResolvedValueOnce([{ id: 'd', webhookId: 'w', eventType: 'e', createdAt: '' }]);
+    const res = await getWebhookDeliveries('user', 'w');
+    expect(provider.listDeliveries).toHaveBeenCalledWith('user', 'w', 10);
+    expect(res.length).toBe(1);
+  });
+});

--- a/src/lib/webhooks/webhook-sender.ts
+++ b/src/lib/webhooks/webhook-sender.ts
@@ -1,17 +1,18 @@
 import crypto from 'crypto';
-import { getServiceSupabase } from '@/lib/database/supabase';
+import type {
+  IWebhookDataProvider,
+  WebhookDelivery,
+} from '@/core/webhooks';
 
 interface WebhookPayload {
   event: string;
-  data: any;
+  data: unknown;
 }
 
-interface WebhookDeliveryResult {
+/** Result of a single webhook delivery */
+interface WebhookDeliveryResult extends WebhookDelivery {
+  /** Whether the delivery succeeded */
   success: boolean;
-  webhookId: string;
-  statusCode?: number;
-  error?: string;
-  response?: string;
 }
 
 /**
@@ -35,27 +36,11 @@ function signPayload(payload: string, secret: string): string {
  * @param error Error message, if any
  */
 async function recordDelivery(
-  webhookId: string,
-  eventType: string,
-  payload: any,
-  statusCode?: number,
-  response?: string,
-  error?: string
+  provider: IWebhookDataProvider,
+  delivery: WebhookDelivery
 ): Promise<void> {
-  const supabase = getServiceSupabase();
-  
   try {
-    await supabase
-      .from('webhook_deliveries')
-      .insert({
-        webhook_id: webhookId,
-        event_type: eventType,
-        payload,
-        status_code: statusCode,
-        response: response?.substring(0, 1000), // Limit response size
-        error: error?.substring(0, 1000), // Limit error size
-        created_at: new Date().toISOString()
-      });
+    await provider.recordDelivery(delivery);
   } catch (err) {
     console.error('Failed to record webhook delivery:', err);
   }
@@ -68,126 +53,106 @@ async function recordDelivery(
  * @param userId Optional: If provided, only sends to webhooks owned by this user
  * @returns Array of delivery results
  */
-export async function sendWebhookEvent(
-  eventType: string,
-  payload: any,
-  userId?: string
-): Promise<WebhookDeliveryResult[]> {
-  const supabase = getServiceSupabase();
-  
-  // Query for eligible webhooks that are subscribed to this event type
-  let query = supabase
-    .from('webhooks')
-    .select('id, url, secret')
-    .contains('events', [eventType])
-    .eq('is_active', true);
-  
-  // Add user filter if provided
-  if (userId) {
-    query = query.eq('user_id', userId);
-  }
-  
-  const { data: webhooks, error } = await query;
-  
-  if (error || !webhooks || webhooks.length === 0) {
-    if (error) {
-      console.error('Error fetching webhooks:', error);
-    }
-    return [];
-  }
-  
-  const results: WebhookDeliveryResult[] = [];
-  const completePayload: WebhookPayload = {
-    event: eventType,
-    data: payload
-  };
-  
-  // Convert payload to JSON string for signing and sending
-  const payloadStr = JSON.stringify(completePayload);
-  
-  // Send the event to each webhook in parallel
-  const deliveryPromises = webhooks.map(async (webhook) => {
-    try {
-      // Sign the payload
-      const signature = signPayload(payloadStr, webhook.secret);
-      
-      // Send the webhook request
-      const response = await fetch(webhook.url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Webhook-Signature': signature,
-          'X-Webhook-Event': eventType
-        },
-        body: payloadStr
-      });
-      
-      const responseText = await response.text();
-      const success = response.ok;
-      
-      // Record the delivery attempt
-      await recordDelivery(
-        webhook.id,
-        eventType,
-        completePayload,
-        response.status,
-        responseText,
-        success ? undefined : `Failed with status: ${response.status}`
-      );
-      
-      results.push({
-        success,
-        webhookId: webhook.id,
-        statusCode: response.status,
-        response: responseText
-      });
-    } catch (err) {
-      const errorMessage = err instanceof Error 
-        ? err.message 
-        : 'Unknown error delivering webhook';
-      
-      // Record the delivery failure
-      await recordDelivery(
-        webhook.id,
-        eventType,
-        completePayload,
-        undefined,
-        undefined,
-        errorMessage
-      );
-      
-      results.push({
-        success: false,
-        webhookId: webhook.id,
-        error: errorMessage
-      });
-    }
-  });
-  
-  await Promise.allSettled(deliveryPromises);
-  return results;
+export interface WebhookSender {
+  sendWebhookEvent(
+    eventType: string,
+    payload: unknown,
+    userId: string
+  ): Promise<WebhookDeliveryResult[]>;
+  getWebhookDeliveries(
+    userId: string,
+    webhookId: string,
+    limit?: number
+  ): Promise<WebhookDelivery[]>;
 }
 
-/**
- * Gets the delivery history for a specific webhook
- * @param webhookId The ID of the webhook
- * @param limit The maximum number of deliveries to return (default: 10)
- * @returns Array of delivery records
- */
-export async function getWebhookDeliveries(webhookId: string, limit = 10): Promise<any[]> {
-  const supabase = getServiceSupabase();
-  
-  const { data, error } = await supabase
-    .from('webhook_deliveries')
-    .select('id, event_type, status_code, created_at, error')
-    .eq('webhook_id', webhookId)
-    .order('created_at', { ascending: false })
-    .limit(limit);
-    
-  if (error) {
-    console.error('Error fetching webhook deliveries:', error);
-    return [];
+export function createWebhookSender(
+  provider: IWebhookDataProvider
+): WebhookSender {
+  async function sendWebhookEvent(
+    eventType: string,
+    payload: unknown,
+    userId: string
+  ): Promise<WebhookDeliveryResult[]> {
+    const webhooks = await provider.listWebhooks(userId);
+    const eligible = webhooks.filter(
+      (w) => w.isActive && w.events.includes(eventType)
+    );
+    if (eligible.length === 0) {
+      return [];
+    }
+
+    const fullPayload: WebhookPayload = { event: eventType, data: payload };
+    const payloadStr = JSON.stringify(fullPayload);
+
+    const results: WebhookDeliveryResult[] = [];
+
+    await Promise.allSettled(
+      eligible.map(async (webhook) => {
+        try {
+          const signature = signPayload(payloadStr, webhook.secret);
+          const response = await fetch(webhook.url, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Webhook-Signature': signature,
+              'X-Webhook-Event': eventType
+            },
+            body: payloadStr
+          });
+
+          const responseText = await response.text();
+
+          const delivery: WebhookDelivery = {
+            id:
+              (crypto as any).randomUUID?.() ||
+              crypto.randomBytes(16).toString('hex'),
+            webhookId: webhook.id,
+            eventType,
+            payload: fullPayload,
+            statusCode: response.status,
+            response: responseText,
+            createdAt: new Date().toISOString(),
+            ...(response.ok
+              ? {}
+              : { error: `Failed with status: ${response.status}` })
+          };
+
+          await recordDelivery(provider, delivery);
+
+          results.push({ ...delivery, success: response.ok });
+        } catch (err) {
+          const errorMessage =
+            err instanceof Error
+              ? err.message
+              : 'Unknown error delivering webhook';
+          const delivery: WebhookDelivery = {
+            id:
+              (crypto as any).randomUUID?.() ||
+              crypto.randomBytes(16).toString('hex'),
+            webhookId: webhook.id,
+            eventType,
+            payload: fullPayload,
+            error: errorMessage,
+            createdAt: new Date().toISOString()
+          };
+
+          await recordDelivery(provider, delivery);
+          results.push({ ...delivery, success: false });
+        }
+      })
+    );
+
+    return results;
   }
-  
-  return data || [];
-} 
+
+  async function getWebhookDeliveries(
+    userId: string,
+    webhookId: string,
+    limit = 10
+  ): Promise<WebhookDelivery[]> {
+    return provider.listDeliveries(userId, webhookId, limit);
+  }
+
+  return { sendWebhookEvent, getWebhookDeliveries };
+}


### PR DESCRIPTION
## Summary
- refactor webhook-sender to depend on the new `IWebhookDataProvider`
- add factory function `createWebhookSender` returning typed methods
- update unit tests for webhook sender to mock the new provider

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*