### PR TITLE
Add GDPR settings page

### DIFF
--- a/app/settings/gdpr/__tests__/page.test.tsx
+++ b/app/settings/gdpr/__tests__/page.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+
+vi.mock('@/ui/styled/gdpr/DataExportRequest', () => ({ DataExportRequest: () => <div>ExportComponent</div> }));
+vi.mock('@/ui/styled/gdpr/DataDeletionRequest', () => ({ DataDeletionRequest: () => <div>DeleteComponent</div> }));
+vi.mock('@/ui/styled/gdpr/ConsentManagement', () => ({ ConsentManagement: () => <div>ConsentComponent</div> }));
+
+import GdprSettingsPage from '../page';
+
+describe('GdprSettingsPage', () => {
+  it('renders gdpr controls', () => {
+    render(<GdprSettingsPage />);
+    expect(screen.getByText('Privacy & Data Controls')).toBeInTheDocument();
+    expect(screen.getByText('ExportComponent')).toBeInTheDocument();
+    expect(screen.getByText('DeleteComponent')).toBeInTheDocument();
+    expect(screen.getByText('ConsentComponent')).toBeInTheDocument();
+  });
+});

--- a/app/settings/gdpr/page.tsx
+++ b/app/settings/gdpr/page.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { Metadata } from 'next';
+import { DataExportRequest } from '@/ui/styled/gdpr/DataExportRequest';
+import { DataDeletionRequest } from '@/ui/styled/gdpr/DataDeletionRequest';
+import { ConsentManagement } from '@/ui/styled/gdpr/ConsentManagement';
+
+export const metadata: Metadata = {
+  title: 'Privacy & Data Controls',
+  description: 'Manage personal data requests and consent preferences',
+};
+
+export default function GdprSettingsPage() {
+  return (
+    <div className="container mx-auto py-8 space-y-8 max-w-3xl">
+      <h1 className="text-2xl font-bold">Privacy & Data Controls</h1>
+
+      <div className="bg-card rounded-lg shadow p-6">
+        <h2 className="text-xl font-semibold mb-4">Export My Data</h2>
+        <DataExportRequest />
+      </div>
+
+      <div className="bg-card rounded-lg shadow p-6">
+        <h2 className="text-xl font-semibold mb-4">Delete My Data</h2>
+        <DataDeletionRequest />
+      </div>
+
+      <div className="bg-card rounded-lg shadow p-6">
+        <h2 className="text-xl font-semibold mb-4">Consent Preferences</h2>
+        <ConsentManagement />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `Privacy & Data Controls` page under settings
- include export, deletion and consent components
- test the new page

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*