### PR TITLE
Refactor services to use data providers

### DIFF
--- a/src/services/csrf/__tests__/browser-csrf.service.test.ts
+++ b/src/services/csrf/__tests__/browser-csrf.service.test.ts
@@ -1,32 +1,30 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { BrowserCsrfService } from '../browser-csrf.service';
-
-declare const global: any;
-
-const originalFetch = global.fetch;
+import type { CsrfDataProvider } from '@/core/csrf/ICsrfDataProvider';
 
 afterEach(() => {
-  global.fetch = originalFetch;
   vi.restoreAllMocks();
 });
 
 describe('BrowserCsrfService', () => {
-  it('fetches token from endpoint', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({ csrfToken: 'abc' })
-    });
-
-    const service = new BrowserCsrfService('/csrf');
+  it('returns token from provider', async () => {
+    const provider: CsrfDataProvider = {
+      generateToken: vi.fn(async () => 'abc')
+    };
+    const service = new BrowserCsrfService(provider);
     const result = await service.generateToken();
 
-    expect(global.fetch).toHaveBeenCalledWith('/csrf', { credentials: 'include' });
+    expect(provider.generateToken).toHaveBeenCalled();
     expect(result).toEqual({ token: 'abc' });
   });
 
-  it('throws on failed request', async () => {
-    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500, statusText: 'err' });
-    const service = new BrowserCsrfService('/csrf');
-    await expect(service.generateToken()).rejects.toThrow('Failed to fetch CSRF token');
+  it('throws on provider error', async () => {
+    const provider: CsrfDataProvider = {
+      generateToken: vi.fn(async () => {
+        throw new Error('fail');
+      })
+    };
+    const service = new BrowserCsrfService(provider);
+    await expect(service.generateToken()).rejects.toThrow('fail');
   });
 });

--- a/src/services/csrf/browser-csrf.service.ts
+++ b/src/services/csrf/browser-csrf.service.ts
@@ -1,17 +1,11 @@
 import { CsrfService } from '@/core/csrf/interfaces';
+import type { CsrfDataProvider } from '@/core/csrf/ICsrfDataProvider';
 
 export class BrowserCsrfService implements CsrfService {
-  constructor(private endpoint = '/api/csrf') {}
+  constructor(private provider: CsrfDataProvider) {}
 
   async generateToken() {
-    const res = await fetch(this.endpoint, { credentials: 'include' });
-    if (!res.ok) {
-      throw new Error('Failed to fetch CSRF token');
-    }
-    const data = await res.json();
-    if (!data.csrfToken) {
-      throw new Error('Invalid CSRF token response');
-    }
-    return { token: data.csrfToken as string };
+    const token = await this.provider.generateToken();
+    return { token };
   }
 }

--- a/src/services/subscription/default-subscription.service.ts
+++ b/src/services/subscription/default-subscription.service.ts
@@ -1,0 +1,27 @@
+import { SubscriptionService } from '@/core/subscription/interfaces';
+import type { ISubscriptionDataProvider } from '@/core/subscription';
+import type { SubscriptionPlan, UserSubscription } from '@/core/subscription/models';
+
+export class DefaultSubscriptionService implements SubscriptionService {
+  constructor(private provider: ISubscriptionDataProvider) {}
+
+  getPlans(): Promise<SubscriptionPlan[]> {
+    return this.provider.getPlans();
+  }
+
+  getUserSubscription(userId: string): Promise<UserSubscription | null> {
+    return this.provider.getUserSubscription(userId);
+  }
+
+  createSubscription(userId: string, planId: string) {
+    return this.provider.createSubscription(userId, planId);
+  }
+
+  cancelSubscription(subscriptionId: string, immediate?: boolean) {
+    return this.provider.cancelSubscription(subscriptionId, immediate);
+  }
+
+  updateSubscription(subscriptionId: string, planId: string) {
+    return this.provider.updateSubscription(subscriptionId, planId);
+  }
+}

--- a/src/services/subscription/index.ts
+++ b/src/services/subscription/index.ts
@@ -1,0 +1,14 @@
+import { SubscriptionService } from '@/core/subscription/interfaces';
+import type { ISubscriptionDataProvider } from '@/core/subscription';
+import { DefaultSubscriptionService } from './default-subscription.service';
+
+export interface SubscriptionServiceConfig {
+  subscriptionDataProvider: ISubscriptionDataProvider;
+}
+
+export function createSubscriptionService(config: SubscriptionServiceConfig): SubscriptionService {
+  return new DefaultSubscriptionService(config.subscriptionDataProvider);
+}
+
+export default { createSubscriptionService };
+

--- a/src/services/webhooks/WebhookService.ts
+++ b/src/services/webhooks/WebhookService.ts
@@ -1,13 +1,9 @@
-import type { AxiosInstance } from 'axios';
 import type { IWebhookService } from '@/core/webhooks/IWebhookService';
 import type { IWebhookDataProvider } from '@/core/webhooks/IWebhookDataProvider';
 import type { Webhook, WebhookCreatePayload, WebhookUpdatePayload, WebhookDelivery } from '@/core/webhooks/models';
 
 export class WebhookService implements IWebhookService {
-  constructor(
-    private apiClient: AxiosInstance,
-    private dataProvider: IWebhookDataProvider
-  ) {}
+  constructor(private dataProvider: IWebhookDataProvider) {}
 
   async getWebhooks(userId: string): Promise<Webhook[]> {
     return this.dataProvider.listWebhooks(userId);

--- a/src/services/webhooks/factory.ts
+++ b/src/services/webhooks/factory.ts
@@ -8,7 +8,6 @@
 import { IWebhookService } from '@/core/webhooks';
 import type { IWebhookDataProvider } from '@/core/webhooks';
 import { AdapterRegistry } from '@/adapters/registry';
-import { api } from '@/lib/api/axios';
 import { WebhookService } from './WebhookService';
 
 // Singleton instance for API routes
@@ -22,8 +21,9 @@ let webhookServiceInstance: IWebhookService | null = null;
 export function getApiWebhookService(): IWebhookService {
   if (!webhookServiceInstance) {
     const webhookDataProvider = AdapterRegistry.getInstance().getAdapter<IWebhookDataProvider>('webhook');
-    webhookServiceInstance = new WebhookService(api, webhookDataProvider);
+    webhookServiceInstance = new WebhookService(webhookDataProvider);
   }
   
   return webhookServiceInstance;
 }
+

--- a/src/services/webhooks/index.ts
+++ b/src/services/webhooks/index.ts
@@ -1,15 +1,14 @@
-import type { AxiosInstance } from 'axios';
 import type { IWebhookService } from '@/core/webhooks/IWebhookService';
 import type { IWebhookDataProvider } from '@/core/webhooks/IWebhookDataProvider';
 import { WebhookService } from './WebhookService';
 
 export interface WebhookServiceConfig {
-  apiClient: AxiosInstance;
   webhookDataProvider: IWebhookDataProvider;
 }
 
 export function createWebhookService(config: WebhookServiceConfig): IWebhookService {
-  return new WebhookService(config.apiClient, config.webhookDataProvider);
+  return new WebhookService(config.webhookDataProvider);
 }
 
 export default { createWebhookService };
+


### PR DESCRIPTION
## Summary
- remove endpoint fetch logic from BrowserCsrfService and use data provider
- update BrowserCsrfService tests
- remove API client dependency from WebhookService
- update webhook service factory and index
- add default subscription service and index

## Testing
- `npx vitest run src/services/csrf/__tests__/browser-csrf.service.test.ts src/services/csrf/__tests__/default-csrf.service.test.ts`