### PR TITLE
Update data provider interfaces

### DIFF
--- a/src/core/address/IAddressDataProvider.ts
+++ b/src/core/address/IAddressDataProvider.ts
@@ -9,26 +9,65 @@ import type {
   AddressCreatePayload,
   AddressUpdatePayload,
   AddressResult,
+  AddressQuery,
 } from './models';
 
 export interface IAddressDataProvider {
-  /** Create an address for the given company */
+  /**
+   * Create a new address for the given company.
+   *
+   * @param companyId - Owning company id
+   * @param address - Data for the new address
+   * @returns Result object with the created address or error information
+   */
   createAddress(
     companyId: string,
     address: AddressCreatePayload,
   ): Promise<AddressResult>;
 
-  /** Retrieve all addresses for the company */
-  getAddresses(companyId: string): Promise<CompanyAddress[]>;
+  /**
+   * Retrieve a single company address by id.
+   *
+   * @param companyId - Owning company id
+   * @param addressId - Identifier of the address
+   * @returns The address or null if not found
+   */
+  getAddress(
+    companyId: string,
+    addressId: string,
+  ): Promise<CompanyAddress | null>;
 
-  /** Update a company address */
+  /**
+   * Retrieve addresses for a company using optional query filters.
+   *
+   * @param companyId - Owning company id
+   * @param query - Pagination, sorting and filtering options
+   * @returns A list of matching addresses and total count
+   */
+  getAddresses(
+    companyId: string,
+    query?: AddressQuery,
+  ): Promise<{ addresses: CompanyAddress[]; count: number }>;
+
+  /**
+   * Update an existing company address.
+   *
+   * @param companyId - Owning company id
+   * @param addressId - Identifier of the address to update
+   * @param update - Partial address fields to apply
+   */
   updateAddress(
     companyId: string,
     addressId: string,
     update: AddressUpdatePayload,
   ): Promise<AddressResult>;
 
-  /** Delete a company address */
+  /**
+   * Remove a company address permanently.
+   *
+   * @param companyId - Owning company id
+   * @param addressId - Identifier of the address to delete
+   */
   deleteAddress(
     companyId: string,
     addressId: string,

--- a/src/core/address/models.ts
+++ b/src/core/address/models.ts
@@ -48,6 +48,23 @@ export interface AddressResult {
   error?: string;
 }
 
+export interface AddressQuery {
+  /** Page number starting from 1 */
+  page?: number;
+  /** Number of items per page */
+  limit?: number;
+  /** Filter by address type */
+  type?: AddressType;
+  /** Only return addresses marked as primary */
+  is_primary?: boolean;
+  /** Filter by validation status */
+  validated?: boolean;
+  /** Field to sort by */
+  sortBy?: keyof CompanyAddress | string;
+  /** Sort order */
+  sortOrder?: 'asc' | 'desc';
+}
+
 export const addressCreateSchema = z.object({
   type: z.enum(['billing', 'shipping', 'legal']),
   street_line1: z.string().min(1).max(100),

--- a/src/core/audit/IAuditDataProvider.ts
+++ b/src/core/audit/IAuditDataProvider.ts
@@ -4,7 +4,13 @@
  * Defines the contract for persistence operations related to audit logs.
  * This allows the service layer to remain database-agnostic.
  */
-import type { AuditLogEntry, AuditLogQuery } from './models';
+import type {
+  AuditLogEntry,
+  AuditLogQuery,
+  AuditLogCreatePayload,
+  AuditLogUpdatePayload,
+  AuditLogResult,
+} from './models';
 
 export interface IAuditDataProvider {
   /**
@@ -13,7 +19,12 @@ export interface IAuditDataProvider {
    * @param entry - Log entry to store
    * @returns Result with success status and new log id or error
    */
-  createLog(entry: AuditLogEntry): Promise<{ success: boolean; id?: string; error?: string }>;
+  createLog(entry: AuditLogCreatePayload): Promise<AuditLogResult>;
+
+  /**
+   * Retrieve a single audit log entry by id.
+   */
+  getLog(id: string): Promise<AuditLogEntry | null>;
 
   /**
    * Retrieve audit log entries using the provided query parameters.
@@ -22,6 +33,16 @@ export interface IAuditDataProvider {
    * @returns List of logs and total count matching the query
    */
   getLogs(query: AuditLogQuery): Promise<{ logs: AuditLogEntry[]; count: number }>;
+
+  /**
+   * Update an existing audit log entry.
+   */
+  updateLog(id: string, updates: AuditLogUpdatePayload): Promise<AuditLogResult>;
+
+  /**
+   * Delete an audit log entry.
+   */
+  deleteLog(id: string): Promise<{ success: boolean; error?: string }>;
 
   /**
    * Export audit log entries that match the given query as a downloadable blob.

--- a/src/core/audit/models.ts
+++ b/src/core/audit/models.ts
@@ -13,6 +13,22 @@ export interface AuditLogEntry {
 
 export type AuditLogStatus = 'SUCCESS' | 'FAILURE' | 'INITIATED' | 'COMPLETED';
 
+export interface AuditLogCreatePayload
+  extends Omit<AuditLogEntry, 'id' | 'createdAt'> {
+  /** Optional creation timestamp */
+  createdAt?: string;
+}
+
+export type AuditLogUpdatePayload = Partial<
+  Omit<AuditLogEntry, 'id' | 'createdAt'>
+>;
+
+export interface AuditLogResult {
+  success: boolean;
+  log?: AuditLogEntry;
+  error?: string;
+}
+
 export interface AuditLogQuery {
   page: number;
   limit: number;


### PR DESCRIPTION
## Summary
- extend address data provider with query filtering and single retrieval
- define `AddressQuery` type
- extend audit data provider with CRUD operations
- add audit payload/result types

## Testing
- `npx vitest run --coverage src/core/address/__tests__/validation.test.ts`