### PR TITLE
Add settings pages for API keys and sessions

### DIFF
--- a/app/settings/api-keys/page.tsx
+++ b/app/settings/api-keys/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+import '@/lib/i18n';
+import { useTranslation } from 'react-i18next';
+import { ApiKeyForm, ApiKeyList } from '@/ui/styled/api-keys';
+import { useApiKeys } from '@/hooks/api-keys/use-api-keys';
+
+export default function ApiKeysPage() {
+  const { t } = useTranslation();
+  const {
+    apiKeys,
+    isLoading,
+    error,
+    createApiKey,
+    revokeApiKey,
+    regenerateApiKey
+  } = useApiKeys();
+
+  return (
+    <div className="container mx-auto py-8 space-y-8 max-w-3xl">
+      <h1 className="text-2xl font-bold text-center md:text-left">
+        {t('apiKeys.title', 'API Keys')}
+      </h1>
+      <div className="bg-card rounded-lg shadow p-6">
+        <h2 className="text-xl font-semibold mb-4">
+          {t('apiKeys.create', 'Create New API Key')}
+        </h2>
+        <ApiKeyForm availablePermissions={[]} onCreated={() => {}} />
+      </div>
+      <div className="bg-card rounded-lg shadow p-6">
+        <h2 className="text-xl font-semibold mb-4">
+          {t('apiKeys.yourKeys', 'Your API Keys')}
+        </h2>
+        <ApiKeyList
+          apiKeys={apiKeys}
+          loading={isLoading}
+          error={error}
+          onRevoke={revokeApiKey}
+          onRegenerate={regenerateApiKey}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/settings/sessions/page.tsx
+++ b/app/settings/sessions/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+import '@/lib/i18n';
+import { useTranslation } from 'react-i18next';
+import { SessionManager } from '@/ui/styled/session/SessionManager';
+
+export default function SessionsPage() {
+  const { t } = useTranslation();
+  return (
+    <div className="container mx-auto py-8 space-y-8 max-w-3xl">
+      <h1 className="text-2xl font-bold text-center md:text-left">
+        {t('sessions.title', 'Active Sessions')}
+      </h1>
+      <SessionManager />
+    </div>
+  );
+}

--- a/src/ui/styled/api-keys/ApiKeyList.tsx
+++ b/src/ui/styled/api-keys/ApiKeyList.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/ui/primitives/card';
 import { Button } from '@/ui/primitives/button';
 import { Badge } from '@/ui/primitives/badge';
+import { ApiKeyList as HeadlessApiKeyList } from '@/ui/headless/api-keys/ApiKeyList';
 
 export function ApiKeyList() {
   return (


### PR DESCRIPTION
## Summary
- add new API Keys settings page
- add new Sessions settings page
- fix missing import in ApiKeyList styled component

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*