### PR TITLE
Migrate API service factories

### DIFF
--- a/app/api/2fa/setup/route.ts
+++ b/app/api/2fa/setup/route.ts
@@ -4,8 +4,8 @@ import { z } from 'zod';
 import { authenticator } from 'otplib';
 import * as qrcode from 'qrcode';
 import { TwoFactorMethod } from '@/types/2fa';
-import { getApiTwoFactorService } from '@/lib/api/two-factor/factory';
-import { getApiAuthService } from '@/lib/api/auth/factory';
+import { getApiTwoFactorService } from '@/services/two-factor/factory';
+import { getApiAuthService } from '@/services/auth/factory';
 
 // Request schema
 const setupRequestSchema = z.object({

--- a/app/api/addresses/[id]/__tests__/route.test.ts
+++ b/app/api/addresses/[id]/__tests__/route.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import { GET, PUT, DELETE } from '../route';
-import { getApiAddressService } from '@/lib/api/address/factory';
+import { getApiAddressService } from '@/services/address/factory';
 
-vi.mock('@/lib/api/address/factory', () => ({
+vi.mock('@/services/address/factory', () => ({
   getApiAddressService: vi.fn(),
 }));
 

--- a/app/api/addresses/[id]/route.ts
+++ b/app/api/addresses/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getApiAddressService } from '@/lib/api/address/factory';
+import { getApiAddressService } from '@/services/address/factory';
 import { addressSchema } from '@/core/address/validation';
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {

--- a/app/api/addresses/__tests__/route.test.ts
+++ b/app/api/addresses/__tests__/route.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import { POST, GET } from '../route';
-import { getApiAddressService } from '@/lib/api/address/factory';
+import { getApiAddressService } from '@/services/address/factory';
 
-vi.mock('@/lib/api/address/factory', () => ({
+vi.mock('@/services/address/factory', () => ({
   getApiAddressService: vi.fn(),
 }));
 

--- a/app/api/addresses/default/[id]/__tests__/route.test.ts
+++ b/app/api/addresses/default/[id]/__tests__/route.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import { POST } from '../route';
-import { getApiAddressService } from '@/lib/api/address/factory';
+import { getApiAddressService } from '@/services/address/factory';
 
-vi.mock('@/lib/api/address/factory', () => ({
+vi.mock('@/services/address/factory', () => ({
   getApiAddressService: vi.fn(),
 }));
 

--- a/app/api/addresses/default/[id]/route.ts
+++ b/app/api/addresses/default/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getApiAddressService } from '@/lib/api/address/factory';
+import { getApiAddressService } from '@/services/address/factory';
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
   const userId = req.headers.get('x-user-id');

--- a/app/api/addresses/route.ts
+++ b/app/api/addresses/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getApiAddressService } from '@/lib/api/address/factory';
+import { getApiAddressService } from '@/services/address/factory';
 import { addressSchema } from '@/core/address/validation';
 
 export async function GET(req: NextRequest) {

--- a/app/api/admin/audit/route.ts
+++ b/app/api/admin/audit/route.ts
@@ -5,7 +5,7 @@ import {
   withErrorHandling,
   withValidation,
 } from '@/lib/api/common';
-import { getApiAdminService } from '@/lib/api/admin/factory';
+import { getApiAdminService } from '@/services/admin/factory';
 import { createAuditLogRetrievalError } from '@/lib/api/admin/error-handler';
 import { createProtectedHandler } from '@/middleware/permissions';
 

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -6,7 +6,7 @@ import {
   withErrorHandling,
   withValidation,
 } from '@/lib/api/common';
-import { getApiAdminService } from '@/lib/api/admin/factory';
+import { getApiAdminService } from '@/services/admin/factory';
 import { createUserNotFoundError } from '@/lib/api/admin/error-handler';
 import { createProtectedHandler } from '@/middleware/permissions';
 

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -5,7 +5,7 @@ import {
   withErrorHandling,
   withValidation,
 } from '@/lib/api/common';
-import { getApiAdminService } from '@/lib/api/admin/factory';
+import { getApiAdminService } from '@/services/admin/factory';
 import { createUserNotFoundError, mapAdminServiceError } from '@/lib/api/admin/error-handler';
 import { createProtectedHandler } from '@/middleware/permissions';
 

--- a/app/api/auth/account/route.ts
+++ b/app/api/auth/account/route.ts
@@ -2,7 +2,7 @@ import { type NextRequest } from "next/server";
 import { z } from "zod";
 import { withSecurity } from "@/middleware/security";
 import { withAuthRateLimit } from "@/middleware/rate-limit";
-import { getApiAuthService } from "@/lib/api/auth/factory";
+import { getApiAuthService } from "@/services/auth/factory";
 import { logUserAction } from "@/lib/audit/auditLogger";
 import {
   createSuccessResponse,

--- a/app/api/auth/login/mfa-check/route.ts
+++ b/app/api/auth/login/mfa-check/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { TwoFactorMethod } from '@/types/2fa';
-import { getApiAuthService } from '@/lib/api/auth/factory';
+import { getApiAuthService } from '@/services/auth/factory';
 import { logUserAction } from '@/lib/audit/auditLogger';
 import { withAuthRateLimit } from '@/middleware/rate-limit';
 import { withSecurity } from '@/middleware/security';

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from 'next/server';
 import { z } from 'zod';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { logUserAction } from '@/lib/audit/auditLogger';
-import { getApiAuthService } from '@/lib/api/auth/factory';
+import { getApiAuthService } from '@/services/auth/factory';
 import { LoginPayload } from '@/core/auth/models';
 import {
   createSuccessResponse,

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest } from "next/server";
 import { checkRateLimit } from "@/middleware/rate-limit";
-import { getApiAuthService } from "@/lib/api/auth/factory";
+import { getApiAuthService } from "@/services/auth/factory";
 import { logUserAction } from "@/lib/audit/auditLogger";
 import {
   createSuccessResponse,

--- a/app/api/auth/mfa/resend-email/route.ts
+++ b/app/api/auth/mfa/resend-email/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
-import { getApiAuthService } from '@/lib/api/auth/factory';
+import { getApiAuthService } from '@/services/auth/factory';
 import { logUserAction } from '@/lib/audit/auditLogger';
 import { withAuthRateLimit } from '@/middleware/rate-limit';
 import { withSecurity } from '@/middleware/security';

--- a/app/api/auth/mfa/resend-sms/route.ts
+++ b/app/api/auth/mfa/resend-sms/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
-import { getApiAuthService } from '@/lib/api/auth/factory';
+import { getApiAuthService } from '@/services/auth/factory';
 import { logUserAction } from '@/lib/audit/auditLogger';
 import { withAuthRateLimit } from '@/middleware/rate-limit';
 import { withSecurity } from '@/middleware/security';

--- a/app/api/auth/mfa/verify/route.ts
+++ b/app/api/auth/mfa/verify/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { z } from "zod";
 import { TwoFactorMethod } from "@/types/2fa";
-import { getApiAuthService } from "@/lib/api/auth/factory";
+import { getApiAuthService } from "@/services/auth/factory";
 import { logUserAction } from "@/lib/audit/auditLogger";
 import { withAuthRateLimit } from "@/middleware/rate-limit";
 import { withSecurity } from "@/middleware/security";

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -5,7 +5,7 @@ import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
 import { withSecurity } from '@/middleware/with-security';
 import { logUserAction } from '@/lib/audit/auditLogger';
 import { associateUserWithCompanyByDomain } from '@/lib/auth/domainMatcher';
-import { getApiAuthService } from '@/lib/api/auth/factory';
+import { getApiAuthService } from '@/services/auth/factory';
 import { RegistrationPayload } from '@/core/auth/models';
 import {
   createSuccessResponse,

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { withAuthRateLimit } from "@/middleware/with-auth-rate-limit";
 import { withSecurity } from "@/middleware/with-security";
 import { logUserAction } from "@/lib/audit/auditLogger";
-import { getApiAuthService } from "@/lib/api/auth/factory";
+import { getApiAuthService } from "@/services/auth/factory";
 import {
   createSuccessResponse,
   withErrorHandling,

--- a/app/api/auth/send-verification-email/__tests__/route.test.ts
+++ b/app/api/auth/send-verification-email/__tests__/route.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../route';
-import { getApiAuthService } from '@/lib/api/auth/factory';
+import { getApiAuthService } from '@/services/auth/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { NextRequest } from 'next/server';
 import { ERROR_CODES } from '@/lib/api/common';
 
-vi.mock('@/lib/api/auth/factory', () => ({
+vi.mock('@/services/auth/factory', () => ({
   getApiAuthService: vi.fn()
 }));
 vi.mock('@/middleware/rate-limit', () => ({

--- a/app/api/auth/send-verification-email/route.ts
+++ b/app/api/auth/send-verification-email/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { checkRateLimit } from '@/middleware/rate-limit';
-import { getApiAuthService } from '@/lib/api/auth/factory';
+import { getApiAuthService } from '@/services/auth/factory';
 import { logUserAction } from '@/lib/audit/auditLogger';
 import {
   createSuccessResponse,

--- a/app/api/auth/update-password/route.ts
+++ b/app/api/auth/update-password/route.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { withAuthRateLimit } from "@/middleware/with-auth-rate-limit";
 import { withSecurity } from "@/middleware/with-security";
 import { logUserAction } from "@/lib/audit/auditLogger";
-import { getApiAuthService } from "@/lib/api/auth/factory";
+import { getApiAuthService } from "@/services/auth/factory";
 import {
   createSuccessResponse,
   withErrorHandling,

--- a/app/api/csrf/route.ts
+++ b/app/api/csrf/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getApiCsrfService } from '@/lib/api/csrf/factory';
+import { getApiCsrfService } from '@/services/csrf/factory';
 
 // Configuration (consider moving to a shared config if used elsewhere)
 const cookieName = 'csrf-token';

--- a/app/api/gdpr/delete/route.ts
+++ b/app/api/gdpr/delete/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { getServiceSupabase } from '@/lib/database/supabase';
 import { logUserAction } from '@/lib/audit/auditLogger';
-import { getApiGdprService } from '@/lib/api/gdpr/factory';
+import { getApiGdprService } from '@/services/gdpr/factory';
 
 export async function POST(request: NextRequest) {
   // 1. Authentication (Essential)

--- a/app/api/gdpr/export/route.ts
+++ b/app/api/gdpr/export/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { getServiceSupabase } from '@/lib/database/supabase';
-import { getApiGdprService } from '@/lib/api/gdpr/factory';
+import { getApiGdprService } from '@/services/gdpr/factory';
 
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get('authorization');

--- a/app/api/permissions/check/__tests__/route.test.ts
+++ b/app/api/permissions/check/__tests__/route.test.ts
@@ -4,14 +4,14 @@ import { GET } from '../route';
 const mockAuthService = {
   getSession: vi.fn(),
 };
-vi.mock('@/lib/api/auth/factory', () => ({
+vi.mock('@/services/auth/factory', () => ({
   getApiAuthService: () => mockAuthService,
 }));
 
 const mockPermissionService = {
   hasPermission: vi.fn(),
 };
-vi.mock('@/lib/api/permission/factory', () => ({
+vi.mock('@/services/permission/factory', () => ({
   getApiPermissionService: () => mockPermissionService,
 }));
 

--- a/app/api/permissions/check/route.ts
+++ b/app/api/permissions/check/route.ts
@@ -11,7 +11,7 @@ import {
   createPermissionNotFoundError,
   mapPermissionServiceError,
 } from '@/lib/api/permission/error-handler';
-import { getApiPermissionService } from '@/lib/api/permission/factory';
+import { getApiPermissionService } from '@/services/permission/factory';
 import { isPermission, Permission } from '@/lib/rbac/roles';
 
 const querySchema = z.object({

--- a/app/api/profile/avatar/route.ts
+++ b/app/api/profile/avatar/route.ts
@@ -18,7 +18,7 @@ import {
   mapUserServiceError,
 } from '@/lib/api/user/error-handler';
 
-import { getApiUserService } from '@/lib/api/user/factory';
+import { getApiUserService } from '@/services/user/factory';
 
 // Schema for avatar upload request body (supports both custom uploads and predefined avatars)
 const AvatarUploadSchema = z.object({

--- a/app/api/sso/__tests__/route.test.ts
+++ b/app/api/sso/__tests__/route.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GET, POST } from '../route';
-import { getApiSsoService } from '@/lib/api/sso/factory';
+import { getApiSsoService } from '@/services/sso/factory';
 
-vi.mock('@/lib/api/sso/factory', () => ({
+vi.mock('@/services/sso/factory', () => ({
   getApiSsoService: vi.fn(),
 }));
 

--- a/app/api/sso/route.ts
+++ b/app/api/sso/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { triggerWebhook } from '@/lib/webhooks/triggerWebhook';
-import { getApiSsoService } from '@/lib/api/sso/factory';
+import { getApiSsoService } from '@/services/sso/factory';
 import { ssoProviderSchema } from '@/core/sso/models';
 
 // Zod schema for SSO provider config

--- a/src/lib/api/common/middleware.ts
+++ b/src/lib/api/common/middleware.ts
@@ -9,7 +9,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { ZodSchema } from 'zod';
 import { ApiError } from './api-error';
 import { createErrorResponse } from './response-formatter';
-import { getApiAuthService } from '../auth/factory';
+import { getApiAuthService } from '@/services/auth/factory';
 
 /**
  * Middleware to handle API errors

--- a/src/services/address/factory.ts
+++ b/src/services/address/factory.ts
@@ -7,6 +7,7 @@
 
 import { CompanyAddressService } from '@/core/address/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
+import type { IAddressDataProvider } from '@/core/address';
 import { createAddressProvider } from '@/adapters/address/factory';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
@@ -24,7 +25,7 @@ export function getApiAddressService(): CompanyAddressService {
     const supabase = getServiceSupabase();
     
     // Create address data provider
-    const addressDataProvider = createAddressProvider({
+    const addressDataProvider: IAddressDataProvider = createAddressProvider({
       type: 'supabase',
       options: {
         supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',

--- a/src/services/admin/factory.ts
+++ b/src/services/admin/factory.ts
@@ -7,6 +7,7 @@
 
 import { AdminService } from '@/core/admin/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
+import type { IAdminDataProvider } from '@/core/admin';
 import { createAdminProvider } from '@/adapters/admin/factory';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
@@ -24,7 +25,7 @@ export function getApiAdminService(): AdminService {
     const supabase = getServiceSupabase();
 
     // Create admin data provider
-    const adminDataProvider = createAdminProvider({
+    const adminDataProvider: IAdminDataProvider = createAdminProvider({
       type: 'supabase',
       options: {
         supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',

--- a/src/services/api-keys/factory.ts
+++ b/src/services/api-keys/factory.ts
@@ -7,6 +7,7 @@
 
 import { ApiKeyService } from '@/core/api-key/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
+import type { IApiKeyDataProvider } from '@/core/api-keys';
 import { createApiKeyProvider } from '@/adapters/api-key/factory';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
@@ -24,7 +25,7 @@ export function getApiKeyService(): ApiKeyService {
     const supabase = getServiceSupabase();
     
     // Create API key data provider
-    const apiKeyDataProvider = createApiKeyProvider({
+    const apiKeyDataProvider: IApiKeyDataProvider = createApiKeyProvider({
       type: 'supabase',
       options: {
         supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',

--- a/src/services/audit/factory.ts
+++ b/src/services/audit/factory.ts
@@ -7,6 +7,7 @@
 
 import { AuditService } from '@/core/audit/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
+import type { IAuditDataProvider } from '@/core/audit';
 import { createAuditProvider } from '@/adapters/audit/factory';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
@@ -24,7 +25,7 @@ export function getApiAuditService(): AuditService {
     const supabase = getServiceSupabase();
     
     // Create audit data provider
-    const auditDataProvider = createAuditProvider({
+    const auditDataProvider: IAuditDataProvider = createAuditProvider({
       type: 'supabase',
       options: {
         supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',

--- a/src/services/auth/factory.ts
+++ b/src/services/auth/factory.ts
@@ -6,7 +6,8 @@
  */
 
 import { AuthService } from '@/core/auth/interfaces';
-import { DefaultAuthService } from '@/services/auth/default-auth.service';
+import type { IAuthDataProvider } from '@/core/auth';
+import { DefaultAuthService } from './default-auth.service';
 import { createAuthProvider } from '@/adapters/auth/factory';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
@@ -24,7 +25,7 @@ export function getApiAuthService(): AuthService {
     const supabase = getServiceSupabase();
     
     // Create auth data provider
-    const authDataProvider = createAuthProvider({
+    const authDataProvider: IAuthDataProvider = createAuthProvider({
       type: 'supabase',
       options: {
         supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',

--- a/src/services/csrf/factory.ts
+++ b/src/services/csrf/factory.ts
@@ -6,8 +6,9 @@
  */
 
 import { CsrfService } from '@/core/csrf/interfaces';
+import type { ICsrfDataProvider } from '@/core/csrf';
 import { createCsrfProvider } from '@/adapters/csrf/factory';
-import { DefaultCsrfService } from '@/services/csrf/default-csrf.service';
+import { DefaultCsrfService } from './default-csrf.service';
 
 // Singleton instance for API routes
 let csrfServiceInstance: CsrfService | null = null;
@@ -19,7 +20,7 @@ let csrfServiceInstance: CsrfService | null = null;
  */
 export function getApiCsrfService(): CsrfService {
   if (!csrfServiceInstance) {
-    const csrfDataProvider = createCsrfProvider({ type: 'default' });
+    const csrfDataProvider: ICsrfDataProvider = createCsrfProvider({ type: 'default' });
     csrfServiceInstance = new DefaultCsrfService(csrfDataProvider);
   }
   return csrfServiceInstance;

--- a/src/services/gdpr/factory.ts
+++ b/src/services/gdpr/factory.ts
@@ -7,6 +7,7 @@
 
 import { GdprService } from '@/core/gdpr/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
+import type { IGdprDataProvider } from '@/core/gdpr';
 import { createGdprProvider } from '@/adapters/gdpr/factory';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
@@ -24,7 +25,7 @@ export function getApiGdprService(): GdprService {
     const supabase = getServiceSupabase();
     
     // Create GDPR data provider
-    const gdprDataProvider = createGdprProvider({
+    const gdprDataProvider: IGdprDataProvider = createGdprProvider({
       type: 'supabase',
       options: {
         supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',

--- a/src/services/notification/factory.ts
+++ b/src/services/notification/factory.ts
@@ -7,6 +7,7 @@
 
 import { NotificationService } from '@/core/notification/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
+import type { INotificationDataProvider } from '@/core/notification';
 import { createNotificationProvider } from '@/adapters/notification/factory';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
@@ -24,7 +25,7 @@ export function getApiNotificationService(): NotificationService {
     const supabase = getServiceSupabase();
     
     // Create notification data provider
-    const notificationDataProvider = createNotificationProvider({
+    const notificationDataProvider: INotificationDataProvider = createNotificationProvider({
       type: 'supabase',
       options: {
         supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',

--- a/src/services/permission/factory.ts
+++ b/src/services/permission/factory.ts
@@ -7,6 +7,7 @@
 
 import { PermissionService } from '@/core/permission/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
+import type { IPermissionDataProvider } from '@/core/permission';
 import { createPermissionProvider } from '@/adapters/permission/factory';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
@@ -24,7 +25,7 @@ export function getApiPermissionService(): PermissionService {
     const supabase = getServiceSupabase();
     
     // Create permission data provider
-    const permissionDataProvider = createPermissionProvider({
+    const permissionDataProvider: IPermissionDataProvider = createPermissionProvider({
       type: 'supabase',
       options: {
         supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',

--- a/src/services/session/factory.ts
+++ b/src/services/session/factory.ts
@@ -7,6 +7,7 @@
 
 import { SessionService } from '@/core/session/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
+import type { ISessionDataProvider } from '@/core/session';
 import { createSessionProvider } from '@/adapters/session/factory';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
@@ -24,7 +25,7 @@ export function getApiSessionService(): SessionService {
     const supabase = getServiceSupabase();
     
     // Create session data provider
-    const sessionDataProvider = createSessionProvider({
+    const sessionDataProvider: ISessionDataProvider = createSessionProvider({
       type: 'supabase',
       options: {
         supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',

--- a/src/services/sso/factory.ts
+++ b/src/services/sso/factory.ts
@@ -7,6 +7,7 @@
 
 import { SsoService } from '@/core/sso/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
+import type { ISsoDataProvider } from '@/core/sso';
 import { createSsoProvider } from '@/adapters/sso/factory';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
@@ -24,7 +25,7 @@ export function getApiSsoService(): SsoService {
     const supabase = getServiceSupabase();
     
     // Create SSO data provider
-    const ssoDataProvider = createSsoProvider({
+    const ssoDataProvider: ISsoDataProvider = createSsoProvider({
       type: 'supabase',
       options: {
         supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',

--- a/src/services/subscription/factory.ts
+++ b/src/services/subscription/factory.ts
@@ -7,6 +7,7 @@
 
 import { SubscriptionService } from '@/core/subscription/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
+import type { ISubscriptionDataProvider } from '@/core/subscription';
 import { createSubscriptionProvider } from '@/adapters/subscription/factory';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
@@ -24,7 +25,7 @@ export function getApiSubscriptionService(): SubscriptionService {
     const supabase = getServiceSupabase();
     
     // Create subscription data provider
-    const subscriptionDataProvider = createSubscriptionProvider({
+    const subscriptionDataProvider: ISubscriptionDataProvider = createSubscriptionProvider({
       type: 'supabase',
       options: {
         supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',

--- a/src/services/team/factory.ts
+++ b/src/services/team/factory.ts
@@ -7,6 +7,7 @@
 
 import { TeamService } from '@/core/team/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
+import type { ITeamDataProvider } from '@/core/team';
 import { createTeamProvider } from '@/adapters/team/factory';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
@@ -24,7 +25,7 @@ export function getApiTeamService(): TeamService {
     const supabase = getServiceSupabase();
     
     // Create team data provider
-    const teamDataProvider = createTeamProvider({
+    const teamDataProvider: ITeamDataProvider = createTeamProvider({
       type: 'supabase',
       options: {
         supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',

--- a/src/services/two-factor/factory.ts
+++ b/src/services/two-factor/factory.ts
@@ -7,6 +7,7 @@
 
 import { TwoFactorService } from '@/core/two-factor/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
+import type { ITwoFactorDataProvider } from '@/core/two-factor';
 import { createTwoFactorProvider } from '@/adapters/two-factor/factory';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
@@ -24,7 +25,7 @@ export function getApiTwoFactorService(): TwoFactorService {
     const supabase = getServiceSupabase();
     
     // Create 2FA data provider
-    const twoFactorDataProvider = createTwoFactorProvider({
+    const twoFactorDataProvider: ITwoFactorDataProvider = createTwoFactorProvider({
       type: 'supabase',
       options: {
         supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',

--- a/src/services/user/factory.ts
+++ b/src/services/user/factory.ts
@@ -7,6 +7,7 @@
 
 import { UserService } from '@/core/user/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
+import type { IUserDataProvider } from '@/core/user';
 import { createUserProvider } from '@/adapters/user/factory';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
@@ -24,7 +25,7 @@ export function getApiUserService(): UserService {
     const supabase = getServiceSupabase();
     
     // Create user data provider
-    const userDataProvider = createUserProvider({
+    const userDataProvider: IUserDataProvider = createUserProvider({
       type: 'supabase',
       options: {
         supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',

--- a/src/services/webhooks/factory.ts
+++ b/src/services/webhooks/factory.ts
@@ -7,6 +7,7 @@
 
 import { IWebhookService } from '@/core/webhooks';
 import { UserManagementConfiguration } from '@/core/config';
+import type { IWebhookDataProvider } from '@/core/webhooks';
 import { createWebhookProvider } from '@/adapters/webhook';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
@@ -24,7 +25,7 @@ export function getApiWebhookService(): IWebhookService {
     const supabase = getServiceSupabase();
     
     // Create webhook data provider
-    const webhookDataProvider = createWebhookProvider({
+    const webhookDataProvider: IWebhookDataProvider = createWebhookProvider({
       type: 'supabase',
       options: {
         supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',


### PR DESCRIPTION
## Summary
- move API route factories into `src/services`
- adjust imports and provider types for new core interfaces
- update API routes and tests to use new paths

## Testing
- `npm run test:coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*