### PR TITLE
Add billing page with tests

### DIFF
--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -1,0 +1,72 @@
+'use client';
+import { useSubscription } from '@/hooks/subscription/use-subscription';
+import { useBilling } from '@/hooks/subscription/use-billing';
+import { SubscriptionManager } from '@/ui/styled/subscription/SubscriptionManager';
+import { PlanSelector } from '@/ui/styled/subscription/PlanSelector';
+import { BillingForm } from '@/ui/styled/subscription/BillingForm';
+import { InvoiceList } from '@/ui/styled/subscription/InvoiceList';
+
+export default function BillingPage() {
+  const {
+    subscription,
+    plans,
+    loading: subLoading,
+    error: subError,
+    changePlan,
+    cancelSubscription
+  } = useSubscription();
+
+  const {
+    billingInfo,
+    invoices,
+    loading: billLoading,
+    error: billError,
+    updateBillingInfo
+  } = useBilling();
+
+  return (
+    <div className="container mx-auto py-8 space-y-8 max-w-3xl">
+      <h1 className="text-2xl font-bold">Subscription Management</h1>
+
+      <div className="bg-card rounded-lg shadow p-6">
+        <h2 className="text-xl font-semibold mb-4">Current Subscription</h2>
+        <SubscriptionManager 
+          subscription={subscription}
+          loading={subLoading}
+          error={subError}
+          onCancel={cancelSubscription}
+        />
+      </div>
+
+      <div className="bg-card rounded-lg shadow p-6">
+        <h2 className="text-xl font-semibold mb-4">Available Plans</h2>
+        <PlanSelector 
+          plans={plans}
+          currentPlanId={subscription?.planId}
+          loading={subLoading}
+          error={subError}
+          onSelect={changePlan}
+        />
+      </div>
+
+      <div className="bg-card rounded-lg shadow p-6">
+        <h2 className="text-xl font-semibold mb-4">Billing Information</h2>
+        <BillingForm 
+          billingInfo={billingInfo}
+          loading={billLoading}
+          error={billError}
+          onUpdate={updateBillingInfo}
+        />
+      </div>
+
+      <div className="bg-card rounded-lg shadow p-6">
+        <h2 className="text-xl font-semibold mb-4">Invoice History</h2>
+        <InvoiceList 
+          invoices={invoices}
+          loading={billLoading}
+          error={billError}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/tests/smoke/billing.smoke.test.tsx
+++ b/src/tests/smoke/billing.smoke.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import BillingPage from '../../../app/billing/page';
+import { useSubscription } from '@/hooks/subscription/use-subscription';
+import { useBilling } from '@/hooks/subscription/use-billing';
+
+vi.mock('@/hooks/subscription/use-subscription');
+vi.mock('@/hooks/subscription/use-billing');
+
+describe('Smoke: Billing Page', () => {
+  it('renders subscription and billing sections', () => {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: 'jest',
+      configurable: true,
+    });
+    (useSubscription as unknown as vi.Mock).mockReturnValue({
+      subscription: null,
+      plans: [],
+      loading: false,
+      error: null,
+      fetchPlans: vi.fn(),
+      changePlan: vi.fn(),
+      cancelSubscription: vi.fn(),
+    });
+    (useBilling as unknown as vi.Mock).mockReturnValue({
+      billingInfo: null,
+      invoices: [],
+      paymentMethods: [],
+      paymentHistory: [],
+      loading: false,
+      error: null,
+      updateBillingInfo: vi.fn(),
+    });
+
+    render(<BillingPage />);
+    expect(screen.getByText(/Subscription Management/i)).toBeInTheDocument();
+    expect(screen.getByText(/Current Subscription/i)).toBeInTheDocument();
+    expect(screen.getByText(/Available Plans/i)).toBeInTheDocument();
+    expect(screen.getByText(/Billing Information/i)).toBeInTheDocument();
+    expect(screen.getByText(/Invoice History/i)).toBeInTheDocument();
+  });
+
+  it('renders with active subscription', () => {
+    (useSubscription as unknown as vi.Mock).mockReturnValue({
+      subscription: { id: 'sub1', planId: 'pro', status: 'active' },
+      plans: [{ id: 'pro', tier: 'pro', price: 10, features: [] }],
+      loading: false,
+      error: null,
+      fetchPlans: vi.fn(),
+      changePlan: vi.fn(),
+      cancelSubscription: vi.fn(),
+    });
+    (useBilling as unknown as vi.Mock).mockReturnValue({
+      billingInfo: { address: '123' },
+      invoices: [{ id: 'inv1', description: 'test', amount: 1 }],
+      paymentMethods: [{ id: 'pm1', type: 'card', brand: 'visa', last4: '1234', expiryMonth: '01', expiryYear: '25' }],
+      paymentHistory: [{ id: 'p1', date: '2020-01-01', description: 'test', amount: 1, status: 'succeeded' }],
+      loading: false,
+      error: null,
+      updateBillingInfo: vi.fn(),
+    });
+
+    render(<BillingPage />);
+    expect(screen.getByText(/Current Subscription/i)).toBeInTheDocument();
+    expect(screen.getByText(/Invoice History/i)).toBeInTheDocument();
+  });
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -104,7 +104,7 @@ Object.assign(mockStore, {
   subscribe: mockStore.subscribe,
   destroy: mockStore.destroy,
 });
-vi.mock('@/hooks/auth/use-auth', () => ({ useAuth: mockStore }));
+vi.mock('@/hooks/auth/useAuth', () => ({ useAuth: mockStore }));
 // --- End Auth Store mock --- 
 
 // --- Mock User Store ---


### PR DESCRIPTION
## Summary
- add `/billing` page using subscription and billing hooks
- cover billing page with smoke test
- fix useAuth mock path in vitest setup

## Testing
- `npx vitest run --coverage src/tests/smoke/billing.smoke.test.tsx`