### PR TITLE
Add SSOConnector and WebhookManager UI components

### DIFF
--- a/src/ui/headless/sso/SSOConnector.tsx
+++ b/src/ui/headless/sso/SSOConnector.tsx
@@ -1,0 +1,64 @@
+import { useEffect } from 'react';
+import type { ReactNode } from 'react';
+import { useSso } from '@/hooks/sso/use-sso';
+import type { SsoProvider, SsoConnection } from '@/types/sso';
+
+export interface SSOConnectorRenderProps {
+  providers: SsoProvider[];
+  connections: SsoConnection[];
+  loading: boolean;
+  error: string | null;
+  connect: (providerId: string) => Promise<void>;
+  disconnect: (connectionId: string) => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export interface SSOConnectorProps {
+  onConnect?: (providerId: string) => Promise<void>;
+  onDisconnect?: (connectionId: string) => Promise<void>;
+  children: (props: SSOConnectorRenderProps) => ReactNode;
+}
+
+export function SSOConnector({ onConnect, onDisconnect, children }: SSOConnectorProps) {
+  const {
+    providers,
+    connectedProviders,
+    loading,
+    error,
+    fetchProviders,
+    fetchConnections,
+    connectProvider,
+    disconnectProvider,
+  } = useSso();
+
+  useEffect(() => {
+    void fetchProviders();
+    void fetchConnections();
+  }, [fetchProviders, fetchConnections]);
+
+  const connect = async (providerId: string) => {
+    if (onConnect) {
+      await onConnect(providerId);
+    } else {
+      await connectProvider(providerId);
+      await fetchConnections();
+    }
+  };
+
+  const disconnect = async (connectionId: string) => {
+    if (onDisconnect) {
+      await onDisconnect(connectionId);
+    } else {
+      await disconnectProvider(connectionId);
+      await fetchConnections();
+    }
+  };
+
+  const refresh = async () => {
+    await Promise.all([fetchProviders(), fetchConnections()]);
+  };
+
+  return <>{children({ providers, connections: connectedProviders, loading, error, connect, disconnect, refresh })}</>;
+}
+
+export default SSOConnector;

--- a/src/ui/headless/sso/__tests__/SSOConnector.test.tsx
+++ b/src/ui/headless/sso/__tests__/SSOConnector.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SSOConnector } from '../SSOConnector';
+import { useSso } from '@/hooks/sso/use-sso';
+
+vi.mock('@/hooks/sso/use-sso', () => ({ useSso: vi.fn() }));
+const mockUseSso = useSso as unknown as ReturnType<typeof vi.fn>;
+let state: any;
+
+describe('SSOConnector', () => {
+  beforeEach(() => {
+    state = {
+      providers: [],
+      connectedProviders: [],
+      loading: false,
+      error: null,
+      fetchProviders: vi.fn(),
+      fetchConnections: vi.fn(),
+      connectProvider: vi.fn(async () => undefined),
+      disconnectProvider: vi.fn(async () => undefined),
+    };
+    mockUseSso.mockReturnValue(state);
+  });
+
+  it('fetches providers and connections on mount', () => {
+    render(<SSOConnector>{() => null}</SSOConnector>);
+    expect(state.fetchProviders).toHaveBeenCalled();
+    expect(state.fetchConnections).toHaveBeenCalled();
+  });
+
+  it('calls connectProvider', async () => {
+    let props: any;
+    render(<SSOConnector>{p => { props = p; return null; }}</SSOConnector>);
+    await act(async () => {
+      await props.connect('google');
+    });
+    expect(state.connectProvider).toHaveBeenCalledWith('google');
+  });
+
+  it('calls disconnectProvider', async () => {
+    let props: any;
+    render(<SSOConnector>{p => { props = p; return null; }}</SSOConnector>);
+    await act(async () => {
+      await props.disconnect('conn1');
+    });
+    expect(state.disconnectProvider).toHaveBeenCalledWith('conn1');
+  });
+});

