### PR TITLE
Extend data provider interfaces

### DIFF
--- a/src/core/csrf/ICsrfDataProvider.ts
+++ b/src/core/csrf/ICsrfDataProvider.ts
@@ -5,15 +5,27 @@
  * This allows the adapter layer to implement any storage mechanism while
  * keeping the core logic database agnostic.
  */
-import type { CsrfToken } from './models';
+import type { PaginationMeta } from "@/lib/api/common/response-formatter";
+import type { CsrfToken, CsrfTokenQuery } from "./models";
 
 export interface ICsrfDataProvider {
+  /**
+   * Generate a raw CSRF token string without persisting it.
+   *
+   * @returns Newly generated token string
+   */
+  generateToken(): Promise<string>;
+
   /**
    * Create a new CSRF token.
    *
    * @returns Result object containing the token or an error message.
    */
-  createToken(): Promise<{ success: boolean; token?: CsrfToken; error?: string }>;
+  createToken(): Promise<{
+    success: boolean;
+    token?: CsrfToken;
+    error?: string;
+  }>;
 
   /**
    * Validate a CSRF token.
@@ -30,6 +42,47 @@ export interface ICsrfDataProvider {
    * @returns Result object with success status or error.
    */
   revokeToken(token: string): Promise<{ success: boolean; error?: string }>;
+
+  /**
+   * Retrieve a stored CSRF token by value.
+   *
+   * @param token - Token value to fetch
+   * @returns The token record or null if not found
+   */
+  getToken(token: string): Promise<CsrfToken | null>;
+
+  /**
+   * Query tokens using filtering and pagination options.
+   *
+   * @param query - Query parameters for filtering and pagination
+   * @returns Array of tokens with pagination metadata
+   */
+  listTokens(
+    query: CsrfTokenQuery,
+  ): Promise<{ tokens: CsrfToken[]; pagination: PaginationMeta }>;
+
+  /**
+   * Update an existing token record.
+   *
+   * @param token - Token value to update
+   * @param data - Partial token fields to update
+   * @returns Updated token or an error
+   */
+  updateToken(
+    token: string,
+    data: Partial<CsrfToken>,
+  ): Promise<{ success: boolean; token?: CsrfToken; error?: string }>;
+
+  /**
+   * Remove expired tokens from storage.
+   *
+   * @returns Number of tokens removed and success status
+   */
+  purgeExpiredTokens(): Promise<{
+    success: boolean;
+    count: number;
+    error?: string;
+  }>;
 }
 
 /**

--- a/src/core/csrf/models.ts
+++ b/src/core/csrf/models.ts
@@ -2,3 +2,29 @@ export interface CsrfToken {
   token: string;
   expiresAt?: Date;
 }
+
+/** Parameters for querying stored CSRF tokens */
+export interface CsrfTokenQuery {
+  /** Filter tokens belonging to a specific user */
+  userId?: string;
+  /** Filter by validity */
+  valid?: boolean;
+  /** Pagination: page number (1-based) */
+  page?: number;
+  /** Pagination: items per page */
+  limit?: number;
+  /** Sort field */
+  sortBy?: "token" | "expiresAt";
+  /** Sort direction */
+  sortOrder?: "asc" | "desc";
+}
+
+/** Type guard for CsrfToken objects */
+export function isCsrfToken(value: unknown): value is CsrfToken {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "token" in value &&
+    typeof (value as any).token === "string"
+  );
+}

--- a/src/core/gdpr/IGdprDataProvider.ts
+++ b/src/core/gdpr/IGdprDataProvider.ts
@@ -7,9 +7,26 @@
  * or other storage mechanism.
  */
 
