### PR TITLE
Align service interfaces with data providers

### DIFF
--- a/src/core/address/interfaces.ts
+++ b/src/core/address/interfaces.ts
@@ -1,18 +1,71 @@
-import { CompanyAddress, AddressCreatePayload, AddressUpdatePayload, AddressResult } from './models';
-import type { Address } from './types';
+import {
+  CompanyAddress,
+  AddressCreatePayload,
+  AddressUpdatePayload,
+  AddressResult,
+} from "./models";
+import type { Address } from "./types";
 
+/**
+ * Service for managing company level addresses.
+ *
+ * All write operations resolve with an {@link AddressResult} describing success
+ * or failure. Implementations should only reject the promise for unexpected
+ * errors such as network issues.
+ */
 export interface CompanyAddressService {
-  createAddress(companyId: string, address: AddressCreatePayload): Promise<AddressResult>;
+  /** Create an address for the given company */
+  createAddress(
+    companyId: string,
+    address: AddressCreatePayload,
+  ): Promise<AddressResult>;
+
+  /** Retrieve all addresses associated with the company */
   getAddresses(companyId: string): Promise<CompanyAddress[]>;
-  updateAddress(companyId: string, addressId: string, update: AddressUpdatePayload): Promise<AddressResult>;
-  deleteAddress(companyId: string, addressId: string): Promise<{ success: boolean; error?: string }>;
+
+  /** Update a specific company address */
+  updateAddress(
+    companyId: string,
+    addressId: string,
+    update: AddressUpdatePayload,
+  ): Promise<AddressResult>;
+
+  /** Remove a company address */
+  deleteAddress(
+    companyId: string,
+    addressId: string,
+  ): Promise<{ success: boolean; error?: string }>;
 }
 
+/**
+ * Service for managing a user's personal addresses.
+ *
+ * These methods resolve with the resulting address objects and should throw
+ * only for unexpected failures. Validation or business errors should be
+ * surfaced via returned objects where applicable.
+ */
 export interface AddressService {
+  /** Retrieve all addresses belonging to the user */
   getAddresses(userId: string): Promise<Address[]>;
+
+  /** Get a single address by id */
   getAddress(id: string, userId: string): Promise<Address>;
-  createAddress(address: Omit<Address, 'id' | 'createdAt' | 'updatedAt'>): Promise<Address>;
-  updateAddress(id: string, updates: Partial<Address>, userId: string): Promise<Address>;
+
+  /** Create a new personal address */
+  createAddress(
+    address: Omit<Address, "id" | "createdAt" | "updatedAt">,
+  ): Promise<Address>;
+
+  /** Update an existing address */
+  updateAddress(
+    id: string,
+    updates: Partial<Address>,
+    userId: string,
+  ): Promise<Address>;
+
+  /** Delete an address */
   deleteAddress(id: string, userId: string): Promise<void>;
+
+  /** Mark an address as the user's default */
   setDefaultAddress(id: string, userId: string): Promise<void>;
 }

--- a/src/core/api-keys/interfaces.ts
+++ b/src/core/api-keys/interfaces.ts
@@ -1,13 +1,60 @@
-import type { ApiKey } from './types';
+import type { ApiKey, ApiKeyCreatePayload, ApiKeyCreateResult } from "./models";
 
+/**
+ * Service for high level API key management.
+ *
+ * Methods return structured result objects. Implementations should only
+ * reject the promise for unexpected failures. Business errors are reported
+ * via the returned objects.
+ */
 export interface ApiKeyService {
-  listApiKeys(): Promise<ApiKey[]>;
+  /** Retrieve all API keys for a user. */
+  listApiKeys(userId: string): Promise<ApiKey[]>;
+
+  /**
+   * Create a new API key for the given user.
+   *
+   * @param userId Owner of the key
+   * @param data   Creation payload
+   */
   createApiKey(
-    name: string,
-    permissions: string[],
-    expiresInDays?: number
-  ): Promise<{ key: string } & ApiKey>;
-  revokeApiKey(id: string): Promise<void>;
-  regenerateApiKey(id: string): Promise<{ key: string } & ApiKey>;
-  validateApiKey(apiKey: string): Promise<boolean>;
+    userId: string,
+    data: ApiKeyCreatePayload,
+  ): Promise<ApiKeyCreateResult>;
+
+  /**
+   * Revoke an existing API key so it can no longer be used.
+   *
+   * @param userId Owner of the key
+   * @param keyId  Identifier of the key to revoke
+   */
+  revokeApiKey(
+    userId: string,
+    keyId: string,
+  ): Promise<{ success: boolean; key?: ApiKey; error?: string }>;
+
+  /**
+   * Regenerate the secret for an API key.
+   *
+   * @param userId Owner of the key
+   * @param keyId  Identifier of the key
+   */
+  regenerateApiKey(
+    userId: string,
+    keyId: string,
+  ): Promise<{
+    success: boolean;
+    key?: ApiKey;
+    plaintext?: string;
+    error?: string;
+  }>;
+
+  /**
+   * Validate an API key. Should resolve with `{ valid: boolean }` rather than
+   * throwing for invalid keys.
+   */
+  validateApiKey(
+    apiKey: string,
+    userId?: string,
+  ): Promise<{ valid: boolean; error?: string }>;
 }

