### PR TITLE
Refactor user service to use data provider

### DIFF
--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -143,17 +143,6 @@ export class AdapterRegistry {
   static registerFactory(name: string, factoryCreator: FactoryCreator): void {
     this.factories[name] = factoryCreator;
   }
-}
-  /**
-   * Register an adapter factory
-   * 
-   * @param name Name to register the factory under
-   * @param factoryCreator Function that creates the factory
-   */
-  static registerFactory(name: string, factoryCreator: FactoryCreator): void {
-    this.factories[name] = factoryCreator;
-  }
-}
   
   /**
    * Get an adapter factory by name

--- a/src/services/user/factory.ts
+++ b/src/services/user/factory.ts
@@ -24,7 +24,7 @@ export function getApiUserService(): UserService {
     const userDataProvider = AdapterRegistry.getInstance().getAdapter<IUserDataProvider>('user');
 
     // Create the user service with the adapter
-    userServiceInstance = new DefaultUserService(null as any, userDataProvider);
+    userServiceInstance = new DefaultUserService(userDataProvider);
   }
   
   return userServiceInstance;

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -7,18 +7,12 @@
 
 import { UserService } from '@/core/user/interfaces';
 import { DefaultUserService } from './default-user.service';
-import type { AxiosInstance } from 'axios';
 import type { UserDataProvider } from '@/core/user/IUserDataProvider';
 
 /**
  * Configuration options for creating a UserService
  */
 export interface UserServiceConfig {
-  /**
-   * API client for making HTTP requests
-   */
-  apiClient: AxiosInstance;
-  
   /**
    * User data provider for database operations
    */
@@ -32,7 +26,7 @@ export interface UserServiceConfig {
  * @returns An instance of the UserService
  */
 export function createUserService(config: UserServiceConfig): UserService {
-  return new DefaultUserService(config.apiClient, config.userDataProvider);
+  return new DefaultUserService(config.userDataProvider);
 }
 
 /**


### PR DESCRIPTION
## Summary
- refactor `DefaultUserService` to remove Axios client
- call `UserDataProvider` in all user service methods
- update service factory and index for new constructor
- fix adapter registry duplication to allow tests to run
- update unit tests

## Testing
- `npx vitest run src/services/user/__tests__/factory.test.ts`
- `npx vitest run --coverage` *(fails: useAuthStore is not defined)*