### PR TITLE
refactor service factories for DI

### DIFF
--- a/src/services/address/__tests__/factory.test.ts
+++ b/src/services/address/__tests__/factory.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AdapterRegistry } from '@/adapters/registry';
+import { UserManagementConfiguration } from '@/core/config';
+
+let getApiAddressService: typeof import('../factory').getApiAddressService;
+let DefaultAddressService: typeof import('../default-address.service').DefaultAddressService;
+
+describe('getApiAddressService', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    (AdapterRegistry as any).instance = null;
+    UserManagementConfiguration.reset();
+    ({ getApiAddressService } = await import('../factory'));
+    ({ DefaultAddressService } = await import('../default-address.service'));
+  });
+
+  it('returns configured service if registered', () => {
+    const svc = {} as any;
+    UserManagementConfiguration.configureServiceProviders({ addressService: svc });
+    expect(getApiAddressService()).toBe(svc);
+    expect(getApiAddressService()).toBe(svc);
+  });
+
+  it('creates default service with adapter when not configured', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('address', adapter);
+    const service = getApiAddressService();
+    expect(service).toBeInstanceOf(DefaultAddressService);
+    expect(getApiAddressService()).toBe(service);
+  });
+});

--- a/src/services/address/factory.ts
+++ b/src/services/address/factory.ts
@@ -9,6 +9,7 @@ import { CompanyAddressService } from '@/core/address/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
 import type { IAddressDataProvider } from '@/core/address';
 import { AdapterRegistry } from '@/adapters/registry';
+import { DefaultAddressService } from './default-address.service';
 
 // Singleton instance for API routes
 let addressServiceInstance: CompanyAddressService | null = null;
@@ -20,17 +21,14 @@ let addressServiceInstance: CompanyAddressService | null = null;
  */
 export function getApiAddressService(): CompanyAddressService {
   if (!addressServiceInstance) {
-    // Get the address adapter from the registry
-    AdapterRegistry.getInstance().getAdapter<IAddressDataProvider>('address');
+    addressServiceInstance =
+      UserManagementConfiguration.getServiceProvider('addressService') as CompanyAddressService | undefined;
 
-    // Retrieve the service implementation
-    addressServiceInstance = UserManagementConfiguration.getServiceProvider('addressService') as CompanyAddressService;
-
-    // If no address service is registered, throw an error
     if (!addressServiceInstance) {
-      throw new Error('Address service not registered in UserManagementConfiguration');
+      const provider = AdapterRegistry.getInstance().getAdapter<IAddressDataProvider>('address');
+      addressServiceInstance = new DefaultAddressService(provider);
     }
   }
-  
+
   return addressServiceInstance;
 }

--- a/src/services/api-keys/__tests__/factory.test.ts
+++ b/src/services/api-keys/__tests__/factory.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AdapterRegistry } from '@/adapters/registry';
+import { UserManagementConfiguration } from '@/core/config';
+
+let getApiKeyService: typeof import('../factory').getApiKeyService;
+let DefaultApiKeysService: typeof import('../default-api-keys.service').DefaultApiKeysService;
+
+describe('getApiKeyService', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    (AdapterRegistry as any).instance = null;
+    UserManagementConfiguration.reset();
+    ({ getApiKeyService } = await import('../factory'));
+    ({ DefaultApiKeysService } = await import('../default-api-keys.service'));
+  });
+
+  it('returns configured service if registered', () => {
+    const svc = {} as any;
+    UserManagementConfiguration.configureServiceProviders({ apiKeyService: svc });
+    expect(getApiKeyService()).toBe(svc);
+    expect(getApiKeyService()).toBe(svc);
+  });
+
+  it('creates default service with adapter when not configured', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('apiKey', adapter);
+    const service = getApiKeyService();
+    expect(service).toBeInstanceOf(DefaultApiKeysService);
+    expect(getApiKeyService()).toBe(service);
+  });
+});