--- a/src/core/audit/interfaces.ts
+++ b/src/core/audit/interfaces.ts
@@ -1,22 +1,31 @@
-import type { AuditLog, AuditLogFilters } from './types';
+import type { AuditLogEntry, AuditLogQuery } from "./models";
 
+/**
+ * High level audit logging service.
+ *
+ * Implementations should surface validation problems via the returned objects
+ * and reserve promise rejection for unexpected failures.
+ */
 export interface AuditService {
-  /** Log an event to the audit log */
+  /**
+   * Persist a new audit log entry.
+   *
+   * @param entry Log information to store
+   * @returns Result object indicating success or failure
+   */
   logEvent(
-    action: string,
-    entityType: string,
-    entityId: string,
-    metadata?: Record<string, unknown>
-  ): Promise<void>;
+    entry: AuditLogEntry,
+  ): Promise<{ success: boolean; id?: string; error?: string }>;
 
-  /** Retrieve audit logs with optional filtering and pagination */
+  /**
+   * Retrieve audit logs using the provided query parameters.
+   */
   getLogs(
-    filters: AuditLogFilters,
-    page: number,
-    pageSize: number
-  ): Promise<{ logs: AuditLog[]; total: number }>;
+    query: AuditLogQuery,
+  ): Promise<{ logs: AuditLogEntry[]; count: number }>;
 
-  /** Export audit logs as a blob (e.g. CSV or Excel) */
-  exportLogs(filters: AuditLogFilters): Promise<Blob>;
+  /**
+   * Export audit logs that match the query as a downloadable blob.
+   */
+  exportLogs(query: AuditLogQuery): Promise<Blob>;
 }
-

--- a/src/core/csrf/interfaces.ts
+++ b/src/core/csrf/interfaces.ts
@@ -1,5 +1,22 @@
-import { CsrfToken } from './models';
+import { CsrfToken } from "./models";
 
+/**
+ * Service responsible for managing CSRF tokens.
+ *
+ * Expected failures such as invalid tokens should be reflected in the
+ * returned result objects. Promises reject only on unexpected errors.
+ */
 export interface CsrfService {
-  generateToken(): Promise<CsrfToken>;
+  /** Create a new token */
+  createToken(): Promise<{
+    success: boolean;
+    token?: CsrfToken;
+    error?: string;
+  }>;
+
+  /** Validate an existing token */
+  validateToken(token: string): Promise<{ valid: boolean; error?: string }>;
+
+  /** Revoke a token */
+  revokeToken(token: string): Promise<{ success: boolean; error?: string }>;
 }

--- a/src/core/gdpr/interfaces.ts
+++ b/src/core/gdpr/interfaces.ts
@@ -4,16 +4,19 @@
  * Defines the operations related to data privacy such as exporting
  * a user's personal data and deleting a user's account.
  */
-import { UserDataExport, AccountDeletionResult } from './models';
+import { UserDataExport, AccountDeletionResult } from "./models";
 
+/**
+ * Service responsible for GDPR related user data operations.
+ */
 export interface GdprService {
   /**
-   * Export all data related to a user.
+   * Generate an export of all data associated with the user.
    *
    * @param userId ID of the user
-   * @returns The exported data or null if not found
+   * @returns Exported data or null if the user does not exist
    */
-  exportUserData(userId: string): Promise<UserDataExport | null>;
+  generateUserExport(userId: string): Promise<UserDataExport | null>;
 
   /**
    * Delete all data related to a user and schedule account removal.
@@ -21,5 +24,5 @@ export interface GdprService {
    * @param userId ID of the user
    * @returns Result of the deletion request
    */
-  deleteAccount(userId: string): Promise<AccountDeletionResult>;
+  deleteUserData(userId: string): Promise<AccountDeletionResult>;
 }

--- a/src/core/subscription/interfaces.ts
+++ b/src/core/subscription/interfaces.ts
@@ -1,32 +1,67 @@
 /**
  * Subscription Service Interface
  */
