### PR TITLE
Implement GDPR hooks and UI

### DIFF
--- a/src/hooks/gdpr/__tests__/use-data-deletion.test.ts
+++ b/src/hooks/gdpr/__tests__/use-data-deletion.test.ts
@@ -1,0 +1,35 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useDataDeletion } from '../use-data-deletion';
+import { api } from '@/lib/api/axios';
+
+vi.mock('@/lib/api/axios', () => ({ api: { post: vi.fn() } }));
+
+const mockPost = api.post as unknown as ReturnType<typeof vi.fn>;
+
+describe('useDataDeletion', () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+  });
+
+  it('requests deletion successfully', async () => {
+    mockPost.mockResolvedValueOnce({});
+    const { result } = renderHook(() => useDataDeletion());
+    await act(async () => {
+      await result.current.requestDeletion();
+    });
+    expect(mockPost).toHaveBeenCalledWith('/gdpr/delete');
+    expect(result.current.success).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('handles error', async () => {
+    mockPost.mockRejectedValueOnce(new Error('oops'));
+    const { result } = renderHook(() => useDataDeletion());
+    await act(async () => {
+      await result.current.requestDeletion();
+    });
+    expect(result.current.success).toBe(false);
+    expect(result.current.error).toBe('oops');
+  });
+});

