### PR TITLE
Integrate session management hooks

### DIFF
--- a/app/settings/sessions/page.tsx
+++ b/app/settings/sessions/page.tsx
@@ -2,39 +2,18 @@
 import React from 'react';
 import '@/lib/i18n';
 import { useTranslation } from 'react-i18next';
-import { useSession } from '@/hooks/session/use-session';
-import { SessionList } from '@/ui/styled/session/SessionList';
+import { SessionManager } from '@/ui/styled/session/SessionManager';
 
 export default function SessionsPage() {
   const { t } = useTranslation();
-  const {
-    sessions,
-    currentSession,
-    loading,
-    error,
-    fetchSessions,
-    terminateSession,
-    terminateAllOtherSessions
-  } = useSession();
-
-  // Fetch sessions on mount
-  React.useEffect(() => {
-    fetchSessions();
-  }, [fetchSessions]);
+  // All logic handled by SessionManager component
 
   return (
     <div className="container mx-auto py-8 space-y-8 max-w-3xl">
       <h1 className="text-2xl font-bold text-center md:text-left">
         {t('sessions.title', 'Active Sessions')}
       </h1>
-      <SessionList
-        sessions={sessions}
-        currentSessionId={currentSession?.id}
-        loading={loading}
-        error={error}
-        onTerminate={terminateSession}
-        onTerminateAll={terminateAllOtherSessions}
-      />
+      <SessionManager />
     </div>
   );
 }

--- a/src/ui/headless/profile/SessionManagement.tsx
+++ b/src/ui/headless/profile/SessionManagement.tsx
@@ -5,14 +5,15 @@
  */
 
 import { useEffect } from 'react';
-import { useSessionStore } from '@/lib/stores/session.store';
+import { useSession } from '@/hooks/session/use-session';
+import type { SessionInfo } from '@/core/session/models';
 
 export interface SessionManagementProps {
   render: (props: SessionManagementRenderProps) => React.ReactNode;
 }
 
 export interface SessionManagementRenderProps {
-  sessions: ReturnType<typeof useSessionStore>['sessions'];
+  sessions: SessionInfo[];
   loading: boolean;
   error?: string | null;
   revoke: (id: string) => Promise<void>;
@@ -22,28 +23,27 @@ export interface SessionManagementRenderProps {
 export function SessionManagement({ render }: SessionManagementProps) {
   const {
     sessions,
-    sessionLoading,
-    sessionError,
+    loading,
+    error,
     fetchSessions,
-    revokeSession,
-  } = useSessionStore();
+    terminateSession,
+    terminateAllOtherSessions,
+  } = useSession();
 
   useEffect(() => {
     fetchSessions();
   }, [fetchSessions]);
 
   const revokeAll = async () => {
-    for (const s of sessions) {
-      if (!s.is_current) await revokeSession(s.id);
-    }
+    await terminateAllOtherSessions();
   };
 
   return (
     <>{render({
       sessions,
-      loading: sessionLoading,
-      error: sessionError,
-      revoke: revokeSession,
+      loading,
+      error,
+      revoke: terminateSession,
       revokeAll,
     })}</>
   );

--- a/src/ui/styled/profile/__tests__/SessionManagement.test.tsx
+++ b/src/ui/styled/profile/__tests__/SessionManagement.test.tsx
@@ -3,10 +3,10 @@ import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import SessionManagement from '../SessionManagement';
-import { useSessionStore } from '@/lib/stores/session.store';
+import { useSession } from '@/hooks/session/use-session';
 
-// Mock Zustand store
-vi.mock('@/lib/stores/session.store');
+// Mock useSession hook
+vi.mock('@/hooks/session/use-session');
 
 const mockSessions = [
   {
@@ -27,17 +27,20 @@ const mockSessions = [
 
 describe('SessionManagement', () => {
   let fetchSessions: any;
-  let revokeSession: any;
+  let terminateSession: any;
+  let terminateAllOtherSessions: any;
 
   beforeEach(() => {
     fetchSessions = vi.fn();
-    revokeSession = vi.fn();
-    (useSessionStore as any).mockReturnValue({
+    terminateSession = vi.fn();
+    terminateAllOtherSessions = vi.fn();
+    (useSession as any).mockReturnValue({
       sessions: mockSessions,
-      sessionLoading: false,
-      sessionError: '',
+      loading: false,
+      error: '',
       fetchSessions,
-      revokeSession,
+      terminateSession,
+      terminateAllOtherSessions,
     });
   });
 
@@ -72,17 +75,18 @@ describe('SessionManagement', () => {
       await userEvent.click(confirmBtn!);
     });
     await waitFor(() => {
-      expect(revokeSession).toHaveBeenCalledWith('session-2');
+      expect(terminateSession).toHaveBeenCalledWith('session-2');
     });
   });
 
   it('shows loading state', async () => {
-    (useSessionStore as any).mockReturnValue({
+    (useSession as any).mockReturnValue({
       sessions: [],
-      sessionLoading: true,
-      sessionError: '',
+      loading: true,
+      error: '',
       fetchSessions,
-      revokeSession,
+      terminateSession,
+      terminateAllOtherSessions,
     });
     await act(async () => {
       render(<SessionManagement />);
@@ -91,12 +95,13 @@ describe('SessionManagement', () => {
   });
 
   it('shows error state', async () => {
-    (useSessionStore as any).mockReturnValue({
+    (useSession as any).mockReturnValue({
       sessions: [],
-      sessionLoading: false,
-      sessionError: 'Failed to fetch',
+      loading: false,
+      error: 'Failed to fetch',
       fetchSessions,
-      revokeSession,
+      terminateSession,
+      terminateAllOtherSessions,
     });
     await act(async () => {
       render(<SessionManagement />);
@@ -105,12 +110,13 @@ describe('SessionManagement', () => {
   });
 
   it('shows empty state', async () => {
-    (useSessionStore as any).mockReturnValue({
+    (useSession as any).mockReturnValue({
       sessions: [],
-      sessionLoading: false,
-      sessionError: '',
+      loading: false,
+      error: '',
       fetchSessions,
-      revokeSession,
+      terminateSession,
+      terminateAllOtherSessions,
     });
     await act(async () => {
       render(<SessionManagement />);


### PR DESCRIPTION
## Summary
- use `SessionManager` component in sessions page
- refactor profile SessionManagement to use session hook
- adjust SessionManagement test to mock session hook

## Testing
- `npx vitest run --coverage` *(fails: useAuthStore is not defined)*