### PR TITLE
Use new service factories in API routes

### DIFF
--- a/app/api/2fa/setup/route.ts
+++ b/app/api/2fa/setup/route.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { authenticator } from 'otplib';
 import * as qrcode from 'qrcode';
 import { TwoFactorMethod } from '@/types/2fa';
-import { getApiTwoFactorService } from '@/services/two-factor/factory';
+import { getApi2FAService } from '@/services/two-factor/factory';
 import { getApiAuthService } from '@/services/auth/factory';
 
 // Request schema
@@ -22,7 +22,7 @@ export async function POST(request: Request) {
 
     // Get service instances from factories
     const authService = getApiAuthService();
-    const twoFactorService = getApiTwoFactorService();
+    const twoFactorService = getApi2FAService();
     
     // Verify user authentication
     const cookieStore = cookies();

--- a/app/api/csrf/route.ts
+++ b/app/api/csrf/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getApiCsrfService } from '@/services/csrf/factory';
+import { getApiCSRFService } from '@/services/csrf/factory';
 
 // Configuration (consider moving to a shared config if used elsewhere)
 const cookieName = 'csrf-token';
@@ -8,7 +8,7 @@ const sameSite = 'strict';
 
 export async function GET() {
   try {
-    const csrfService = getApiCsrfService();
+    const csrfService = getApiCSRFService();
     const { token } = await csrfService.generateToken();
     const response = NextResponse.json({ csrfToken: token }, { status: 200 });
 

--- a/app/api/gdpr/delete/route.ts
+++ b/app/api/gdpr/delete/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { getServiceSupabase } from '@/lib/database/supabase';
 import { logUserAction } from '@/lib/audit/auditLogger';
-import { getApiGdprService } from '@/services/gdpr/factory';
+import { getApiGDPRService } from '@/services/gdpr/factory';
 
 export async function POST(request: NextRequest) {
   // 1. Authentication (Essential)
@@ -45,7 +45,7 @@ export async function POST(request: NextRequest) {
   // }
 
   try {
-    const gdprService = getApiGdprService();
+    const gdprService = getApiGDPRService();
     const result = await gdprService.deleteAccount(user.id);
 
     if (!result.success) {

--- a/app/api/gdpr/export/route.ts
+++ b/app/api/gdpr/export/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { getServiceSupabase } from '@/lib/database/supabase';
-import { getApiGdprService } from '@/services/gdpr/factory';
+import { getApiGDPRService } from '@/services/gdpr/factory';
 
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get('authorization');
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: userError?.message || 'Invalid token' }, { status: 401 });
   }
 
-  const gdprService = getApiGdprService();
+  const gdprService = getApiGDPRService();
 
   try {
     const exportData = await gdprService.exportUserData(user.id);

--- a/src/services/api-keys/factory.ts
+++ b/src/services/api-keys/factory.ts
@@ -44,3 +44,10 @@ export function getApiKeyService(): ApiKeyService {
   
   return apiKeyServiceInstance;
 }
+
+/**
+ * Temporary alias for backwards compatibility with older route imports.
+ */
+export function getApiKeysService(): ApiKeyService {
+  return getApiKeyService();
+}

--- a/src/services/csrf/factory.ts
+++ b/src/services/csrf/factory.ts
@@ -25,3 +25,10 @@ export function getApiCsrfService(): CsrfService {
   }
   return csrfServiceInstance;
 }
+
+/**
+ * Temporary alias for backwards compatibility with older route imports.
+ */
+export function getApiCSRFService(): CsrfService {
+  return getApiCsrfService();
+}

--- a/src/services/gdpr/factory.ts
+++ b/src/services/gdpr/factory.ts
@@ -44,3 +44,10 @@ export function getApiGdprService(): GdprService {
   
   return gdprServiceInstance;
 }
+
+/**
+ * Temporary alias for backwards compatibility with older route imports.
+ */
+export function getApiGDPRService(): GdprService {
+  return getApiGdprService();
+}

--- a/src/services/two-factor/factory.ts
+++ b/src/services/two-factor/factory.ts
@@ -44,3 +44,11 @@ export function getApiTwoFactorService(): TwoFactorService {
   
   return twoFactorServiceInstance;
 }
+
+/**
+ * Temporary alias for backwards compatibility. Will be removed once all
+ * routes are updated to use the new naming convention.
+ */
+export function getApi2FAService(): TwoFactorService {
+  return getApiTwoFactorService();
+}


### PR DESCRIPTION
## Summary
- add compatibility aliases for `getApi2FAService`, `getApiKeysService`, `getApiCSRFService`, and `getApiGDPRService`
- update API routes to import from new factory names

## Testing
- `git status --short`