-import type { UserDataExport, AccountDeletionResult } from './models';
+import type { PaginationMeta } from "@/lib/api/common/response-formatter";
+import type {
+  UserDataExport,
+  AccountDeletionResult,
+  DataExportQuery,
+  DeletionRequest,
+  DeletionRequestQuery,
+} from "./models";
 
 export interface IGdprDataProvider {
+  /**
+   * Initiate generation of a user data export.
+   *
+   * @param userId - Identifier of the user
+   * @returns Operation result with created export metadata or error
+   */
+  requestUserExport(
+    userId: string,
+  ): Promise<{ success: boolean; export?: UserDataExport; error?: string }>;
+
   /**
    * Generate a full export of the specified user's data.
    *
@@ -19,6 +36,24 @@ export interface IGdprDataProvider {
   generateUserExport(userId: string): Promise<UserDataExport | null>;
 
   /**
+   * Retrieve a previously generated export by identifier.
+   *
+   * @param exportId - Identifier of the export
+   * @returns Export data or null if not found
+   */
+  getUserExport(exportId: string): Promise<UserDataExport | null>;
+
+  /**
+   * Query user exports with pagination support.
+   *
+   * @param query - Filtering and pagination options
+   * @returns Array of exports with pagination metadata
+   */
+  listUserExports(
+    query: DataExportQuery,
+  ): Promise<{ exports: UserDataExport[]; pagination: PaginationMeta }>;
+
+  /**
    * Permanently remove all data associated with the user and schedule
    * account removal if applicable.
    *
@@ -26,4 +61,39 @@ export interface IGdprDataProvider {
    * @returns Result object indicating success or failure with messages
    */
   deleteUserData(userId: string): Promise<AccountDeletionResult>;
+
+  /**
+   * Create an account deletion request for the user.
+   *
+   * @param userId - Identifier of the user
+   * @returns Created deletion request or error information
+   */
+  requestAccountDeletion(
+    userId: string,
+  ): Promise<{ success: boolean; request?: DeletionRequest; error?: string }>;
+
+  /**
+   * Retrieve a deletion request by user id.
+   *
+   * @param userId - Identifier of the user
+   */
+  getDeletionRequest(userId: string): Promise<DeletionRequest | null>;
+
+  /**
+   * List deletion requests with pagination and sorting.
+   *
+   * @param query - Filtering and pagination options
+   */
+  listDeletionRequests(
+    query: DeletionRequestQuery,
+  ): Promise<{ requests: DeletionRequest[]; pagination: PaginationMeta }>;
+
+  /**
+   * Cancel a pending deletion request.
+   *
+   * @param requestId - Identifier of the request to cancel
+   */
+  cancelDeletionRequest(
+    requestId: string,
+  ): Promise<{ success: boolean; error?: string }>;
 }

--- a/src/core/gdpr/models.ts
+++ b/src/core/gdpr/models.ts
@@ -24,3 +24,59 @@ export interface AccountDeletionResult {
   /** Optional error message */
   error?: string;
 }
+
+/** Parameters for querying user data exports */
+export interface DataExportQuery {
+  /** Filter exports by user */
+  userId?: string;
+  /** Pagination: page number (1-based) */
+  page?: number;
+  /** Pagination: items per page */
+  limit?: number;
+  /** Sort field */
+  sortBy?: "createdAt" | "userId";
+  /** Sort direction */
+  sortOrder?: "asc" | "desc";
+}
+
+/** Deletion request record */
+export interface DeletionRequest {
+  /** Unique identifier of the request */
+  id: string;
+  /** ID of the user the request belongs to */
+  userId: string;
+  /** Current request status */
+  status: "pending" | "completed" | "failed";
+  /** Timestamp when the request was created */
+  requestedAt: string;
+  /** When the request was completed */
+  completedAt?: string;
+  /** Optional message or error */
+  message?: string;
+}
+
+/** Parameters for querying deletion requests */
+export interface DeletionRequestQuery {
+  /** Filter by user */
+  userId?: string;
+  /** Filter by request status */
+  status?: "pending" | "completed" | "failed";
+  /** Pagination: page number (1-based) */
+  page?: number;
+  /** Pagination: items per page */
+  limit?: number;
+  /** Sort field */
+  sortBy?: "requestedAt" | "status";
+  /** Sort direction */
+  sortOrder?: "asc" | "desc";
+}
+
+/** Type guard for DeletionRequest */
+export function isDeletionRequest(value: unknown): value is DeletionRequest {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "id" in value &&
+    typeof (value as any).id === "string"
+  );
+}


### PR DESCRIPTION
## Summary
- extend CSRF data provider interface with full CRUD
- add filtering and pagination support for CSRF tokens
- expand GDPR data provider with export/deletion request operations
- add query models and type guards for new data types

## Testing
- `npx prettier -w src/core/csrf/ICsrfDataProvider.ts src/core/csrf/models.ts src/core/gdpr/IGdprDataProvider.ts src/core/gdpr/models.ts`