### PR TITLE
Add two-factor data provider interfaces

### DIFF
--- a/src/core/two-factor/ITwoFactorDataProvider.ts
+++ b/src/core/two-factor/ITwoFactorDataProvider.ts
@@ -1,0 +1,60 @@
+import type {
+  TwoFactorSetupPayload,
+  TwoFactorSetupResponse,
+  TwoFactorVerifyPayload,
+  TwoFactorVerifyResponse,
+  TwoFactorDisableResponse,
+  BackupCodesResponse,
+  TwoFactorMethodType,
+} from './models';
+
+/**
+ * Two-Factor Authentication Data Provider Interface
+ *
+ * Defines the contract for persistence operations related to two-factor
+ * authentication. Implementations handle storing secrets, verifying codes
+ * and managing backup codes. No business logic should be included here.
+ */
+export interface ITwoFactorDataProvider {
+  /**
+   * Start two-factor setup for a user.
+   *
+   * @param payload User id and selected method
+   * @returns Setup details including shared secret and QR code
+   */
+  startSetup(payload: TwoFactorSetupPayload): Promise<TwoFactorSetupResponse>;
+
+  /**
+   * Verify a two-factor code and complete setup.
+   *
+   * @param payload Verification payload with code and method
+   * @returns Verification result with optional token or backup codes
+   */
+  verifySetup(payload: TwoFactorVerifyPayload): Promise<TwoFactorVerifyResponse>;
+
+  /**
+   * Disable two-factor authentication for a user.
+   *
+   * @param userId ID of the user
+   * @param method Method to disable
+   * @param code Optional confirmation code
+   * @returns Result object with success state or error
+   */
+  disable(userId: string, method: TwoFactorMethodType, code?: string): Promise<TwoFactorDisableResponse>;
+
+  /**
+   * Get the current backup codes for a user.
+   *
+   * @param userId ID of the user
+   * @returns Backup codes or an error
+   */
+  getBackupCodes(userId: string): Promise<BackupCodesResponse>;
+
+  /**
+   * Regenerate backup codes for a user.
+   *
+   * @param userId ID of the user
+   * @returns New backup codes or an error
+   */
+  regenerateBackupCodes(userId: string): Promise<BackupCodesResponse>;
+}

--- a/src/core/two-factor/index.ts
+++ b/src/core/two-factor/index.ts
@@ -1,0 +1,3 @@
+export * from './ITwoFactorDataProvider';
+export * from './interfaces';
+export * from './models';

--- a/src/core/two-factor/interfaces.ts
+++ b/src/core/two-factor/interfaces.ts
@@ -1,0 +1,41 @@
+/**
+ * Two-Factor Authentication Service Interface
+ *
+ * High level operations for managing two-factor authentication.
+ * Implementations orchestrate validation and delegate persistence to
+ * a data provider, keeping business logic separate from storage.
+ */
+import type {
+  TwoFactorSetupPayload,
+  TwoFactorSetupResponse,
+  TwoFactorVerifyPayload,
+  TwoFactorVerifyResponse,
+  TwoFactorDisableResponse,
+  BackupCodesResponse,
+  MFAMethod,
+  AvailableMFAMethod,
+  TwoFactorMethodType,
+} from './models';
+
+export interface TwoFactorService {
+  /** Begin setup for a two-factor method */
+  startSetup(payload: TwoFactorSetupPayload): Promise<TwoFactorSetupResponse>;
+
+  /** Verify a setup code to activate 2FA */
+  verifySetup(payload: TwoFactorVerifyPayload): Promise<TwoFactorVerifyResponse>;
+
+  /** Disable a configured 2FA method */
+  disable(userId: string, method: TwoFactorMethodType, code?: string): Promise<TwoFactorDisableResponse>;
+
+  /** Retrieve a user's configured MFA methods */
+  getUserMethods(userId: string): Promise<MFAMethod[]>;
+
+  /** Retrieve all available MFA methods */
+  getAvailableMethods(): Promise<AvailableMFAMethod[]>;
+
+  /** Get existing backup codes for a user */
+  getBackupCodes(userId: string): Promise<BackupCodesResponse>;
+
+  /** Generate a new set of backup codes for a user */
+  regenerateBackupCodes(userId: string): Promise<BackupCodesResponse>;
+}

--- a/src/core/two-factor/models.ts
+++ b/src/core/two-factor/models.ts
@@ -1,0 +1,55 @@
+export type TwoFactorMethodType = 'totp' | 'sms' | 'email';
+
+export interface TwoFactorSetupPayload {
+  userId: string;
+  method: TwoFactorMethodType;
+}
+
+export interface TwoFactorSetupResponse {
+  success: boolean;
+  secret?: string;
+  qrCode?: string;
+  backupCodes?: string[];
+  error?: string;
+}
+
+export interface TwoFactorVerifyPayload {
+  userId: string;
+  code: string;
+  method: TwoFactorMethodType;
+  isBackupCode?: boolean;
+}
+
+export interface TwoFactorVerifyResponse {
+  success: boolean;
+  token?: string;
+  backupCodes?: string[];
+  error?: string;
+}
+
+export interface TwoFactorDisableResponse {
+  success: boolean;
+  error?: string;
+}
+
+export interface BackupCodesResponse {
+  success: boolean;
+  codes?: string[];
+  error?: string;
+}
+
+export interface MFAMethod {
+  id: string;
+  type: TwoFactorMethodType;
+  name: string;
+  isEnabled: boolean;
+  createdAt: string;
+  lastUsed?: string;
+}
+
+export interface AvailableMFAMethod {
+  type: TwoFactorMethodType;
+  name: string;
+  description: string;
+  canEnable: boolean;
+}


### PR DESCRIPTION
## Summary
- define ITwoFactorDataProvider for two-factor data operations
- define service interface and models for two-factor domain

## Testing
- `vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*