### PR TITLE
Add notification data provider interface

### DIFF
--- a/src/core/notification/INotificationDataProvider.ts
+++ b/src/core/notification/INotificationDataProvider.ts
@@ -1,0 +1,163 @@
+/**
+ * Notification Data Provider Interface
+ *
+ * Defines the contract for persistence operations related to notifications.
+ * Implementations handle data storage and retrieval so the service layer
+ * remains database agnostic.
+ */
+import type {
+  NotificationPayload,
+  NotificationPreferences,
+  NotificationTemplate,
+  NotificationResult,
+  NotificationBatch,
+  NotificationFilter,
+  NotificationDeliveryStatus,
+  NotificationChannel
+} from './models';
+
+export interface INotificationDataProvider {
+  /**
+   * Persist a notification for a single user.
+   *
+   * @param userId - ID of the user receiving the notification
+   * @param payload - Notification content and metadata
+   * @returns Result object with success status and notification ID or error
+   */
+  createNotification(
+    userId: string,
+    payload: NotificationPayload
+  ): Promise<NotificationResult>;
+
+  /**
+   * Persist a notification for multiple users.
+   *
+   * @param userIds - IDs of users to receive the notification
+   * @param payload - Notification content and metadata
+   * @returns Result list for each user
+   */
+  createBulkNotifications(
+    userIds: string[],
+    payload: NotificationPayload
+  ): Promise<{
+    success: boolean;
+    results: { userId: string; notificationId?: string; error?: string }[];
+  }>;
+
+  /**
+   * Schedule a notification to be sent later.
+   *
+   * @param userId - ID of the user receiving the notification
+   * @param payload - Notification content and metadata
+   * @param scheduledTime - ISO string or Date for when to send
+   */
+  scheduleNotification(
+    userId: string,
+    payload: NotificationPayload,
+    scheduledTime: string | Date
+  ): Promise<NotificationResult>;
+
+  /**
+   * Cancel a previously scheduled notification.
+   *
+   * @param notificationId - ID of the scheduled notification
+   */
+  cancelScheduledNotification(
+    notificationId: string
+  ): Promise<{ success: boolean; error?: string }>;
+
+  /**
+   * Create a reusable notification template.
+   */
+  createTemplate(
+    template: NotificationTemplate
+  ): Promise<{ success: boolean; templateId?: string; error?: string }>;
+
+  /**
+   * Update an existing notification template.
+   */
+  updateTemplate(
+    templateId: string,
+    update: Partial<NotificationTemplate>
+  ): Promise<{ success: boolean; template?: NotificationTemplate; error?: string }>;
+
+  /**
+   * Delete a notification template.
+   */
+  deleteTemplate(templateId: string): Promise<{ success: boolean; error?: string }>;
+
+  /**
+   * Send a notification using a template and data replacements.
+   */
+  sendTemplatedNotification(
+    userId: string,
+    templateId: string,
+    data: Record<string, any>
+  ): Promise<NotificationResult>;
+
+  /**
+   * Retrieve a user's notification preferences.
+   */
+  getUserPreferences(userId: string): Promise<NotificationPreferences>;
+
+  /**
+   * Update a user's notification preferences.
+   */
+  updateUserPreferences(
+    userId: string,
+    preferences: Partial<NotificationPreferences>
+  ): Promise<NotificationPreferences>;
+
+  /**
+   * Fetch notifications for a user with optional filtering.
+   */
+  getUserNotifications(
+    userId: string,
+    filter?: NotificationFilter
+  ): Promise<NotificationBatch>;
+
+  /**
+   * Mark a single notification as read.
+   */
+  markAsRead(notificationId: string): Promise<{ success: boolean; error?: string }>;
+
+  /**
+   * Mark multiple notifications as read for a user.
+   */
+  markAllAsRead(
+    userId: string,
+    filter?: NotificationFilter
+  ): Promise<{ success: boolean; count?: number; error?: string }>;
+
+  /**
+   * Permanently remove a notification.
+   */
+  deleteNotification(notificationId: string): Promise<{ success: boolean; error?: string }>;
+
+  /**
+   * Retrieve delivery status information for a notification.
+   */
+  getDeliveryStatus(notificationId: string): Promise<NotificationDeliveryStatus>;
+
+  /**
+   * Register a device for push notifications.
+   */
+  registerDevice(
+    userId: string,
+    deviceToken: string,
+    deviceInfo?: Record<string, any>
+  ): Promise<{ success: boolean; error?: string }>;
+
+  /**
+   * Unregister a device from push notifications.
+   */
+  unregisterDevice(
+    userId: string,
+    deviceToken: string
+  ): Promise<{ success: boolean; error?: string }>;
+
+  /**
+   * Check if a channel is enabled for the user.
+   */
+  isChannelEnabled(userId: string, channel: NotificationChannel): Promise<boolean>;
+}

--- a/src/core/notification/index.ts
+++ b/src/core/notification/index.ts
@@ -6,6 +6,7 @@
 
 // Export interfaces
 export * from './interfaces';
+export * from './INotificationDataProvider';
 
 // Export models
 export * from './models';


### PR DESCRIPTION
## Summary
- add `INotificationDataProvider` to core notification domain
- export the interface from `src/core/notification/index.ts`

## Testing
- `npm run lint`
- `npm run test:coverage` *(fails: Cannot read properties of undefined, loginWithProvider is not a function)*