### PR TITLE
Add TeamList headless and styled components

### DIFF
--- a/src/ui/headless/team/TeamList.tsx
+++ b/src/ui/headless/team/TeamList.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTeams } from '@/hooks/team/useTeams';
+import { useAuth } from '@/hooks/auth/useAuth';
+import type { Team } from '@/core/team/models';
+
+export interface TeamListRenderProps {
+  teams: Team[];
+  filter: string;
+  setFilter: (value: string) => void;
+  selectedTeam: Team | null;
+  selectTeam: (teamId: string) => void;
+  refresh: () => Promise<void>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export interface TeamListProps {
+  onSelectTeam?: (team: Team) => void;
+  children: (props: TeamListRenderProps) => React.ReactNode;
+}
+
+export function TeamList({ onSelectTeam, children }: TeamListProps) {
+  const { user } = useAuth();
+  const {
+    teams,
+    currentTeam,
+    fetchUserTeams,
+    setCurrentTeam,
+    isLoading,
+    error
+  } = useTeams();
+  const [filter, setFilter] = useState('');
+
+  useEffect(() => {
+    if (user?.id) {
+      fetchUserTeams(user.id);
+    }
+  }, [user, fetchUserTeams]);
+
+  const filteredTeams = useMemo(
+    () => teams.filter(t => t.name.toLowerCase().includes(filter.toLowerCase())),
+    [teams, filter]
+  );
+
+  const selectTeam = (teamId: string) => {
+    const team = teams.find(t => t.id === teamId);
+    if (!team) return;
+    setCurrentTeam(team);
+    onSelectTeam?.(team);
+  };
+
+  const refresh = async () => {
+    if (user?.id) {
+      await fetchUserTeams(user.id);
+    }
+  };
+
+  return (
+    <>{children({
+      teams: filteredTeams,
+      filter,
+      setFilter,
+      selectedTeam: currentTeam,
+      selectTeam,
+      refresh,
+      isLoading,
+      error,
+    })}</>
+  );
+}
+
+export default TeamList;

--- a/src/ui/headless/team/__tests__/TeamList.test.tsx
+++ b/src/ui/headless/team/__tests__/TeamList.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { TeamList } from '../TeamList';
+import { useTeams } from '@/hooks/team/useTeams';
+import { useAuth } from '@/hooks/auth/useAuth';
+
+vi.mock('@/hooks/team/useTeams', () => ({ useTeams: vi.fn() }));
+vi.mock('@/hooks/auth/useAuth', () => ({ useAuth: vi.fn() }));
+
+describe('TeamList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useAuth as unknown as vi.Mock).mockReturnValue({ user: { id: 'u1' } });
+    (useTeams as unknown as vi.Mock).mockReturnValue({
+      teams: [
+        { id: 't1', name: 'Alpha', ownerId: '', isActive: true, visibility: 'public', memberLimit: 0, createdAt: '', updatedAt: '' },
+        { id: 't2', name: 'Beta', ownerId: '', isActive: true, visibility: 'public', memberLimit: 0, createdAt: '', updatedAt: '' }
+      ],
+      currentTeam: null,
+      fetchUserTeams: vi.fn(),
+      setCurrentTeam: vi.fn(),
+      isLoading: false,
+      error: null
+    });
+  });
+
+  it('filters teams based on filter value', () => {
+    let props: any;
+    render(
+      <TeamList>
+        {(p) => {
+          props = p;
+          return <div />;
+        }}
+      </TeamList>
+    );
+
+    expect(props.teams.length).toBe(2);
+    act(() => {
+      props.setFilter('bet');
+    });
+    expect(props.teams.length).toBe(1);
+    expect(props.teams[0].id).toBe('t2');
+  });
+
+  it('selects a team and calls setCurrentTeam', () => {
+    const mockSet = vi.fn();
+    (useTeams as unknown as vi.Mock).mockReturnValueOnce({
+      teams: [
+        { id: 't1', name: 'Alpha', ownerId: '', isActive: true, visibility: 'public', memberLimit: 0, createdAt: '', updatedAt: '' }
+      ],
+      currentTeam: null,
+      fetchUserTeams: vi.fn(),
+      setCurrentTeam: mockSet,
+      isLoading: false,
+      error: null
+    });
+
+    let props: any;
+    render(
+      <TeamList>
+        {(p) => {
+          props = p;
+          return <div />;
+        }}
+      </TeamList>
+    );
+
+    act(() => {
+      props.selectTeam('t1');
+    });
+
+    expect(mockSet).toHaveBeenCalled();
+  });
+});

--- a/src/ui/styled/team/TeamList.tsx
+++ b/src/ui/styled/team/TeamList.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { TeamList as HeadlessTeamList, TeamListProps } from '../../headless/team/TeamList';
+import { Input } from '@/ui/primitives/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/ui/primitives/card';
+import { Button } from '@/ui/primitives/button';
+
+export interface StyledTeamListProps extends Omit<TeamListProps, 'children'> {
+  title?: string;
+  className?: string;
+}
+
+export function TeamList({ title = 'Your Teams', className, ...props }: StyledTeamListProps) {
+  return (
+    <HeadlessTeamList {...props}>
+      {({ teams, filter, setFilter, selectedTeam, selectTeam, isLoading, error }) => (
+        <Card className={className}>
+          <CardHeader>
+            <CardTitle>{title}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Input
+              placeholder="Filter teams..."
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+            />
+            {error && <p className="text-sm text-red-500">{error}</p>}
+            <ul className="space-y-2">
+              {teams.map(team => (
+                <li key={team.id}>
+                  <Button
+                    variant={selectedTeam?.id === team.id ? 'default' : 'outline'}
+                    className="w-full justify-start"
+                    onClick={() => selectTeam(team.id)}
+                    disabled={isLoading}
+                  >
+                    {team.name}
+                  </Button>
+                </li>
+              ))}
+              {teams.length === 0 && !isLoading && (
+                <li className="text-sm text-muted-foreground">No teams found</li>
+              )}
+              {isLoading && <li className="text-sm">Loading...</li>}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+    </HeadlessTeamList>
+  );
+}
+
+export default TeamList;


### PR DESCRIPTION
## Summary
- implement `TeamList` headless component hooked to `useTeams`
- add styled `TeamList` using headless logic
- provide tests for `TeamList`

## Testing
- `npx vitest run --coverage src/ui/headless/team/__tests__/TeamList.test.tsx`
