### PR TITLE
Add IUserDataProvider core interface

### DIFF
--- a/src/core/user/IUserDataProvider.ts
+++ b/src/core/user/IUserDataProvider.ts
@@ -1,0 +1,86 @@
+/**
+ * User Data Provider Interface
+ *
+ * Defines the contract for persistence operations related to user profiles
+ * and preferences. This abstraction allows the service layer to remain
+ * database-agnostic by delegating all data access to implementations of
+ * this interface.
+ */
+import type {
+  UserProfile,
+  ProfileUpdatePayload,
+  UserPreferences,
+  PreferencesUpdatePayload,
+  UserProfileResult,
+  UserSearchParams,
+  UserSearchResult,
+  ProfileVisibility
+} from './models';
+
+/**
+ * Core interface for user data operations.
+ *
+ * Implementations should focus purely on data persistence and retrieval.
+ * Business logic, validation, and transformation should be handled in
+ * higher layers of the application.
+ */
+export interface IUserDataProvider {
+  /** Get the profile of a user by ID */
+  getUserProfile(userId: string): Promise<UserProfile | null>;
+
+  /** Update a user's profile */
+  updateUserProfile(
+    userId: string,
+    profileData: ProfileUpdatePayload
+  ): Promise<UserProfileResult>;
+
+  /** Retrieve a user's preferences */
+  getUserPreferences(userId: string): Promise<UserPreferences>;
+
+  /** Update a user's preferences */
+  updateUserPreferences(
+    userId: string,
+    preferences: PreferencesUpdatePayload
+  ): Promise<{ success: boolean; preferences?: UserPreferences; error?: string }>;
+
+  /** Upload a profile picture for a user */
+  uploadProfilePicture(
+    userId: string,
+    imageData: Blob
+  ): Promise<{ success: boolean; imageUrl?: string; error?: string }>;
+
+  /** Delete a user's profile picture */
+  deleteProfilePicture(userId: string): Promise<{ success: boolean; error?: string }>;
+
+  /** Update a user's profile visibility settings */
+  updateProfileVisibility(
+    userId: string,
+    visibility: ProfileVisibility
+  ): Promise<{ success: boolean; visibility?: ProfileVisibility; error?: string }>;
+
+  /** Search for users based on parameters */
+  searchUsers(params: UserSearchParams): Promise<UserSearchResult>;
+
+  /** Deactivate a user account */
+  deactivateUser(
+    userId: string,
+    reason?: string
+  ): Promise<{ success: boolean; error?: string }>;
+
+  /** Reactivate a previously deactivated user account */
+  reactivateUser(userId: string): Promise<{ success: boolean; error?: string }>;
+
+  /**
+   * Convert a user's account type (e.g., from private to corporate)
+   * with optional additional data for the new type.
+   */
+  convertUserType(
+    userId: string,
+    newType: string,
+    additionalData?: Record<string, any>
+  ): Promise<UserProfileResult>;
+
+  /** Subscribe to user profile changes */
+  onUserProfileChanged(callback: (profile: UserProfile) => void): () => void;
+}
+

--- a/src/core/user/index.ts
+++ b/src/core/user/index.ts
@@ -6,6 +6,7 @@
 
 // Export interfaces
 export * from './interfaces';
+export * from './IUserDataProvider';
 
 // Export models
 export * from './models';


### PR DESCRIPTION
## Summary
- create `IUserDataProvider` in `src/core/user`
- export the new interface in `src/core/user/index.ts`

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined)*