### PR TITLE
Refactor API key components per template

### DIFF
--- a/app/settings/api-keys/page.tsx
+++ b/app/settings/api-keys/page.tsx
@@ -24,7 +24,11 @@ export default function ApiKeysPage() {
         <h2 className="text-xl font-semibold mb-4">
           {t('apiKeys.create', 'Create New API Key')}
         </h2>
-        <ApiKeyForm availablePermissions={[]} onCreated={() => {}} />
+        <ApiKeyForm
+          availablePermissions={[]}
+          onSubmit={createApiKey}
+          defaultPermissions={[]}
+        />
       </div>
       <div className="bg-card rounded-lg shadow p-6">
         <h2 className="text-xl font-semibold mb-4">

--- a/src/ui/headless/api-keys/ApiKeyForm.tsx
+++ b/src/ui/headless/api-keys/ApiKeyForm.tsx
@@ -1,5 +1,4 @@
 import { FormEvent, useState } from 'react';
-import { useApiKeys } from '@/hooks/api-keys/use-api-keys';
 import type { ApiKey } from '@/core/api-keys/types';
 
 export interface ApiKeyFormRenderProps {
@@ -16,12 +15,16 @@ export interface ApiKeyFormRenderProps {
 }
 
 export interface ApiKeyFormProps {
+  onSubmit: (
+    name: string,
+    permissions: string[],
+    expiresInDays?: number
+  ) => Promise<{ key: string } & ApiKey>;
   defaultPermissions?: string[];
   children: (props: ApiKeyFormRenderProps) => React.ReactNode;
 }
 
-export function ApiKeyForm({ children, defaultPermissions = [] }: ApiKeyFormProps) {
-  const { createApiKey } = useApiKeys();
+export function ApiKeyForm({ onSubmit, children, defaultPermissions = [] }: ApiKeyFormProps) {
   const [name, setName] = useState('');
   const [permissions, setPermissions] = useState<string[]>(defaultPermissions);
   const [expiresInDays, setExpiresInDays] = useState<number | undefined>(undefined);
@@ -40,7 +43,7 @@ export function ApiKeyForm({ children, defaultPermissions = [] }: ApiKeyFormProp
     setIsSubmitting(true);
     setError(null);
     try {
-      const key = await createApiKey(name, permissions, expiresInDays);
+      const key = await onSubmit(name, permissions, expiresInDays);
       setCreatedKey(key);
       setName('');
       setPermissions(defaultPermissions);

--- a/src/ui/headless/api-keys/ApiKeyList.tsx
+++ b/src/ui/headless/api-keys/ApiKeyList.tsx
@@ -1,23 +1,35 @@
 import type { ApiKey } from '@/core/api-keys/types';
-import { useApiKeys } from '@/hooks/api-keys/use-api-keys';
-
-export interface ApiKeyListRenderProps {
-  apiKeys: ApiKey[];
-  isLoading: boolean;
-  error: string | null;
-  revoke: (id: string) => Promise<void>;
-  regenerate: (id: string) => Promise<{ key: string } & ApiKey>;
-  refresh: () => Promise<void>;
-}
 
 export interface ApiKeyListProps {
-  children: (props: ApiKeyListRenderProps) => React.ReactNode;
+  apiKeys: ApiKey[];
+  loading: boolean;
+  error: string | null;
+  onRevoke: (id: string) => Promise<void>;
+  onRegenerate: (id: string) => Promise<{ key: string } & ApiKey>;
+  renderItem?: (
+    key: ApiKey,
+    actions: { onRevoke: (id: string) => Promise<void>; onRegenerate: (id: string) => Promise<{ key: string } & ApiKey> }
+  ) => React.ReactNode;
 }
 
-export function ApiKeyList({ children }: ApiKeyListProps) {
-  const { apiKeys, isLoading, error, revokeApiKey, regenerateApiKey, fetchApiKeys } = useApiKeys();
+export function ApiKeyList({ apiKeys, loading, error, onRevoke, onRegenerate, renderItem }: ApiKeyListProps) {
+  if (loading) {
+    return <p>Loading...</p>;
+  }
+
+  if (error) {
+    return (
+      <p className="text-destructive text-sm" role="alert">
+        {error}
+      </p>
+    );
+  }
 
   return (
-    <>{children({ apiKeys, isLoading, error, revoke: revokeApiKey, regenerate: regenerateApiKey, refresh: fetchApiKeys })}</>
+    <div className="space-y-4">
+      {apiKeys.map((key) => (
+        <div key={key.id}>{renderItem ? renderItem(key, { onRevoke, onRegenerate }) : null}</div>
+      ))}
+    </div>
   );
 }

--- a/src/ui/headless/api-keys/__tests__/ApiKeyList.test.tsx
+++ b/src/ui/headless/api-keys/__tests__/ApiKeyList.test.tsx
@@ -2,33 +2,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { ApiKeyList } from '../ApiKeyList';
-import { useApiKeys } from '@/hooks/api-keys/use-api-keys';
-
-vi.mock('@/hooks/api-keys/use-api-keys', () => ({ useApiKeys: vi.fn() }));
 
 describe('ApiKeyList', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    (useApiKeys as unknown as vi.Mock).mockReturnValue({
-      apiKeys: [{ id: '1', name: 'Key', keyPrefix: 'pref', permissions: [], createdAt: new Date(), isActive: true }],
-      isLoading: false,
-      error: null,
-      revokeApiKey: vi.fn(),
-      regenerateApiKey: vi.fn(),
-      fetchApiKeys: vi.fn()
-    });
-  });
-
-  it('provides api keys to children', () => {
-    let props: any;
-    render(
-      <ApiKeyList>
-        {(p) => {
-          props = p;
-          return <div />;
-        }}
-      </ApiKeyList>
+  it('renders api keys', () => {
+    const { getByText } = render(
+      <ApiKeyList
+        apiKeys={[{ id: '1', name: 'Key', keyPrefix: 'pref', permissions: [], createdAt: new Date(), isActive: true }]}
+        loading={false}
+        error={null}
+        onRevoke={vi.fn()}
+        onRegenerate={vi.fn()}
+        renderItem={(key) => <div>{key.name}</div>}
+      />
     );
-    expect(props.apiKeys.length).toBe(1);
+    expect(getByText('Key')).toBeInTheDocument();
   });
 });

--- a/src/ui/styled/api-keys/ApiKeyForm.tsx
+++ b/src/ui/styled/api-keys/ApiKeyForm.tsx
@@ -2,16 +2,18 @@ import { Input } from '@/ui/primitives/input';
 import { Button } from '@/ui/primitives/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/ui/primitives/card';
 import { Checkbox } from '@/ui/primitives/checkbox';
-import { ApiKeyForm as HeadlessApiKeyForm } from '@/ui/headless/api-keys/ApiKeyForm';
+import {
+  ApiKeyForm as HeadlessApiKeyForm,
+  ApiKeyFormProps as HeadlessApiKeyFormProps,
+} from '@/ui/headless/api-keys/ApiKeyForm';
 
-export interface ApiKeyFormProps {
+export interface ApiKeyFormProps extends HeadlessApiKeyFormProps {
   availablePermissions: string[];
-  onCreated?: (key: string) => void;
 }
 
-export function ApiKeyForm({ availablePermissions, onCreated }: ApiKeyFormProps) {
+export function ApiKeyForm({ availablePermissions, onSubmit, defaultPermissions }: ApiKeyFormProps) {
   return (
-    <HeadlessApiKeyForm>
+    <HeadlessApiKeyForm onSubmit={onSubmit} defaultPermissions={defaultPermissions}>
       {({
         name,
         setName,

--- a/src/ui/styled/api-keys/ApiKeyList.tsx
+++ b/src/ui/styled/api-keys/ApiKeyList.tsx
@@ -1,51 +1,45 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/ui/primitives/card';
 import { Button } from '@/ui/primitives/button';
 import { Badge } from '@/ui/primitives/badge';
-import { ApiKeyList as HeadlessApiKeyList } from '@/ui/headless/api-keys/ApiKeyList';
+import {
+  ApiKeyList as HeadlessApiKeyList,
+  ApiKeyListProps as HeadlessApiKeyListProps,
+} from '@/ui/headless/api-keys/ApiKeyList';
 
-export function ApiKeyList() {
+export function ApiKeyList(props: HeadlessApiKeyListProps) {
   return (
-    <HeadlessApiKeyList>
-      {({ apiKeys, isLoading, error, revoke, regenerate }) => (
-        <div className="space-y-4">
-          {isLoading && <p>Loading...</p>}
-          {error && (
-            <p className="text-destructive text-sm" role="alert">
-              {error}
-            </p>
-          )}
-          {apiKeys.map((key) => (
-            <Card key={key.id} className="flex flex-col md:flex-row md:items-center md:justify-between">
-              <CardHeader>
-                <CardTitle>{key.name}</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2">
-                <div className="flex items-center space-x-2">
-                  <span className="font-mono text-sm">{key.keyPrefix}...</span>
-                  <Badge variant={key.isActive ? 'default' : 'destructive'}>
-                    {key.isActive ? 'Active' : 'Revoked'}
-                  </Badge>
-                </div>
-                <div className="flex flex-wrap gap-1">
-                  {key.permissions.map((p) => (
-                    <Badge key={p} variant="secondary">
-                      {p}
-                    </Badge>
-                  ))}
-                </div>
-                <div className="flex space-x-2">
-                  <Button size="sm" variant="outline" onClick={() => regenerate(key.id)}>
-                    Regenerate
-                  </Button>
-                  <Button size="sm" variant="destructive" onClick={() => revoke(key.id)}>
-                    Revoke
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+    <HeadlessApiKeyList
+      {...props}
+      renderItem={(key, { onRevoke, onRegenerate }) => (
+        <Card key={key.id} className="flex flex-col md:flex-row md:items-center md:justify-between">
+          <CardHeader>
+            <CardTitle>{key.name}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <div className="flex items-center space-x-2">
+              <span className="font-mono text-sm">{key.keyPrefix}...</span>
+              <Badge variant={key.isActive ? 'default' : 'destructive'}>
+                {key.isActive ? 'Active' : 'Revoked'}
+              </Badge>
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {key.permissions.map((p) => (
+                <Badge key={p} variant="secondary">
+                  {p}
+                </Badge>
+              ))}
+            </div>
+            <div className="flex space-x-2">
+              <Button size="sm" variant="outline" onClick={() => onRegenerate(key.id)}>
+                Regenerate
+              </Button>
+              <Button size="sm" variant="destructive" onClick={() => onRevoke(key.id)}>
+                Revoke
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
       )}
-    </HeadlessApiKeyList>
+    />
   );
 }


### PR DESCRIPTION
## Summary
- adapt API key form and list to follow the UI integration template
- update API keys settings page to pass data via hooks
- adjust headless tests for new API key list

## Testing
- `npm run -s lint` *(fails: `'message' is assigned a value but never used` etc.)*
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*