### PR TITLE
Move address data provider interface to core

### DIFF
--- a/src/adapters/address/factory.ts
+++ b/src/adapters/address/factory.ts
@@ -1,11 +1,17 @@
-import { AddressDataProvider } from './interfaces';
+import type { IAddressDataProvider } from '@/core/address/IAddressDataProvider';
 import { SupabaseAddressAdapter } from './supabase-adapter';
 
-export function createSupabaseAddressProvider(supabaseUrl: string, supabaseKey: string): AddressDataProvider {
+export function createSupabaseAddressProvider(
+  supabaseUrl: string,
+  supabaseKey: string,
+): IAddressDataProvider {
   return new SupabaseAddressAdapter(supabaseUrl, supabaseKey);
 }
 
-export function createAddressProvider(config: { type: 'supabase' | string; options: Record<string, any> }): AddressDataProvider {
+export function createAddressProvider(config: {
+  type: 'supabase' | string;
+  options: Record<string, any>;
+}): IAddressDataProvider {
   switch (config.type) {
     case 'supabase':
       return createSupabaseAddressProvider(config.options.supabaseUrl, config.options.supabaseKey);

--- a/src/adapters/address/index.ts
+++ b/src/adapters/address/index.ts
@@ -1,3 +1,3 @@
-export * from './interfaces';
+export type { IAddressDataProvider } from '@/core/address/IAddressDataProvider';
 export * from './factory';
 export * from './supabase-adapter';

--- a/src/adapters/address/interfaces.ts
+++ b/src/adapters/address/interfaces.ts
@@ -1,8 +1,0 @@
-import { CompanyAddress, AddressCreatePayload, AddressUpdatePayload, AddressResult } from '../../core/address/models';
-
-export interface AddressDataProvider {
-  createAddress(companyId: string, address: AddressCreatePayload): Promise<AddressResult>;
-  getAddresses(companyId: string): Promise<CompanyAddress[]>;
-  updateAddress(companyId: string, addressId: string, update: AddressUpdatePayload): Promise<AddressResult>;
-  deleteAddress(companyId: string, addressId: string): Promise<{ success: boolean; error?: string }>;
-}

--- a/src/adapters/address/supabase-adapter.ts
+++ b/src/adapters/address/supabase-adapter.ts
@@ -1,7 +1,5 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import {
-  AddressDataProvider
-} from './interfaces';
+import type { IAddressDataProvider } from '@/core/address/IAddressDataProvider';
 import {
   CompanyAddress,
   AddressCreatePayload,
@@ -9,7 +7,7 @@ import {
   AddressResult
 } from '../../core/address/models';
 
-export class SupabaseAddressAdapter implements AddressDataProvider {
+export class SupabaseAddressAdapter implements IAddressDataProvider {
   private supabase: SupabaseClient;
 
   constructor(supabaseUrl: string, supabaseKey: string) {

--- a/src/core/address/IAddressDataProvider.ts
+++ b/src/core/address/IAddressDataProvider.ts
@@ -1,0 +1,36 @@
+/**
+ * Address Data Provider Interface
+ *
+ * Defines the contract for persistence operations related to company addresses.
+ * Implementations should contain data access logic only.
+ */
+import type {
+  CompanyAddress,
+  AddressCreatePayload,
+  AddressUpdatePayload,
+  AddressResult,
+} from './models';
+
+export interface IAddressDataProvider {
+  /** Create an address for the given company */
+  createAddress(
+    companyId: string,
+    address: AddressCreatePayload,
+  ): Promise<AddressResult>;
+
+  /** Retrieve all addresses for the company */
+  getAddresses(companyId: string): Promise<CompanyAddress[]>;
+
+  /** Update a company address */
+  updateAddress(
+    companyId: string,
+    addressId: string,
+    update: AddressUpdatePayload,
+  ): Promise<AddressResult>;
+
+  /** Delete a company address */
+  deleteAddress(
+    companyId: string,
+    addressId: string,
+  ): Promise<{ success: boolean; error?: string }>;
+}

--- a/src/core/address/index.ts
+++ b/src/core/address/index.ts
@@ -1,3 +1,4 @@
 export * from './interfaces';
+export * from './IAddressDataProvider';
 export * from './models';
 export * from './types';


### PR DESCRIPTION
## Summary
- move `AddressDataProvider` interface into core layer
- rename to `IAddressDataProvider`
- update address adapter factory and implementation
- re-export new interface from adapter index

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Found 42 errors in 11 files)*