--- a/src/services/api-keys/factory.ts
+++ b/src/services/api-keys/factory.ts
@@ -9,6 +9,7 @@ import { ApiKeyService } from '@/core/api-key/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
 import type { IApiKeyDataProvider } from '@/core/api-keys';
 import { AdapterRegistry } from '@/adapters/registry';
+import { DefaultApiKeysService } from './default-api-keys.service';
 
 // Singleton instance for API routes
 let apiKeyServiceInstance: ApiKeyService | null = null;
@@ -20,15 +21,15 @@ let apiKeyServiceInstance: ApiKeyService | null = null;
  */
 export function getApiKeyService(): ApiKeyService {
   if (!apiKeyServiceInstance) {
-    AdapterRegistry.getInstance().getAdapter<IApiKeyDataProvider>('apiKey');
-    apiKeyServiceInstance = UserManagementConfiguration.getServiceProvider('apiKeyService') as ApiKeyService;
+    apiKeyServiceInstance =
+      UserManagementConfiguration.getServiceProvider('apiKeyService') as ApiKeyService | undefined;
 
-    // If no API key service is registered, throw an error
     if (!apiKeyServiceInstance) {
-      throw new Error('API Key service not registered in UserManagementConfiguration');
+      const provider = AdapterRegistry.getInstance().getAdapter<IApiKeyDataProvider>('apiKey');
+      apiKeyServiceInstance = new DefaultApiKeysService(provider);
     }
   }
-  
+
   return apiKeyServiceInstance;
 }
 

--- a/src/services/audit/__tests__/factory.test.ts
+++ b/src/services/audit/__tests__/factory.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AdapterRegistry } from '@/adapters/registry';
+import { UserManagementConfiguration } from '@/core/config';
+
+let getApiAuditService: typeof import('../factory').getApiAuditService;
+let DefaultAuditService: typeof import('../default-audit.service').DefaultAuditService;
+
+describe('getApiAuditService', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    (AdapterRegistry as any).instance = null;
+    UserManagementConfiguration.reset();
+    ({ getApiAuditService } = await import('../factory'));
+    ({ DefaultAuditService } = await import('../default-audit.service'));
+  });
+
+  it('returns configured service if registered', () => {
+    const svc = {} as any;
+    UserManagementConfiguration.configureServiceProviders({ auditService: svc });
+    expect(getApiAuditService()).toBe(svc);
+    expect(getApiAuditService()).toBe(svc);
+  });
+
+  it('creates default service with adapter when not configured', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('audit', adapter);
+    const service = getApiAuditService();
+    expect(service).toBeInstanceOf(DefaultAuditService);
+    expect(getApiAuditService()).toBe(service);
+  });
+});

--- a/src/services/audit/factory.ts
+++ b/src/services/audit/factory.ts
@@ -9,6 +9,7 @@ import { AuditService } from '@/core/audit/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
 import type { IAuditDataProvider } from '@/core/audit';
 import { AdapterRegistry } from '@/adapters/registry';
+import { DefaultAuditService } from './default-audit.service';
 
 // Singleton instance for API routes
 let auditServiceInstance: AuditService | null = null;
@@ -20,17 +21,14 @@ let auditServiceInstance: AuditService | null = null;
  */
 export function getApiAuditService(): AuditService {
   if (!auditServiceInstance) {
-    // Get the audit adapter from the registry
-    AdapterRegistry.getInstance().getAdapter<IAuditDataProvider>('audit');
+    auditServiceInstance =
+      UserManagementConfiguration.getServiceProvider('auditService') as AuditService | undefined;
 
-    // Retrieve the service implementation
-    auditServiceInstance = UserManagementConfiguration.getServiceProvider('auditService') as AuditService;
-
-    // If no audit service is registered, throw an error
     if (!auditServiceInstance) {
-      throw new Error('Audit service not registered in UserManagementConfiguration');
+      const provider = AdapterRegistry.getInstance().getAdapter<IAuditDataProvider>('audit');
+      auditServiceInstance = new DefaultAuditService(provider);
     }
   }
-  
+
   return auditServiceInstance;
 }