--- a/src/hooks/gdpr/__tests__/use-data-export.test.ts
+++ b/src/hooks/gdpr/__tests__/use-data-export.test.ts
@@ -1,0 +1,36 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useDataExport } from '../use-data-export';
+import { api } from '@/lib/api/axios';
+
+vi.mock('@/lib/api/axios', () => ({ api: { get: vi.fn() } }));
+
+const mockGet = api.get as unknown as ReturnType<typeof vi.fn>;
+
+describe('useDataExport', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('requests export and returns download url', async () => {
+    const blob = new Blob(['data'], { type: 'application/json' });
+    mockGet.mockResolvedValueOnce({ data: blob });
+    const { result } = renderHook(() => useDataExport());
+    await act(async () => {
+      await result.current.requestExport();
+    });
+    expect(mockGet).toHaveBeenCalledWith('/gdpr/export', { responseType: 'blob' });
+    expect(result.current.downloadUrl).toContain('blob:');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('handles error', async () => {
+    mockGet.mockRejectedValueOnce(new Error('fail'));
+    const { result } = renderHook(() => useDataExport());
+    await act(async () => {
+      await result.current.requestExport();
+    });
+    expect(result.current.error).toBe('fail');
+    expect(result.current.downloadUrl).toBeNull();
+  });
+});

--- a/src/hooks/gdpr/use-data-deletion.ts
+++ b/src/hooks/gdpr/use-data-deletion.ts
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { api } from '@/lib/api/axios';
+
+/**
+ * Hook for requesting deletion of personal data via the GDPR API.
+ */
+export function useDataDeletion() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const requestDeletion = async (): Promise<boolean> => {
+    setIsLoading(true);
+    setError(null);
+    setSuccess(false);
+    try {
+      await api.post('/gdpr/delete');
+      setSuccess(true);
+      return true;
+    } catch (err: any) {
+      setError(err?.response?.data?.error || err?.message || 'Deletion failed');
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { isLoading, error, success, requestDeletion };
+}
+
+export default useDataDeletion;

--- a/src/hooks/gdpr/use-data-export.ts
+++ b/src/hooks/gdpr/use-data-export.ts
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { api } from '@/lib/api/axios';
+
+/**
+ * Hook for requesting a personal data export via the GDPR API.
+ * Returns a download URL when the export is complete.
+ */
+export function useDataExport() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
+
+  const requestExport = async (): Promise<string | null> => {
+    setIsLoading(true);
+    setError(null);
+    setDownloadUrl(null);
+    try {
+      const response = await api.get('/gdpr/export', { responseType: 'blob' });
+      const blob = new Blob([response.data], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      setDownloadUrl(url);
+      return url;
+    } catch (err: any) {
+      setError(err?.message || 'Failed to export data');
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { isLoading, error, downloadUrl, requestExport };
+}
+
+export default useDataExport;

--- a/src/ui/headless/gdpr/ConsentManager.tsx
+++ b/src/ui/headless/gdpr/ConsentManager.tsx
@@ -1,0 +1,2 @@
+export { ConsentManagement as ConsentManager } from './ConsentManagement';
+export { ConsentManagement as default } from './ConsentManagement';

--- a/src/ui/headless/gdpr/DataDeletionRequest.tsx
+++ b/src/ui/headless/gdpr/DataDeletionRequest.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useDataDeletion } from '@/hooks/gdpr/use-data-deletion';
+
+export interface DataDeletionRequestProps {
+  render: (props: {
+    requestDeletion: () => Promise<void>;
+    isLoading: boolean;
+    success: boolean;
+    error: string | null;
+  }) => React.ReactNode;
+}
+
+export function DataDeletionRequest({ render }: DataDeletionRequestProps) {
+  const { requestDeletion, isLoading, success, error } = useDataDeletion();
+  return <>{render({ requestDeletion, isLoading, success, error })}</>;
+}
+
+export default DataDeletionRequest;

--- a/src/ui/headless/gdpr/DataExportRequest.tsx
+++ b/src/ui/headless/gdpr/DataExportRequest.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useDataExport } from '@/hooks/gdpr/use-data-export';
+
+export interface DataExportRequestProps {
+  render: (props: {
+    requestExport: () => Promise<void>;
+    isLoading: boolean;
+    error: string | null;
+    downloadUrl: string | null;
+  }) => React.ReactNode;
+}
+
+export function DataExportRequest({ render }: DataExportRequestProps) {
+  const { requestExport, isLoading, error, downloadUrl } = useDataExport();
+  return <>{render({ requestExport, isLoading, error, downloadUrl })}</>;
+}
+
+export default DataExportRequest;

--- a/src/ui/headless/gdpr/__tests__/DataDeletionRequest.test.tsx
+++ b/src/ui/headless/gdpr/__tests__/DataDeletionRequest.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DataDeletionRequest } from '../DataDeletionRequest';
+import { useDataDeletion } from '@/hooks/gdpr/use-data-deletion';
+
+vi.mock('@/hooks/gdpr/use-data-deletion', () => ({ useDataDeletion: vi.fn() }));
+
+const mockHook = useDataDeletion as unknown as ReturnType<typeof vi.fn>;
+
+describe('DataDeletionRequest', () => {
+  beforeEach(() => {
+    mockHook.mockReturnValue({
+      requestDeletion: vi.fn(),
+      isLoading: false,
+      success: false,
+      error: null,
+    });
+  });
+
+  it('calls requestDeletion', () => {
+    const { requestDeletion } = mockHook.mock.results[0].value;
+    const { getByRole } = render(
+      <DataDeletionRequest
+        render={({ requestDeletion: del }) => (
+          <button onClick={del}>delete</button>
+        )}
+      />
+    );
+    fireEvent.click(getByRole('button'));
+    expect(requestDeletion).toHaveBeenCalled();
+  });
+});

--- a/src/ui/headless/gdpr/__tests__/DataExportRequest.test.tsx
+++ b/src/ui/headless/gdpr/__tests__/DataExportRequest.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DataExportRequest } from '../DataExportRequest';
+import { useDataExport } from '@/hooks/gdpr/use-data-export';
+
+vi.mock('@/hooks/gdpr/use-data-export', () => ({ useDataExport: vi.fn() }));
+
+const mockHook = useDataExport as unknown as ReturnType<typeof vi.fn>;
+
+describe('DataExportRequest', () => {
+  beforeEach(() => {
+    mockHook.mockReturnValue({
+      requestExport: vi.fn(),
+      isLoading: false,
+      error: null,
+      downloadUrl: null,
+    });
+  });
+
+  it('calls requestExport', () => {
+    const { requestExport } = mockHook.mock.results[0].value;
+    const { getByRole } = render(
+      <DataExportRequest
+        render={({ requestExport: req }) => (
+          <button onClick={req}>export</button>
+        )}
+      />
+    );
+    fireEvent.click(getByRole('button'));
+    expect(requestExport).toHaveBeenCalled();
+  });
+});

--- a/src/ui/styled/gdpr/ConsentManager.tsx
+++ b/src/ui/styled/gdpr/ConsentManager.tsx
@@ -1,0 +1,2 @@
+export { ConsentManagement as ConsentManager } from './ConsentManagement';
+export { ConsentManagement as default } from './ConsentManagement';

