### PR TITLE
Add address management page

### DIFF
--- a/app/settings/addresses/__tests__/page.test.tsx
+++ b/app/settings/addresses/__tests__/page.test.tsx
@@ -1,0 +1,29 @@
+import '@/tests/i18nTestSetup';
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+
+vi.mock('@/hooks/address/use-addresses', () => ({
+  useAddresses: () => ({
+    addresses: [
+      { id: '1', userId: 'u1', type: 'shipping', isDefault: true, fullName: 'John Doe', street1: '123 Main', city: 'City', state: 'ST', postalCode: '12345', country: 'US', createdAt: new Date(), updatedAt: new Date() },
+    ],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    addAddress: vi.fn(),
+    updateAddress: vi.fn(),
+    deleteAddress: vi.fn(),
+    setDefaultAddress: vi.fn(),
+  })
+}));
+
+import AddressManagementPage from '../page';
+
+describe('AddressManagementPage', () => {
+  it('renders address list', () => {
+    render(<AddressManagementPage />);
+    expect(screen.getByText('Address Management')).toBeInTheDocument();
+    expect(screen.getByText('Saved Addresses')).toBeInTheDocument();
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+  });
+});

--- a/app/settings/addresses/page.tsx
+++ b/app/settings/addresses/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { Address } from '@/core/address/types';
+import { useAddresses } from '@/hooks/address/use-addresses';
+import { StyledAddressForm as AddressForm } from '@/ui/styled/address/AddressForm';
+import { StyledAddressList as AddressList } from '@/ui/styled/address/AddressList';
+
+export default function AddressManagementPage() {
+  const { t } = useTranslation();
+  const { addresses, loading, error, addAddress, updateAddress, deleteAddress, setDefaultAddress } = useAddresses();
+  const [editing, setEditing] = useState<Address | null>(null);
+
+  const handleSubmit = async (data: Omit<Address, 'id' | 'createdAt' | 'updatedAt'>) => {
+    if (editing) {
+      await updateAddress(editing.id, data);
+      setEditing(null);
+    } else {
+      await addAddress(data);
+    }
+  };
+
+  return (
+    <div className="container mx-auto py-8 space-y-8 max-w-3xl">
+      <h1 className="text-2xl font-bold text-center md:text-left">
+        {t('addresses.title', 'Address Management')}
+      </h1>
+      <div className="bg-card rounded-lg shadow p-6">
+        <h2 className="text-xl font-semibold mb-4">
+          {editing ? t('addresses.edit', 'Edit Address') : t('addresses.add', 'Add New Address')}
+        </h2>
+        <AddressForm onSubmit={handleSubmit} onCancel={() => setEditing(null)} initialValues={editing || undefined} loading={loading} />
+        {error && <p className="text-destructive text-sm mt-2">{error}</p>}
+      </div>
+      <div className="bg-card rounded-lg shadow p-6">
+        <h2 className="text-xl font-semibold mb-4">
+          {t('addresses.list', 'Saved Addresses')}
+        </h2>
+        <AddressList
+          addresses={addresses}
+          loading={loading}
+          onEdit={(addr) => setEditing(addr)}
+          onDelete={deleteAddress}
+          onSetDefault={setDefaultAddress}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate address management using template
- add basic test for address page

## Testing
- `vitest run app/settings/addresses/__tests__/page.test.tsx --coverage` *(fails: No test files found)*