### PR TITLE
Add CSRF data provider interface

### DIFF
--- a/src/core/csrf/ICsrfDataProvider.ts
+++ b/src/core/csrf/ICsrfDataProvider.ts
@@ -1,0 +1,33 @@
+/**
+ * CSRF Data Provider Interface
+ *
+ * Defines the contract for persistence operations related to CSRF tokens.
+ * This allows the adapter layer to implement any storage mechanism while
+ * keeping the core logic database agnostic.
+ */
+import type { CsrfToken } from './models';
+
+export interface ICsrfDataProvider {
+  /**
+   * Create a new CSRF token.
+   *
+   * @returns Result object containing the token or an error message.
+   */
+  createToken(): Promise<{ success: boolean; token?: CsrfToken; error?: string }>;
+
+  /**
+   * Validate a CSRF token.
+   *
+   * @param token Token to validate
+   * @returns Object indicating whether the token is valid or not.
+   */
+  validateToken(token: string): Promise<{ valid: boolean; error?: string }>;
+
+  /**
+   * Revoke an existing CSRF token.
+   *
+   * @param token Token to revoke
+   * @returns Result object with success status or error.
+   */
+  revokeToken(token: string): Promise<{ success: boolean; error?: string }>;
+}

--- a/src/core/csrf/index.ts
+++ b/src/core/csrf/index.ts
@@ -1,2 +1,3 @@
 export * from './interfaces';
+export * from './ICsrfDataProvider';
 export * from './models';


### PR DESCRIPTION
## Summary
- define `ICsrfDataProvider` in `src/core/csrf`
- export the new interface from the CSRF domain index

## Testing
- `vitest run --coverage` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*