--- a/src/services/csrf/__tests__/factory.test.ts
+++ b/src/services/csrf/__tests__/factory.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AdapterRegistry } from '@/adapters/registry';
+import { UserManagementConfiguration } from '@/core/config';
+
+let getApiCsrfService: typeof import('../factory').getApiCsrfService;
+let DefaultCsrfService: typeof import('../default-csrf.service').DefaultCsrfService;
+
+describe('getApiCsrfService', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    (AdapterRegistry as any).instance = null;
+    UserManagementConfiguration.reset();
+    ({ getApiCsrfService } = await import('../factory'));
+    ({ DefaultCsrfService } = await import('../default-csrf.service'));
+  });
+
+  it('returns configured service if registered', () => {
+    const service = {} as any;
+    UserManagementConfiguration.configureServiceProviders({ csrfService: service });
+    expect(getApiCsrfService()).toBe(service);
+    expect(getApiCsrfService()).toBe(service);
+  });
+
+  it('creates default service with adapter when not configured', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('csrf', adapter);
+    const service = getApiCsrfService();
+    expect(service).toBeInstanceOf(DefaultCsrfService);
+    expect(getApiCsrfService()).toBe(service);
+  });
+});

--- a/src/services/csrf/factory.ts
+++ b/src/services/csrf/factory.ts
@@ -9,6 +9,7 @@ import { CsrfService } from '@/core/csrf/interfaces';
 import type { ICsrfDataProvider } from '@/core/csrf';
 import { DefaultCsrfService } from './default-csrf.service';
 import { AdapterRegistry } from '@/adapters/registry';
+import { UserManagementConfiguration } from '@/core/config';
 
 // Singleton instance for API routes
 let csrfServiceInstance: CsrfService | null = null;
@@ -20,8 +21,13 @@ let csrfServiceInstance: CsrfService | null = null;
  */
 export function getApiCsrfService(): CsrfService {
   if (!csrfServiceInstance) {
-    const csrfDataProvider = AdapterRegistry.getInstance().getAdapter<ICsrfDataProvider>('csrf');
-    csrfServiceInstance = new DefaultCsrfService(csrfDataProvider);
+    csrfServiceInstance =
+      UserManagementConfiguration.getServiceProvider('csrfService') as CsrfService | undefined;
+
+    if (!csrfServiceInstance) {
+      const csrfDataProvider = AdapterRegistry.getInstance().getAdapter<ICsrfDataProvider>('csrf');
+      csrfServiceInstance = new DefaultCsrfService(csrfDataProvider);
+    }
   }
   return csrfServiceInstance;
 }

--- a/src/services/gdpr/__tests__/factory.test.ts
+++ b/src/services/gdpr/__tests__/factory.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AdapterRegistry } from '@/adapters/registry';
+import { UserManagementConfiguration } from '@/core/config';
+
+let getApiGdprService: typeof import('../factory').getApiGdprService;
+let DefaultGdprService: typeof import('../default-gdpr.service').DefaultGdprService;
+
+describe('getApiGdprService', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    (AdapterRegistry as any).instance = null;
+    UserManagementConfiguration.reset();
+    ({ getApiGdprService } = await import('../factory'));
+    ({ DefaultGdprService } = await import('../default-gdpr.service'));
+  });
+
+  it('returns configured service if registered', () => {
+    const service = {} as any;
+    UserManagementConfiguration.configureServiceProviders({ gdprService: service });
+    expect(getApiGdprService()).toBe(service);
+    expect(getApiGdprService()).toBe(service);
+  });
+
+  it('creates default service with adapter when not configured', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('gdpr', adapter);
+    const service = getApiGdprService();
+    expect(service).toBeInstanceOf(DefaultGdprService);
+    expect(getApiGdprService()).toBe(service);
+  });
+});

