### PR TITLE
Extend data provider interfaces

### DIFF
--- a/src/core/api-keys/IApiKeyDataProvider.ts
+++ b/src/core/api-keys/IApiKeyDataProvider.ts
@@ -8,12 +8,19 @@
 import type {
   ApiKey,
   ApiKeyCreatePayload,
-  ApiKeyCreateResult
+  ApiKeyCreateResult,
+  ApiKeyQuery,
+  ApiKeyListResult
 } from './models';
 
 export interface IApiKeyDataProvider {
-  /** List all API keys belonging to a user */
-  listApiKeys(userId: string): Promise<ApiKey[]>;
+  /**
+   * List API keys belonging to a user.
+   *
+   * @param userId Identifier of the owner
+   * @param query  Optional query and pagination options
+   */
+  listApiKeys(userId: string, query?: ApiKeyQuery): Promise<ApiKeyListResult>;
 
   /** Retrieve a single API key by id */
   getApiKey(userId: string, keyId: string): Promise<ApiKey | null>;
@@ -53,4 +60,17 @@ export interface IApiKeyDataProvider {
     userId: string,
     keyId: string
   ): Promise<{ success: boolean; key?: ApiKey; plaintext?: string; error?: string }>;
+
+  /**
+   * Update an existing API key.
+   *
+   * @param userId Owner of the key
+   * @param keyId  Identifier of the key to update
+   * @param update Partial data to update
+   */
+  updateApiKey(
+    userId: string,
+    keyId: string,
+    update: Partial<ApiKeyCreatePayload>
+  ): Promise<{ success: boolean; key?: ApiKey; error?: string }>;
 }

--- a/src/core/api-keys/models.ts
+++ b/src/core/api-keys/models.ts
@@ -32,3 +32,49 @@ export interface ApiKeyCreateResult {
   plaintext?: string;
   error?: string;
 }
+
+/**
+ * Parameters for querying API keys.
+ */
+export interface ApiKeyQuery {
+  /** Search by key name */
+  search?: string;
+
+  /** Filter by revoked state */
+  isRevoked?: boolean;
+
+  /** Filter by expiration date (ISO string) */
+  expiresBefore?: string;
+
+  /** Sort field */
+  sortBy?: 'name' | 'createdAt' | 'expiresAt';
+
+  /** Sort direction */
+  sortDirection?: 'asc' | 'desc';
+
+  /** Page number starting from 1 */
+  page?: number;
+
+  /** Items per page */
+  limit?: number;
+}
+
+/**
+ * Result of an API key list query.
+ */
+export interface ApiKeyListResult {
+  /** Array of API keys for the current page */
+  apiKeys: ApiKey[];
+
+  /** Total number of keys matching the query */
+  total: number;
+
+  /** Current page number */
+  page: number;
+
+  /** Items per page */
+  limit: number;
+
+  /** Total number of pages */
+  totalPages: number;
+}

--- a/src/core/notification/INotificationDataProvider.ts
+++ b/src/core/notification/INotificationDataProvider.ts
@@ -6,6 +6,7 @@
  * remains database agnostic.
  */
 import type {
+  Notification,
   NotificationPayload,
   NotificationPreferences,
   NotificationTemplate,
@@ -13,6 +14,8 @@ import type {
   NotificationBatch,
   NotificationFilter,
   NotificationDeliveryStatus,
+  NotificationTemplateQuery,
+  NotificationTemplateList,
   NotificationChannel
 } from './models';
 
@@ -58,6 +61,14 @@ export interface INotificationDataProvider {
   ): Promise<NotificationResult>;
 
   /**
+   * Retrieve a notification by its identifier.
+   *
+   * @param notificationId - Unique identifier of the notification
+   * @returns The notification or null if not found
+   */
+  getNotification(notificationId: string): Promise<Notification | null>;
+
+  /**
    * Cancel a previously scheduled notification.
    *
    * @param notificationId - ID of the scheduled notification
@@ -85,6 +96,26 @@ export interface INotificationDataProvider {
    * Delete a notification template.
    */
   deleteTemplate(templateId: string): Promise<{ success: boolean; error?: string }>;
+
+  /**
+   * List notification templates with optional filtering and pagination.
+   *
+   * @param query - Filtering and pagination options
+   * @returns Templates with paging information
+   */
+  listTemplates(
+    query?: NotificationTemplateQuery
+  ): Promise<NotificationTemplateList>;
+
+  /**
+   * Retrieve a notification template by id.
+   *
+   * @param templateId - Unique identifier of the template
+   * @returns The template or null if not found
+   */
+  getTemplate(
+    templateId: string
+  ): Promise<NotificationTemplate | null>;
 
   /**
    * Send a notification using a template and data replacements.

--- a/src/core/notification/models.ts
+++ b/src/core/notification/models.ts
@@ -665,3 +665,49 @@ export const notificationTemplateSchema = z.object({
 export type NotificationPayloadData = z.infer<typeof notificationPayloadSchema>;
 export type NotificationPreferencesData = z.infer<typeof notificationPreferencesSchema>;
 export type NotificationTemplateData = z.infer<typeof notificationTemplateSchema>;
+
+/**
+ * Parameters for listing notification templates.
+ */
+export interface NotificationTemplateQuery {
+  /** Free text search */
+  search?: string;
+
+  /** Filter by channel */
+  channel?: NotificationChannel;
+
+  /** Filter by category */
+  category?: NotificationCategory;
+
+  /** Sort field */
+  sortBy?: 'name' | 'createdAt' | 'updatedAt';
+
+  /** Sort direction */
+  sortDirection?: 'asc' | 'desc';
+
+  /** Page number starting from 1 */
+  page?: number;
+
+  /** Items per page */
+  limit?: number;
+}
+
+/**
+ * Result of a template list operation.
+ */
+export interface NotificationTemplateList {
+  /** Array of templates for the current page */
+  templates: NotificationTemplate[];
+
+  /** Total number of templates matching the query */
+  total: number;
+
+  /** Current page number */
+  page: number;
+
+  /** Items per page */
+  limit: number;
+
+  /** Total number of pages */
+  totalPages: number;
+}


### PR DESCRIPTION
## Summary
- extend API key provider interface with search and update methods
- add query and list result types for API keys
- extend notification provider interface to support template queries and lookups
- add query and list result types for notification templates

## Testing
- `npx tsc -p tsconfig.json` *(fails: TS errors in unrelated test files)*