### PR TITLE
Refactor TeamService to use data providers

### DIFF
--- a/src/services/team/factory.ts
+++ b/src/services/team/factory.ts
@@ -24,7 +24,7 @@ export function getApiTeamService(): TeamService {
     const teamDataProvider = AdapterRegistry.getInstance().getAdapter<ITeamDataProvider>('team');
 
     // Create team service with the adapter
-    teamServiceInstance = new DefaultTeamService(null as any, teamDataProvider);
+    teamServiceInstance = new DefaultTeamService(teamDataProvider);
   }
   
   return teamServiceInstance;

--- a/src/services/team/index.ts
+++ b/src/services/team/index.ts
@@ -7,18 +7,12 @@
 
 import { TeamService } from '@/core/team/interfaces';
 import { DefaultTeamService } from './default-team.service';
-import type { AxiosInstance } from 'axios';
 import type { TeamDataProvider } from '@/core/team/ITeamDataProvider';
 
 /**
  * Configuration options for creating a TeamService
  */
 export interface TeamServiceConfig {
-  /**
-   * API client for making HTTP requests
-   */
-  apiClient: AxiosInstance;
-  
   /**
    * Team data provider for database operations
    */
@@ -32,7 +26,7 @@ export interface TeamServiceConfig {
  * @returns An instance of the TeamService
  */
 export function createTeamService(config: TeamServiceConfig): TeamService {
-  return new DefaultTeamService(config.apiClient, config.teamDataProvider);
+  return new DefaultTeamService(config.teamDataProvider);
 }
 
 /**


### PR DESCRIPTION
## Summary
- update `DefaultTeamService` to rely solely on `TeamDataProvider`
- adjust factory and public API for the new constructor
- update unit test factory

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*