### PR TITLE
Implement missing default services

### DIFF
--- a/src/services/address/default-address.service.ts
+++ b/src/services/address/default-address.service.ts
@@ -1,0 +1,117 @@
+import { AddressService } from '@/core/address/interfaces';
+import type { IAddressDataProvider } from '@/core/address/IAddressDataProvider';
+import type {
+  CompanyAddress,
+  AddressCreatePayload,
+  AddressUpdatePayload,
+  AddressResult
+} from '@/core/address/models';
+import type { Address } from '@/core/address/types';
+
+/**
+ * Default implementation of the {@link AddressService} interface.
+ *
+ * This service translates between user level address objects and the
+ * data provider which works with company style addresses.
+ */
+export class DefaultAddressService implements AddressService {
+  constructor(private provider: IAddressDataProvider) {}
+
+  private mapToAddress(data: CompanyAddress): Address {
+    return {
+      id: data.id,
+      userId: data.company_id,
+      type: (data.type as 'billing' | 'shipping') ?? 'shipping',
+      isDefault: data.is_primary,
+      fullName: '',
+      company: undefined,
+      street1: data.street_line1,
+      street2: data.street_line2,
+      city: data.city,
+      state: data.state ?? '',
+      postalCode: data.postal_code,
+      country: data.country,
+      phone: undefined,
+      createdAt: new Date(data.created_at),
+      updatedAt: new Date(data.updated_at)
+    };
+  }
+
+  private toCreatePayload(address: Omit<Address, 'id' | 'createdAt' | 'updatedAt'>): AddressCreatePayload {
+    return {
+      type: address.type === 'both' ? 'shipping' : address.type,
+      street_line1: address.street1,
+      street_line2: address.street2,
+      city: address.city,
+      state: address.state,
+      postal_code: address.postalCode,
+      country: address.country,
+      is_primary: address.isDefault,
+      validated: false
+    };
+  }
+
+  private toUpdatePayload(updates: Partial<Address>): AddressUpdatePayload {
+    return {
+      type: updates.type && updates.type !== 'both' ? updates.type : undefined,
+      street_line1: updates.street1,
+      street_line2: updates.street2,
+      city: updates.city,
+      state: updates.state,
+      postal_code: updates.postalCode,
+      country: updates.country,
+      is_primary: updates.isDefault,
+      validated: undefined
+    };
+  }
+
+  /** @inheritdoc */
+  async getAddresses(userId: string): Promise<Address[]> {
+    const list = await this.provider.getAddresses(userId);
+    return list.map(a => this.mapToAddress(a));
+  }
+
+  /** @inheritdoc */
+  async getAddress(id: string, userId: string): Promise<Address> {
+    const list = await this.provider.getAddresses(userId);
+    const found = list.find(a => a.id === id);
+    if (!found) {
+      throw new Error('Address not found');
+    }
+    return this.mapToAddress(found);
+  }
+
+  /** @inheritdoc */
+  async createAddress(address: Omit<Address, 'id' | 'createdAt' | 'updatedAt'>): Promise<Address> {
+    const result: AddressResult = await this.provider.createAddress(
+      address.userId,
+      this.toCreatePayload(address)
+    );
+    if (!result.success || !result.address) {
+      throw new Error(result.error || 'Failed to create address');
+    }
+    return this.mapToAddress(result.address);
+  }
+
+  /** @inheritdoc */
+  async updateAddress(id: string, updates: Partial<Address>, userId: string): Promise<Address> {
+    const result = await this.provider.updateAddress(userId, id, this.toUpdatePayload(updates));
+    if (!result.success || !result.address) {
+      throw new Error(result.error || 'Failed to update address');
+    }
+    return this.mapToAddress(result.address);
+  }
+
+  /** @inheritdoc */
+  async deleteAddress(id: string, userId: string): Promise<void> {
+    const result = await this.provider.deleteAddress(userId, id);
+    if (!result.success) {
+      throw new Error(result.error || 'Failed to delete address');
+    }
+  }
+
+  /** @inheritdoc */
+  async setDefaultAddress(id: string, userId: string): Promise<void> {
+    await this.provider.updateAddress(userId, id, { is_primary: true });
+  }
+}

