### PR TITLE
Update supabase adapter interfaces

### DIFF
--- a/src/adapters/gdpr/supabase-adapter.ts
+++ b/src/adapters/gdpr/supabase-adapter.ts
@@ -7,10 +7,10 @@
  */
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { GdprDataProvider } from './interfaces';
+import type { IGdprDataProvider } from '@/core/gdpr/IGdprDataProvider';
 import { UserDataExport, AccountDeletionResult } from '../../core/gdpr/models';
 
-export class SupabaseGdprAdapter implements GdprDataProvider {
+export class SupabaseGdprAdapter implements IGdprDataProvider {
   private supabase: SupabaseClient;
 
   constructor(private supabaseUrl: string, private supabaseKey: string) {

--- a/src/adapters/session/supabase-adapter.ts
+++ b/src/adapters/session/supabase-adapter.ts
@@ -4,9 +4,9 @@
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { SessionInfo } from '../../core/session/models';
-import { SessionDataProvider } from './interfaces';
+import type { ISessionDataProvider } from '@/core/session/ISessionDataProvider';
 
-export class SupabaseSessionProvider implements SessionDataProvider {
+export class SupabaseSessionProvider implements ISessionDataProvider {
   private supabase: SupabaseClient;
 
   constructor(supabaseUrl: string, supabaseKey: string) {

--- a/src/adapters/sso/supabase-adapter.ts
+++ b/src/adapters/sso/supabase-adapter.ts
@@ -7,9 +7,9 @@
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { SsoProvider, SsoProviderPayload } from '../../core/sso/models';
-import { SsoDataProvider } from './interfaces';
+import type { ISsoDataProvider } from '@/core/sso/ISsoDataProvider';
 
-export class SupabaseSsoProvider implements SsoDataProvider {
+export class SupabaseSsoProvider implements ISsoDataProvider {
   private supabase: SupabaseClient;
 
   constructor(supabaseUrl: string, supabaseKey: string) {

--- a/src/adapters/subscription/supabase-adapter.ts
+++ b/src/adapters/subscription/supabase-adapter.ts
@@ -2,10 +2,10 @@
  * Supabase implementation of the SubscriptionDataProvider
  */
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
-import type { SubscriptionDataProvider } from './interfaces';
+import type { ISubscriptionDataProvider } from '@/core/subscription/ISubscriptionDataProvider';
 import type { SubscriptionPlan, UserSubscription } from '../../core/subscription/models';
 
-export class SupabaseSubscriptionAdapter implements SubscriptionDataProvider {
+export class SupabaseSubscriptionAdapter implements ISubscriptionDataProvider {
   private supabase: SupabaseClient;
 
   constructor(private supabaseUrl: string, private supabaseKey: string) {


### PR DESCRIPTION
## Summary
- align gdpr, session, sso and subscription supabase adapters with new `I*DataProvider` interfaces

## Testing
- `npx vitest run --coverage` *(fails: useAuthStore is not defined and other test errors)*