--- a/src/ui/styled/gdpr/DataDeletionRequest.tsx
+++ b/src/ui/styled/gdpr/DataDeletionRequest.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Button } from "@/ui/primitives/button";
+import { Alert, AlertDescription } from "@/ui/primitives/alert";
+import { DataDeletionRequest as HeadlessDataDeletionRequest } from "../../headless/gdpr/DataDeletionRequest";
+
+export function DataDeletionRequest() {
+  return (
+    <HeadlessDataDeletionRequest
+      render={({ requestDeletion, isLoading, error }) => (
+        <div className="space-y-2">
+          {error && (
+            <Alert variant="destructive" role="alert">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <Button onClick={requestDeletion} disabled={isLoading}>
+            {isLoading ? "Submitting..." : "Delete My Data"}
+          </Button>
+        </div>
+      )}
+    />
+  );
+}
+
+export default DataDeletionRequest;

--- a/src/ui/styled/gdpr/DataExportRequest.tsx
+++ b/src/ui/styled/gdpr/DataExportRequest.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Button } from "@/ui/primitives/button";
+import { Alert, AlertDescription } from "@/ui/primitives/alert";
+import { DataExportRequest as HeadlessDataExportRequest } from "../../headless/gdpr/DataExportRequest";
+
+export function DataExportRequest() {
+  return (
+    <HeadlessDataExportRequest
+      render={({ requestExport, isLoading, error }) => (
+        <div className="space-y-2">
+          {error && (
+            <Alert variant="destructive" role="alert">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <Button onClick={requestExport} disabled={isLoading}>
+            {isLoading ? "Exporting..." : "Export My Data"}
+          </Button>
+        </div>
+      )}
+    />
+  );
+}
+
+export default DataExportRequest;

--- a/src/ui/styled/gdpr/PrivacyPreferences.tsx
+++ b/src/ui/styled/gdpr/PrivacyPreferences.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Checkbox } from "@/ui/primitives/checkbox";
+import { Label } from "@/ui/primitives/label";
+import { Button } from "@/ui/primitives/button";
+import { usePreferencesStore } from "@/lib/stores/preferences.store";
+
+export function PrivacyPreferences() {
+  const { preferences, updatePreferences } = usePreferencesStore();
+  const marketing = !!preferences?.notifications?.marketing;
+
+  const toggle = async () => {
+    await updatePreferences({ notifications: { ...preferences?.notifications, marketing: !marketing } });
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center space-x-2">
+        <Checkbox id="marketing" checked={marketing} onCheckedChange={toggle} />
+        <Label htmlFor="marketing">Allow marketing emails</Label>
+      </div>
+      <Button onClick={toggle}>Save</Button>
+    </div>
+  );
+}
+
+export default PrivacyPreferences;

--- a/src/ui/styled/gdpr/__tests__/ConsentManager.test.tsx
+++ b/src/ui/styled/gdpr/__tests__/ConsentManager.test.tsx
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import * as mod from '../ConsentManager';
+
+describe('ConsentManager re-export', () => {
+  it('exports component', () => {
+    expect(mod).toHaveProperty('ConsentManager');
+  });
+});

--- a/src/ui/styled/gdpr/__tests__/DataDeletionRequest.test.tsx
+++ b/src/ui/styled/gdpr/__tests__/DataDeletionRequest.test.tsx
@@ -1,0 +1,16 @@
+// @vitest-environment jsdom
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DataDeletionRequest } from '../DataDeletionRequest';
+
+vi.mock('../../headless/gdpr/DataDeletionRequest', () => ({
+  DataDeletionRequest: ({ render }: any) => render({ requestDeletion: vi.fn(), isLoading: false, error: null })
+}));
+
+describe('DataDeletionRequest styled', () => {
+  it('renders button', () => {
+    const { getByRole } = render(<DataDeletionRequest />);
+    fireEvent.click(getByRole('button'));
+    expect(getByRole('button')).toBeInTheDocument();
+  });
+});

--- a/src/ui/styled/gdpr/__tests__/DataExportRequest.test.tsx
+++ b/src/ui/styled/gdpr/__tests__/DataExportRequest.test.tsx
@@ -1,0 +1,16 @@
+// @vitest-environment jsdom
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DataExportRequest } from '../DataExportRequest';
+
+vi.mock('../../headless/gdpr/DataExportRequest', () => ({
+  DataExportRequest: ({ render }: any) => render({ requestExport: vi.fn(), isLoading: false, error: null })
+}));
+
+describe('DataExportRequest styled', () => {
+  it('renders button', () => {
+    const { getByRole } = render(<DataExportRequest />);
+    fireEvent.click(getByRole('button'));
+    expect(getByRole('button')).toBeInTheDocument();
+  });
+});

--- a/src/ui/styled/gdpr/__tests__/PrivacyPreferences.test.tsx
+++ b/src/ui/styled/gdpr/__tests__/PrivacyPreferences.test.tsx
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { PrivacyPreferences } from '../PrivacyPreferences';
+
+vi.mock('@/lib/stores/preferences.store', () => ({
+  usePreferencesStore: () => ({
+    preferences: { notifications: { marketing: false } },
+    updatePreferences: vi.fn(),
+  }),
+}));
+
+describe('PrivacyPreferences', () => {
+  it('toggles checkbox', () => {
+    const { getByLabelText } = render(<PrivacyPreferences />);
+    fireEvent.click(getByLabelText('Allow marketing emails'));
+    expect(getByLabelText('Allow marketing emails')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add GDPR hooks for data export and deletion
- create headless components for export and deletion requests
- add styled GDPR components and privacy preferences
- include basic tests for new hooks and components

## Testing
- `vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*