--- a/src/ui/headless/webhooks/WebhookManager.tsx
+++ b/src/ui/headless/webhooks/WebhookManager.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+import type { ReactNode } from 'react';
+import { useWebhooks } from '@/hooks/webhooks/use-webhooks';
+import type { Webhook, WebhookCreatePayload, WebhookUpdatePayload } from '@/core/webhooks/models';
+
+export interface WebhookManagerRenderProps {
+  webhooks: Webhook[];
+  loading: boolean;
+  error: string | null;
+  create: (payload: WebhookCreatePayload) => Promise<void>;
+  update: (id: string, payload: WebhookUpdatePayload) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export interface WebhookManagerProps {
+  userId: string;
+  children: (props: WebhookManagerRenderProps) => ReactNode;
+}
+
+export function WebhookManager({ userId, children }: WebhookManagerProps) {
+  const {
+    webhooks,
+    loading,
+    error,
+    fetchWebhooks,
+    createWebhook,
+    updateWebhook,
+    deleteWebhook,
+  } = useWebhooks(userId);
+
+  useEffect(() => {
+    void fetchWebhooks();
+  }, [fetchWebhooks]);
+
+  const create = async (payload: WebhookCreatePayload) => {
+    await (createWebhook.mutateAsync ? createWebhook.mutateAsync(payload) : createWebhook(payload));
+    await fetchWebhooks();
+  };
+
+  const update = async (id: string, payload: WebhookUpdatePayload) => {
+    await (updateWebhook.mutateAsync ? updateWebhook.mutateAsync({ id, ...payload }) : updateWebhook({ id, ...payload }));
+    await fetchWebhooks();
+  };
+
+  const remove = async (id: string) => {
+    await (deleteWebhook.mutateAsync ? deleteWebhook.mutateAsync(id) : deleteWebhook(id));
+    await fetchWebhooks();
+  };
+
+  const refresh = async () => {
+    await fetchWebhooks();
+  };
+
+  return children({ webhooks, loading, error, create, update, remove, refresh });
+}
+
+export default WebhookManager;

--- a/src/ui/headless/webhooks/__tests__/WebhookManager.test.tsx
+++ b/src/ui/headless/webhooks/__tests__/WebhookManager.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { WebhookManager } from '../WebhookManager';
+import { useWebhooks } from '@/hooks/webhooks/use-webhooks';
+
+vi.mock('@/hooks/webhooks/use-webhooks', () => ({ useWebhooks: vi.fn() }));
+const mockUseWebhooks = useWebhooks as unknown as ReturnType<typeof vi.fn>;
+let state: any;
+
+describe('WebhookManager', () => {
+  beforeEach(() => {
+    state = {
+      webhooks: [],
+      loading: false,
+      error: null,
+      fetchWebhooks: vi.fn(),
+      createWebhook: vi.fn(async () => ({ success: true })),
+      updateWebhook: vi.fn(async () => ({ success: true })),
+      deleteWebhook: vi.fn(async () => ({ success: true })),
+    };
+    mockUseWebhooks.mockReturnValue(state);
+  });
+
+  it('fetches webhooks on mount', () => {
+    render(<WebhookManager userId="u1">{() => null}</WebhookManager>);
+    expect(state.fetchWebhooks).toHaveBeenCalled();
+  });
+
+  it('calls createWebhook', async () => {
+    let props: any;
+    render(<WebhookManager userId="u1">{p => { props = p; return null; }}</WebhookManager>);
+    await act(async () => {
+      await props.create({ name: 'n', url: 'u', events: [] });
+    });
+    expect(state.createWebhook).toHaveBeenCalled();
+  });
+
+  it('calls deleteWebhook', async () => {
+    let props: any;
+    render(<WebhookManager userId="u1">{p => { props = p; return null; }}</WebhookManager>);
+    await act(async () => {
+      await props.remove('id1');
+    });
+    expect(state.deleteWebhook).toHaveBeenCalledWith('id1');
+  });
+});

--- a/src/ui/headless/webhooks/index.ts
+++ b/src/ui/headless/webhooks/index.ts
@@ -1,3 +1,4 @@
 export * from './WebhookList';
 export * from './WebhookForm';
 export * from './WebhookEvents';
+export * from './WebhookManager';

--- a/src/ui/styled/sso/SSOConnector.tsx
+++ b/src/ui/styled/sso/SSOConnector.tsx
@@ -1,0 +1,49 @@
+import { SSOConnector as HeadlessSSOConnector, type SSOConnectorProps } from '@/ui/headless/sso/SSOConnector';
+import { SsoProviderButton } from './SsoProviderButton';
+import { Card, CardHeader, CardTitle, CardContent } from '@/ui/primitives/card';
+import { Button } from '@/ui/primitives/button';
+import { Alert } from '@/ui/primitives/alert';
+
+export type StyledSSOConnectorProps = Omit<SSOConnectorProps, 'children'>;
+
+export function SSOConnector(props: StyledSSOConnectorProps) {
+  return (
+    <HeadlessSSOConnector {...props}>
+      {({ providers, connections, loading, error, connect, disconnect, refresh }) => (
+        <div className="space-y-4">
+          {error && <Alert variant="destructive">{error}</Alert>}
+          <Card>
+            <CardHeader>
+              <CardTitle>Connected Providers</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {connections.map(c => (
+                <div key={c.id} className="flex items-center justify-between">
+                  <span>{c.providerName}</span>
+                  <Button size="sm" variant="destructive" onClick={() => disconnect(c.id)}>
+                    Disconnect
+                  </Button>
+                </div>
+              ))}
+              {connections.length === 0 && <p className="text-sm">No connections</p>}
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Available Providers</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {providers.map(p => (
+                <SsoProviderButton key={p.id} provider={p} onClick={() => connect(p.id)} />
+              ))}
+              {providers.length === 0 && <p className="text-sm">No providers</p>}
+            </CardContent>
+          </Card>
+          <Button onClick={refresh} disabled={loading}>Refresh</Button>
+        </div>
+      )}
+    </HeadlessSSOConnector>
+  );
+}
+
+export default SSOConnector;

--- a/src/ui/styled/webhooks/WebhookManager.tsx
+++ b/src/ui/styled/webhooks/WebhookManager.tsx
@@ -1,0 +1,24 @@
+import { WebhookManager as HeadlessWebhookManager, type WebhookManagerProps } from '@/ui/headless/webhooks/WebhookManager';
+import { WebhookForm } from './WebhookForm';
+import { WebhookList } from './WebhookList';
+import { Alert } from '@/ui/primitives/alert';
+
+export type StyledWebhookManagerProps = Omit<WebhookManagerProps, 'children'> & {
+  availableEvents?: string[];
+};
+
+export function WebhookManager({ availableEvents = [], ...props }: StyledWebhookManagerProps) {
+  return (
+    <HeadlessWebhookManager {...props}>
+      {({ webhooks, create, update, remove, refresh, loading, error }) => (
+        <div className="space-y-4">
+          {error && <Alert variant="destructive">{error}</Alert>}
+          <WebhookForm userId={props.userId} onSubmit={create} availableEvents={availableEvents} />
+          <WebhookList userId={props.userId} onDelete={remove} />
+        </div>
+      )}
+    </HeadlessWebhookManager>
+  );
+}
+
+export default WebhookManager;

--- a/src/ui/styled/webhooks/index.ts
+++ b/src/ui/styled/webhooks/index.ts
@@ -4,3 +4,4 @@ export * from './WebhookForm';
 export * from './WebhookCard';
 export * from './WebhookEvents';
 export * from './WebhookLogs';
+export * from './WebhookManager';


### PR DESCRIPTION
## Summary
- implement `SSOConnector` with headless/styled versions
- implement `WebhookManager` with headless/styled versions
- export the new components via existing index files
- add unit tests for the new headless components

## Testing
- `npx vitest run --coverage src/ui/headless/sso/__tests__/SSOConnector.test.tsx src/ui/headless/webhooks/__tests__/WebhookManager.test.tsx`