--- a/src/services/notification/__tests__/factory.test.ts
+++ b/src/services/notification/__tests__/factory.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AdapterRegistry } from '@/adapters/registry';
+import { UserManagementConfiguration } from '@/core/config';
+
+let getApiNotificationService: typeof import('../factory').getApiNotificationService;
+let DefaultNotificationService: typeof import('../default-notification.service').DefaultNotificationService;
+
+describe('getApiNotificationService', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    (AdapterRegistry as any).instance = null;
+    UserManagementConfiguration.reset();
+    ({ getApiNotificationService } = await import('../factory'));
+    ({ DefaultNotificationService } = await import('../default-notification.service'));
+  });
+
+  it('returns configured service if registered', () => {
+    const service = {} as any;
+    UserManagementConfiguration.configureServiceProviders({ notificationService: service });
+    expect(getApiNotificationService()).toBe(service);
+    expect(getApiNotificationService()).toBe(service);
+  });
+
+  it('creates default service with adapter when not configured', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('notification', adapter);
+    const service = getApiNotificationService();
+    expect(service).toBeInstanceOf(DefaultNotificationService);
+    expect(getApiNotificationService()).toBe(service);
+  });
+});

--- a/src/services/notification/factory.ts
+++ b/src/services/notification/factory.ts
@@ -10,6 +10,7 @@ import type { INotificationDataProvider } from '@/core/notification';
 import { DefaultNotificationService } from './default-notification.service';
 import { DefaultNotificationHandler } from './default-notification.handler';
 import { AdapterRegistry } from '@/adapters/registry';
+import { UserManagementConfiguration } from '@/core/config';
 
 // Singleton instance for API routes
 let notificationServiceInstance: NotificationService | null = null;
@@ -21,9 +22,15 @@ let notificationServiceInstance: NotificationService | null = null;
  */
 export function getApiNotificationService(): NotificationService {
   if (!notificationServiceInstance) {
-    const notificationDataProvider = AdapterRegistry.getInstance().getAdapter<INotificationDataProvider>('notification');
-    const handler = new DefaultNotificationHandler();
-    notificationServiceInstance = new DefaultNotificationService(notificationDataProvider, handler);
+    notificationServiceInstance =
+      UserManagementConfiguration.getServiceProvider('notificationService') as NotificationService | undefined;
+
+    if (!notificationServiceInstance) {
+      const notificationDataProvider =
+        AdapterRegistry.getInstance().getAdapter<INotificationDataProvider>('notification');
+      const handler = new DefaultNotificationHandler();
+      notificationServiceInstance = new DefaultNotificationService(notificationDataProvider, handler);
+    }
   }
 
   return notificationServiceInstance;

--- a/src/services/subscription/__tests__/factory.test.ts
+++ b/src/services/subscription/__tests__/factory.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AdapterRegistry } from '@/adapters/registry';
+import { UserManagementConfiguration } from '@/core/config';
+
+let getApiSubscriptionService: typeof import('../factory').getApiSubscriptionService;
+let DefaultSubscriptionService: typeof import('../default-subscription.service').DefaultSubscriptionService;
+
+describe('getApiSubscriptionService', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    (AdapterRegistry as any).instance = null;
+    UserManagementConfiguration.reset();
+    ({ getApiSubscriptionService } = await import('../factory'));
+    ({ DefaultSubscriptionService } = await import('../default-subscription.service'));
+  });
+
+  it('returns configured service if registered', () => {
+    const svc = {} as any;
+    UserManagementConfiguration.configureServiceProviders({ subscriptionService: svc });
+    expect(getApiSubscriptionService()).toBe(svc);
+    expect(getApiSubscriptionService()).toBe(svc);
+  });
+
+  it('creates default service with adapter when not configured', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('subscription', adapter);
+    const service = getApiSubscriptionService();
+    expect(service).toBeInstanceOf(DefaultSubscriptionService);
+    expect(getApiSubscriptionService()).toBe(service);
+  });
+});

--- a/src/services/subscription/factory.ts
+++ b/src/services/subscription/factory.ts
@@ -9,6 +9,7 @@ import { SubscriptionService } from '@/core/subscription/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
 import type { ISubscriptionDataProvider } from '@/core/subscription';
 import { AdapterRegistry } from '@/adapters/registry';
