### PR TITLE
Implement org SSO config hook

### DIFF
--- a/src/hooks/sso/__tests__/use-org-sso-config.test.ts
+++ b/src/hooks/sso/__tests__/use-org-sso-config.test.ts
@@ -1,0 +1,40 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { api } from '@/lib/api/axios';
+import { useOrgSsoConfig } from '../use-org-sso-config';
+
+vi.mock('@/lib/api/axios', () => ({ api: { get: vi.fn(), put: vi.fn() } }));
+
+const mockGet = api.get as unknown as ReturnType<typeof vi.fn>;
+const mockPut = api.put as unknown as ReturnType<typeof vi.fn>;
+
+describe('useOrgSsoConfig', () => {
+  const orgId = 'org1';
+
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPut.mockReset();
+  });
+
+  it('fetches settings', async () => {
+    mockGet.mockResolvedValueOnce({ data: { sso_enabled: true, idp_type: 'saml' } });
+    const { result } = renderHook(() => useOrgSsoConfig(orgId));
+    let settings;
+    await act(async () => {
+      settings = await result.current.getSettings();
+    });
+    expect(mockGet).toHaveBeenCalledWith(`/organizations/${orgId}/sso/settings`);
+    expect(settings).toEqual({ sso_enabled: true, idp_type: 'saml' });
+  });
+
+  it('updates idp config', async () => {
+    mockPut.mockResolvedValueOnce({ data: { clientId: 'id' } });
+    const { result } = renderHook(() => useOrgSsoConfig(orgId));
+    let data;
+    await act(async () => {
+      data = await result.current.updateIdpConfig('oidc', { clientId: 'id' });
+    });
+    expect(mockPut).toHaveBeenCalledWith(`/organizations/${orgId}/sso/oidc/config`, { clientId: 'id' });
+    expect(data).toEqual({ clientId: 'id' });
+  });
+});

--- a/src/hooks/sso/use-org-sso-config.ts
+++ b/src/hooks/sso/use-org-sso-config.ts
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import { api } from '@/lib/api/axios';
+
+export interface OrgSsoSettings {
+  sso_enabled: boolean;
+  idp_type: 'saml' | 'oidc' | null;
+}
+
+export interface OrgSsoStatus {
+  status: 'healthy' | 'warning' | 'error' | 'unknown';
+  lastSuccessfulLogin: string | null;
+  lastError: string | null;
+  totalSuccessfulLogins24h: number;
+}
+
+export function useOrgSsoConfig(orgId: string) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const getSettings = async (): Promise<OrgSsoSettings> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data } = await api.get(`/organizations/${orgId}/sso/settings`);
+      return data as OrgSsoSettings;
+    } catch (err: any) {
+      setError(err?.message || 'Failed to fetch settings');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateSettings = async (settings: OrgSsoSettings): Promise<OrgSsoSettings> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data } = await api.put(`/organizations/${orgId}/sso/settings`, settings);
+      return data as OrgSsoSettings;
+    } catch (err: any) {
+      setError(err?.message || 'Failed to update settings');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getStatus = async (): Promise<OrgSsoStatus> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data } = await api.get(`/organizations/${orgId}/sso/status`);
+      return data as OrgSsoStatus;
+    } catch (err: any) {
+      setError(err?.message || 'Failed to fetch status');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getMetadata = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data } = await api.get(`/organizations/${orgId}/sso/metadata`);
+      return data as { url: string; entity_id: string; xml: string };
+    } catch (err: any) {
+      setError(err?.message || 'Failed to fetch metadata');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getIdpConfig = async (idpType: 'saml' | 'oidc') => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data } = await api.get(`/organizations/${orgId}/sso/${idpType}/config`);
+      return data as Record<string, any>;
+    } catch (err: any) {
+      setError(err?.message || 'Failed to fetch configuration');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateIdpConfig = async (idpType: 'saml' | 'oidc', config: Record<string, any>) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data } = await api.put(`/organizations/${orgId}/sso/${idpType}/config`, config);
+      return data as Record<string, any>;
+    } catch (err: any) {
+      setError(err?.message || 'Failed to update configuration');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    loading,
+    error,
+    getSettings,
+    updateSettings,
+    getStatus,
+    getMetadata,
+    getIdpConfig,
+    updateIdpConfig,
+  };
+}
+
+export default useOrgSsoConfig;

--- a/src/ui/styled/auth/OrganizationSSO.tsx
+++ b/src/ui/styled/auth/OrganizationSSO.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CheckCircle, XCircle, AlertTriangle, Clock } from 'lucide-react';
-import { api } from '@/lib/api/axios';
+import { useOrgSsoConfig } from '@/hooks/sso/use-org-sso-config';
 import BusinessSSOSetup from './BusinessSSOSetup';
 import IDPConfiguration from './IDPConfiguration';
 
@@ -35,28 +35,32 @@ const OrganizationSSO: React.FC<OrganizationSSOProps> = ({ orgId }) => {
     totalSuccessfulLogins24h: 0
   });
 
+  const {
+    getSettings,
+    getStatus,
+  } = useOrgSsoConfig(orgId);
+
   // Fetch initial SSO settings on mount
   useEffect(() => {
     const fetchSettings = async () => {
       try {
-        const response = await api.get(`/organizations/${orgId}/sso/settings`);
-        setSsoSettings(response.data);
+        const data = await getSettings();
+        setSsoSettings(data);
       } catch (error) {
         if (process.env.NODE_ENV === 'development') {
           console.error('Failed to fetch SSO settings:', error);
         }
-        // Optionally: setSsoSettings({ sso_enabled: false, idp_type: null });
       }
     };
     fetchSettings();
-  }, [orgId]);
+  }, [orgId, getSettings]);
 
   // Fetch SSO status periodically
   useEffect(() => {
     const fetchStatus = async () => {
       try {
-        const response = await api.get(`/organizations/${orgId}/sso/status`);
-        setSsoStatus(response.data);
+        const data = await getStatus();
+        setSsoStatus(data);
       } catch (error) {
         if (process.env.NODE_ENV === 'development') { console.error('Failed to fetch SSO status:', error) }
       }


### PR DESCRIPTION
## Summary
- create `useOrgSsoConfig` hook for organization SSO settings
- refactor `OrganizationSSO` and `IDPConfiguration` components to use new hook
- add unit tests for the hook

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*