-import type { SubscriptionPlan, UserSubscription } from './models';
+import type { SubscriptionPlan, UserSubscription } from "./models";
 
+/**
+ * Service managing user subscription plans.
+ */
 export interface SubscriptionService {
   /**
    * Fetch all available subscription plans
    */
+  /** Retrieve all available subscription plans */
   getPlans(): Promise<SubscriptionPlan[]>;
 
   /**
    * Get a subscription for a user
    * @param userId User identifier
    */
+  /**
+   * Get the current subscription for a user.
+   *
+   * @param userId Identifier of the user
+   */
   getUserSubscription(userId: string): Promise<UserSubscription | null>;
 
   /**
    * Create a new subscription for a user
    */
-  createSubscription(userId: string, planId: string): Promise<UserSubscription>;
+  /**
+   * Create a subscription for a user and plan.
+   */
+  createSubscription(
+    userId: string,
+    planId: string,
+  ): Promise<{
+    success: boolean;
+    subscription?: UserSubscription;
+    error?: string;
+  }>;
 
   /**
    * Cancel an existing subscription
    */
-  cancelSubscription(subscriptionId: string, immediate?: boolean): Promise<void>;
+  /**
+   * Cancel an active subscription.
+   */
+  cancelSubscription(
+    subscriptionId: string,
+    immediate?: boolean,
+  ): Promise<{ success: boolean; error?: string }>;
 
   /**
    * Update a subscription's plan
    */
-  updateSubscription(subscriptionId: string, planId: string): Promise<UserSubscription>;
+  /**
+   * Change the plan of an existing subscription.
+   */
+  updateSubscription(
+    subscriptionId: string,
+    planId: string,
+  ): Promise<{
+    success: boolean;
+    subscription?: UserSubscription;
+    error?: string;
+  }>;
 }

--- a/src/core/webhooks/IWebhookService.ts
+++ b/src/core/webhooks/IWebhookService.ts
@@ -2,12 +2,22 @@
  * Webhook Service Interface
  *
  * Provides high level business logic for managing webhooks and sending events.
+ * Methods should resolve with result objects describing business failures and
+ * only reject on unexpected errors.
  */
-import type { Webhook, WebhookCreatePayload, WebhookUpdatePayload, WebhookDelivery } from './models';
+import type {
+  Webhook,
+  WebhookCreatePayload,
+  WebhookUpdatePayload,
+  WebhookDelivery,
+} from "./models";
 
 export interface IWebhookService {
   /** Create a new webhook for the given user */
-  createWebhook(userId: string, data: WebhookCreatePayload): Promise<{
+  createWebhook(
+    userId: string,
+    data: WebhookCreatePayload,
+  ): Promise<{
     success: boolean;
     webhook?: Webhook;
     error?: string;
@@ -23,15 +33,26 @@ export interface IWebhookService {
   updateWebhook(
     userId: string,
     webhookId: string,
-    data: WebhookUpdatePayload
+    data: WebhookUpdatePayload,
   ): Promise<{ success: boolean; webhook?: Webhook; error?: string }>;
 
   /** Remove a webhook */
-  deleteWebhook(userId: string, webhookId: string): Promise<{ success: boolean; error?: string }>;
+  deleteWebhook(
+    userId: string,
+    webhookId: string,
+  ): Promise<{ success: boolean; error?: string }>;
 
   /** Get delivery history for a webhook */
-  getWebhookDeliveries(userId: string, webhookId: string, limit?: number): Promise<WebhookDelivery[]>;
+  getWebhookDeliveries(
+    userId: string,
+    webhookId: string,
+    limit?: number,
+  ): Promise<WebhookDelivery[]>;
 
   /** Trigger an event for all matching webhooks */
-  triggerEvent(eventType: string, payload: unknown, userId?: string): Promise<WebhookDelivery[]>;
+  triggerEvent(
+    eventType: string,
+    payload: unknown,
+    userId?: string,
+  ): Promise<WebhookDelivery[]>;
 }


### PR DESCRIPTION
## Summary
- sync `ApiKeyService` with provider contract
- document company & personal address services
- align `AuditService` methods with data provider patterns
- expand CSRF service for full token lifecycle
- rename GDPR operations and update docs
- return result objects from subscription service
- clarify webhook service error handling

## Testing
- `npx prettier -w src/core/api-keys/interfaces.ts src/core/address/interfaces.ts src/core/audit/interfaces.ts src/core/csrf/interfaces.ts src/core/gdpr/interfaces.ts src/core/subscription/interfaces.ts src/core/webhooks/IWebhookService.ts`