+import { DefaultSubscriptionService } from './default-subscription.service';
 
 // Singleton instance for API routes
 let subscriptionServiceInstance: SubscriptionService | null = null;
@@ -20,14 +21,14 @@ let subscriptionServiceInstance: SubscriptionService | null = null;
  */
 export function getApiSubscriptionService(): SubscriptionService {
   if (!subscriptionServiceInstance) {
-    AdapterRegistry.getInstance().getAdapter<ISubscriptionDataProvider>('subscription');
-    subscriptionServiceInstance = UserManagementConfiguration.getServiceProvider('subscriptionService') as SubscriptionService;
+    subscriptionServiceInstance =
+      UserManagementConfiguration.getServiceProvider('subscriptionService') as SubscriptionService | undefined;
 
-    // If no subscription service is registered, throw an error
     if (!subscriptionServiceInstance) {
-      throw new Error('Subscription service not registered in UserManagementConfiguration');
+      const provider = AdapterRegistry.getInstance().getAdapter<ISubscriptionDataProvider>('subscription');
+      subscriptionServiceInstance = new DefaultSubscriptionService(provider);
     }
   }
-  
+
   return subscriptionServiceInstance;
 }

--- a/src/services/webhooks/__tests__/factory.test.ts
+++ b/src/services/webhooks/__tests__/factory.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AdapterRegistry } from '@/adapters/registry';
+import { UserManagementConfiguration } from '@/core/config';
+
+let getApiWebhookService: typeof import('../factory').getApiWebhookService;
+let WebhookServiceClass: typeof import('../WebhookService').WebhookService;
+
+describe('getApiWebhookService', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    (AdapterRegistry as any).instance = null;
+    UserManagementConfiguration.reset();
+    ({ getApiWebhookService } = await import('../factory'));
+    ({ WebhookService: WebhookServiceClass } = await import('../WebhookService'));
+  });
+
+  it('returns configured service if registered', () => {
+    const svc = {} as any;
+    UserManagementConfiguration.configureServiceProviders({ webhookService: svc });
+    expect(getApiWebhookService()).toBe(svc);
+    expect(getApiWebhookService()).toBe(svc);
+  });
+
+  it('creates default service with adapter when not configured', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('webhook', adapter);
+    const service = getApiWebhookService();
+    expect(service).toBeInstanceOf(WebhookServiceClass);
+    expect(getApiWebhookService()).toBe(service);
+  });
+});

--- a/src/services/webhooks/factory.ts
+++ b/src/services/webhooks/factory.ts
@@ -9,6 +9,7 @@ import { IWebhookService } from '@/core/webhooks';
 import type { IWebhookDataProvider } from '@/core/webhooks';
 import { AdapterRegistry } from '@/adapters/registry';
 import { WebhookService } from './WebhookService';
+import { UserManagementConfiguration } from '@/core/config';
 
 // Singleton instance for API routes
 let webhookServiceInstance: IWebhookService | null = null;
@@ -20,10 +21,15 @@ let webhookServiceInstance: IWebhookService | null = null;
  */
 export function getApiWebhookService(): IWebhookService {
   if (!webhookServiceInstance) {
-    const webhookDataProvider = AdapterRegistry.getInstance().getAdapter<IWebhookDataProvider>('webhook');
-    webhookServiceInstance = new WebhookService(webhookDataProvider);
+    webhookServiceInstance =
+      UserManagementConfiguration.getServiceProvider('webhookService') as IWebhookService | undefined;
+
+    if (!webhookServiceInstance) {
+      const webhookDataProvider = AdapterRegistry.getInstance().getAdapter<IWebhookDataProvider>('webhook');
+      webhookServiceInstance = new WebhookService(webhookDataProvider);
+    }
   }
-  
+
   return webhookServiceInstance;
 }
 


### PR DESCRIPTION
## Summary
- refactor several service factories to retrieve configured service providers
- fallback to default service using adapter when provider not registered
- add comprehensive factory tests for address, api-keys, audit, csrf, gdpr, notification, subscription, and webhooks services

## Testing
- `npm run test:coverage` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands)*