--- a/src/services/api-keys/default-api-keys.service.ts
+++ b/src/services/api-keys/default-api-keys.service.ts
@@ -1,0 +1,61 @@
+import { ApiKeyService } from '@/core/api-keys/interfaces';
+import type { IApiKeyDataProvider } from '@/core/api-keys/IApiKeyDataProvider';
+import type { ApiKey, ApiKeyCreatePayload, ApiKeyCreateResult } from '@/core/api-keys/models';
+import { getKeyPrefix } from '@/lib/api-keys/api-key-utils';
+
+/**
+ * Default implementation of the {@link ApiKeyService} interface.
+ *
+ * This service contains high level business logic for managing API keys
+ * while delegating persistence to the injected {@link IApiKeyDataProvider}.
+ */
+export class DefaultApiKeysService implements ApiKeyService {
+  constructor(private provider: IApiKeyDataProvider) {}
+
+  /** @inheritdoc */
+  async listApiKeys(userId: string): Promise<ApiKey[]> {
+    return this.provider.listApiKeys(userId);
+  }
+
+  /** @inheritdoc */
+  async createApiKey(userId: string, data: ApiKeyCreatePayload): Promise<ApiKeyCreateResult> {
+    return this.provider.createApiKey(userId, data);
+  }
+
+  /** @inheritdoc */
+  async revokeApiKey(
+    userId: string,
+    keyId: string
+  ): Promise<{ success: boolean; key?: ApiKey; error?: string }> {
+    return this.provider.revokeApiKey(userId, keyId);
+  }
+
+  /** @inheritdoc */
+  async regenerateApiKey(
+    userId: string,
+    keyId: string
+  ): Promise<{ success: boolean; key?: ApiKey; plaintext?: string; error?: string }> {
+    return this.provider.regenerateApiKey(userId, keyId);
+  }
+
+  /** @inheritdoc */
+  async validateApiKey(apiKey: string, userId?: string): Promise<{ valid: boolean; error?: string }> {
+    if (!userId) {
+      return { valid: false, error: 'User id is required' };
+    }
+    try {
+      const prefix = getKeyPrefix(apiKey);
+      const keys = await this.provider.listApiKeys(userId);
+      const match = keys.find(k => k.prefix === prefix && !k.isRevoked);
+      if (!match) {
+        return { valid: false, error: 'API key not found' };
+      }
+      if (match.expiresAt && new Date(match.expiresAt) < new Date()) {
+        return { valid: false, error: 'API key expired' };
+      }
+      return { valid: true };
+    } catch (error: any) {
+      return { valid: false, error: error.message };
+    }
+  }
+}

--- a/src/services/audit/default-audit.service.ts
+++ b/src/services/audit/default-audit.service.ts
@@ -1,0 +1,28 @@
+import { AuditService } from '@/core/audit/interfaces';
+import type { IAuditDataProvider } from '@/core/audit/IAuditDataProvider';
+import type { AuditLogEntry, AuditLogQuery } from '@/core/audit/models';
+
+/**
+ * Default implementation of the {@link AuditService} interface.
+ *
+ * The service delegates persistence to an injected {@link IAuditDataProvider}
+ * while exposing high level methods for logging and querying audit events.
+ */
+export class DefaultAuditService implements AuditService {
+  constructor(private provider: IAuditDataProvider) {}
+
+  /** @inheritdoc */
+  logEvent(entry: AuditLogEntry): Promise<{ success: boolean; id?: string; error?: string }> {
+    return this.provider.createLog(entry);
+  }
+
+  /** @inheritdoc */
+  getLogs(query: AuditLogQuery): Promise<{ logs: AuditLogEntry[]; count: number }> {
+    return this.provider.getLogs(query);
+  }
+
+  /** @inheritdoc */
+  exportLogs(query: AuditLogQuery): Promise<Blob> {
+    return this.provider.exportLogs(query);
+  }
+}


### PR DESCRIPTION
## Summary
- add DefaultApiKeysService for API key management
- add DefaultAddressService with mapping from provider models
- add DefaultAuditService for logging and querying

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*