### PR TITLE
Implement session page per integration template

### DIFF
--- a/app/settings/sessions/__tests__/page.test.tsx
+++ b/app/settings/sessions/__tests__/page.test.tsx
@@ -1,0 +1,31 @@
+import '@/tests/i18nTestSetup';
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+
+// Mock the useSession hook
+vi.mock('@/hooks/session/use-session', () => ({
+  useSession: () => ({
+    sessions: [
+      { id: '1', ip_address: '127.0.0.1', user_agent: 'Chrome', last_active_at: '2024-01-01T00:00:00Z', is_current: true },
+      { id: '2', ip_address: '10.0.0.2', user_agent: 'Firefox', last_active_at: '2024-01-02T00:00:00Z', is_current: false }
+    ],
+    currentSession: { id: '1', is_current: true },
+    loading: false,
+    error: null,
+    fetchSessions: vi.fn(),
+    terminateSession: vi.fn(),
+    terminateAllOtherSessions: vi.fn()
+  })
+}));
+
+import SessionsPage from '../page';
+
+describe('SessionsPage', () => {
+  it('renders active sessions list', () => {
+    render(<SessionsPage />);
+    expect(screen.getByText('Active Sessions')).toBeInTheDocument();
+    // The revoke button should be rendered for the second session
+    expect(screen.getAllByText('Revoke')).toHaveLength(1);
+    expect(screen.getByText('Terminate Other Sessions')).toBeInTheDocument();
+  });
+});

--- a/app/settings/sessions/page.tsx
+++ b/app/settings/sessions/page.tsx
@@ -1,16 +1,40 @@
 'use client';
+import React from 'react';
 import '@/lib/i18n';
 import { useTranslation } from 'react-i18next';
-import { SessionManager } from '@/ui/styled/session/SessionManager';
+import { useSession } from '@/hooks/session/use-session';
+import { SessionList } from '@/ui/styled/session/SessionList';
 
 export default function SessionsPage() {
   const { t } = useTranslation();
+  const {
+    sessions,
+    currentSession,
+    loading,
+    error,
+    fetchSessions,
+    terminateSession,
+    terminateAllOtherSessions
+  } = useSession();
+
+  // Fetch sessions on mount
+  React.useEffect(() => {
+    fetchSessions();
+  }, [fetchSessions]);
+
   return (
     <div className="container mx-auto py-8 space-y-8 max-w-3xl">
       <h1 className="text-2xl font-bold text-center md:text-left">
         {t('sessions.title', 'Active Sessions')}
       </h1>
-      <SessionManager />
+      <SessionList
+        sessions={sessions}
+        currentSessionId={currentSession?.id}
+        loading={loading}
+        error={error}
+        onTerminate={terminateSession}
+        onTerminateAll={terminateAllOtherSessions}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- refactor session settings page to use useSession hook
- add a basic test for the sessions page

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*