### PR TITLE
Implement new Supabase provider methods

### DIFF
--- a/app/api/subscription/route.ts
+++ b/app/api/subscription/route.ts
@@ -1,6 +1,6 @@
 import { stripe, createCustomer, createSubscription } from '@/lib/payments/stripe';
 import { getServiceSupabase } from '@/lib/database/supabase';
-import { SupabaseSubscriptionAdapter } from '@/adapters/subscription/supabase-adapter';
+import { SupabaseSubscriptionProvider } from '@/adapters/subscription/supabase/supabase-subscription.provider';
 import { z } from 'zod';
 import { NextResponse } from 'next/server';
 
@@ -9,7 +9,7 @@ const SubscriptionSchema = z.object({ plan: z.string() });
 export async function GET(request: Request) {
   // Assume auth header is present and valid
   const supabase = getServiceSupabase();
-  const provider = new SupabaseSubscriptionAdapter(
+  const provider = new SupabaseSubscriptionProvider(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!
   );
@@ -41,7 +41,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   const supabase = getServiceSupabase();
-  const provider = new SupabaseSubscriptionAdapter(
+  const provider = new SupabaseSubscriptionProvider(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!
   );

--- a/src/adapters/subscription/__tests__/supabase-adapter.test.ts
+++ b/src/adapters/subscription/__tests__/supabase-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { SupabaseSubscriptionAdapter } from '../supabase-adapter';
+import { SupabaseSubscriptionProvider } from '../supabase/supabase-subscription.provider';
 import { setTableMockData, resetSupabaseMock } from '@/tests/mocks/supabase';
 
 const SUPABASE_URL = 'http://localhost';
@@ -15,7 +15,7 @@ const subRecord = {
 
 const planRecord = { id: 'plan-1', name: 'Pro', tier: 'premium', price: 10, period: 'monthly', features: [], is_public: true, trial_days: 0 };
 
-describe('SupabaseSubscriptionAdapter', () => {
+describe('SupabaseSubscriptionProvider', () => {
   beforeEach(() => {
     resetSupabaseMock();
     setTableMockData('subscriptions', { data: [subRecord], error: null });
@@ -23,14 +23,14 @@ describe('SupabaseSubscriptionAdapter', () => {
   });
 
   it('retrieves a user subscription', async () => {
-    const provider = new SupabaseSubscriptionAdapter(SUPABASE_URL, SUPABASE_KEY);
+    const provider = new SupabaseSubscriptionProvider(SUPABASE_URL, SUPABASE_KEY);
     const result = await provider.getUserSubscription('user-1');
     expect(result?.id).toBe('sub-1');
     expect(result?.planId).toBe('plan-1');
   });
 
   it('lists plans', async () => {
-    const provider = new SupabaseSubscriptionAdapter(SUPABASE_URL, SUPABASE_KEY);
+    const provider = new SupabaseSubscriptionProvider(SUPABASE_URL, SUPABASE_KEY);
     const plans = await provider.getPlans();
     expect(plans[0]?.id).toBe('plan-1');
   });

--- a/src/adapters/subscription/factory.ts
+++ b/src/adapters/subscription/factory.ts
@@ -1,8 +1,8 @@
 import type { ISubscriptionDataProvider } from '@/core/subscription/ISubscriptionDataProvider';
-import { SupabaseSubscriptionAdapter } from './supabase-adapter';
+import { SupabaseSubscriptionProvider } from './supabase/supabase-subscription.provider';
 
 export function createSupabaseSubscriptionProvider(options: { supabaseUrl: string; supabaseKey: string }): ISubscriptionDataProvider {
-  return new SupabaseSubscriptionAdapter(options.supabaseUrl, options.supabaseKey);
+  return new SupabaseSubscriptionProvider(options.supabaseUrl, options.supabaseKey);
 }
 
 export function createSubscriptionProvider(config: { type: 'supabase' | string; options: Record<string, any> }): ISubscriptionDataProvider {

--- a/src/adapters/subscription/index.ts
+++ b/src/adapters/subscription/index.ts
@@ -1,3 +1,3 @@
 export * from '@/core/subscription/ISubscriptionDataProvider';
 export * from './factory';
-export * from './supabase-adapter';
+export * from './supabase/supabase-subscription.provider';

--- a/src/adapters/subscription/supabase/supabase-subscription.provider.ts
+++ b/src/adapters/subscription/supabase/supabase-subscription.provider.ts
@@ -1,0 +1,191 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { ISubscriptionDataProvider } from '@/core/subscription/ISubscriptionDataProvider';
+import type {
+  SubscriptionPlan,
+  UserSubscription,
+  SubscriptionUpsertPayload,
+  SubscriptionQuery
+} from '@/core/subscription/models';
+
+/**
+ * Supabase implementation of {@link ISubscriptionDataProvider}.
+ * Handles persistence of subscription plans and user subscriptions.
+ */
+export class SupabaseSubscriptionProvider implements ISubscriptionDataProvider {
+  private supabase: SupabaseClient;
+
+  constructor(private supabaseUrl: string, private supabaseKey: string) {
+    this.supabase = createClient(this.supabaseUrl, this.supabaseKey);
+  }
+
+  /** @inheritdoc */
+  async getPlans(): Promise<SubscriptionPlan[]> {
+    const { data, error } = await this.supabase
+      .from('subscription_plans')
+      .select('*')
+      .eq('is_active', true);
+
+    if (error || !data) return [];
+    return data.map((p: any) => this.mapPlan(p));
+  }
+
+  /** @inheritdoc */
+  async getUserSubscription(userId: string): Promise<UserSubscription | null> {
+    const { data, error } = await this.supabase
+      .from('subscriptions')
+      .select('*')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error || !data) return null;
+    return this.mapSubscription(data);
+  }
+
+  /** @inheritdoc */
+  async upsertSubscription(sub: SubscriptionUpsertPayload): Promise<UserSubscription> {
+    const { data, error } = await this.supabase
+      .from('subscriptions')
+      .upsert({
+        id: sub.id,
+        user_id: sub.userId,
+        plan_id: sub.planId,
+        status: sub.status,
+        start_date: sub.startDate,
+        end_date: sub.endDate,
+        renewal_date: sub.renewalDate,
+        canceled_at: sub.canceledAt,
+        payment_method: sub.paymentMethod,
+        metadata: sub.metadata,
+        updated_at: new Date().toISOString()
+      })
+      .select('*')
+      .single();
+
+    if (error || !data) {
+      throw new Error(error?.message || 'Failed to upsert subscription');
+    }
+    return this.mapSubscription(data);
+  }
+
+  /** @inheritdoc */
+  async createSubscription(
+    userId: string,
+    planId: string
+  ): Promise<{ success: boolean; subscription?: UserSubscription; error?: string }> {
+    try {
+      const subscription = await this.upsertSubscription({
+        userId,
+        planId,
+        status: 'active' as any,
+        startDate: new Date().toISOString()
+      });
+      return { success: true, subscription };
+    } catch (err: any) {
+      return { success: false, error: err.message };
+    }
+  }
+
+  /** @inheritdoc */
+  async updateSubscription(
+    subscriptionId: string,
+    planId: string
+  ): Promise<{ success: boolean; subscription?: UserSubscription; error?: string }> {
+    const { data, error } = await this.supabase
+      .from('subscriptions')
+      .update({ plan_id: planId, updated_at: new Date().toISOString() })
+      .eq('id', subscriptionId)
+      .select('*')
+      .maybeSingle();
+
+    if (error || !data) {
+      return { success: false, error: error?.message };
+    }
+    return { success: true, subscription: this.mapSubscription(data) };
+  }
+
+  /** @inheritdoc */
+  async cancelSubscription(
+    subscriptionId: string,
+    immediate?: boolean
+  ): Promise<{ success: boolean; error?: string }> {
+    const updates: Record<string, any> = {
+      status: 'canceled',
+      canceled_at: new Date().toISOString(),
+      updated_at: new Date().toISOString()
+    };
+    if (immediate) {
+      updates.end_date = new Date().toISOString();
+    }
+
+    const { error } = await this.supabase
+      .from('subscriptions')
+      .update(updates)
+      .eq('id', subscriptionId);
+
+    if (error) {
+      return { success: false, error: error.message };
+    }
+    return { success: true };
+  }
+
+  /** @inheritdoc */
+  async listSubscriptions(query: SubscriptionQuery): Promise<{
+    subscriptions: UserSubscription[];
+    count: number;
+  }> {
+    let req = this.supabase.from('subscriptions').select('*', { count: 'exact' });
+    if (query.userId) req = req.eq('user_id', query.userId);
+    if (query.planId) req = req.eq('plan_id', query.planId);
+    if (query.status) req = req.eq('status', query.status);
+    if (query.sortBy)
+      req = req.order(query.sortBy as string, { ascending: query.sortOrder !== 'desc' });
+
+    if (query.limit && query.page) {
+      const from = (query.page - 1) * query.limit;
+      const to = from + query.limit - 1;
+      req = req.range(from, to);
+    } else if (query.limit) {
+      req = req.limit(query.limit);
+    }
+
+    const { data, error, count } = await req;
+    if (error || !data) {
+      return { subscriptions: [], count: 0 };
+    }
+    return { subscriptions: data.map((s: any) => this.mapSubscription(s)), count: count ?? data.length };
+  }
+
+  /** Convert raw plan record to domain model */
+  private mapPlan(p: any): SubscriptionPlan {
+    return {
+      id: p.id,
+      name: p.name,
+      tier: p.tier,
+      price: p.price,
+      period: p.period,
+      features: p.features || [],
+      isPublic: p.is_public ?? true,
+      trialDays: p.trial_days ?? 0,
+      metadata: p.metadata || {}
+    } as SubscriptionPlan;
+  }
+
+  /** Convert raw subscription record to domain model */
+  private mapSubscription(s: any): UserSubscription {
+    return {
+      id: s.id,
+      userId: s.user_id,
+      planId: s.plan_id,
+      status: s.status,
+      startDate: s.start_date,
+      endDate: s.end_date,
+      renewalDate: s.renewal_date,
+      canceledAt: s.canceled_at,
+      paymentMethod: s.payment_method,
+      paymentProviderData: s.payment_provider_data,
+      metadata: s.metadata
+    } as UserSubscription;
+  }
+}
+
+export default SupabaseSubscriptionProvider;

--- a/src/adapters/webhook/__tests__/supabase-webhook-provider.test.ts
+++ b/src/adapters/webhook/__tests__/supabase-webhook-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { SupabaseWebhookProvider } from '../SupabaseWebhookProvider';
+import { SupabaseWebhookProvider } from '../supabase/supabase-webhook.provider';
 import { setTableMockData, resetSupabaseMock } from '@/tests/mocks/supabase';
 
 const SUPABASE_URL = 'http://localhost';

--- a/src/adapters/webhook/index.ts
+++ b/src/adapters/webhook/index.ts
@@ -1,8 +1,8 @@
 export * from '@/core/webhooks/IWebhookDataProvider';
-export * from './SupabaseWebhookProvider';
+export * from './supabase/supabase-webhook.provider';
 
 import { IWebhookDataProvider } from '@/core/webhooks/IWebhookDataProvider';
-import { SupabaseWebhookProvider } from './SupabaseWebhookProvider';
+import { SupabaseWebhookProvider } from './supabase/supabase-webhook.provider';
 
 export function createSupabaseWebhookProvider(options: {
   supabaseUrl: string;

--- a/src/adapters/webhook/supabase/supabase-webhook.provider.ts
+++ b/src/adapters/webhook/supabase/supabase-webhook.provider.ts
@@ -1,0 +1,224 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import type { IWebhookDataProvider } from '@/core/webhooks/IWebhookDataProvider';
+import type {
+  Webhook,
+  WebhookCreatePayload,
+  WebhookUpdatePayload,
+  WebhookDelivery,
+  WebhookListQuery,
+  WebhookDeliveryQuery
+} from '@/core/webhooks/models';
+import type { PaginationMeta } from '@/lib/api/common/response-formatter';
+
+/**
+ * Supabase implementation of the {@link IWebhookDataProvider} interface.
+ *
+ * Provides CRUD operations for webhook records and delivery logs using
+ * Supabase as the persistence layer.
+ */
+export class SupabaseWebhookProvider implements IWebhookDataProvider {
+  private supabase: SupabaseClient;
+
+  /**
+   * Create a new provider instance.
+   *
+   * @param supabaseUrl   Supabase project URL
+   * @param supabaseKey   Supabase service role key
+   */
+  constructor(supabaseUrl: string, supabaseKey: string) {
+    this.supabase = createClient(supabaseUrl, supabaseKey);
+  }
+
+  /** @inheritdoc */
+  async listWebhooks(userId: string): Promise<Webhook[]> {
+    const { data, error } = await this.supabase
+      .from('webhooks')
+      .select('*')
+      .eq('user_id', userId);
+
+    if (error || !data) return [];
+    return data.map(r => this.mapRecord(r));
+  }
+
+  /** @inheritdoc */
+  async searchWebhooks(
+    userId: string,
+    query: WebhookListQuery
+  ): Promise<{ webhooks: Webhook[]; pagination: PaginationMeta }> {
+    let req = this.supabase
+      .from('webhooks')
+      .select('*', { count: 'exact' })
+      .eq('user_id', userId);
+
+    if (typeof query.isActive === 'boolean') req = req.eq('is_active', query.isActive);
+    if (query.event) req = req.contains('events', [query.event]);
+    if (query.sortBy)
+      req = req.order(query.sortBy as string, { ascending: query.sortOrder !== 'desc' });
+
+    if (query.limit && query.page) {
+      const from = (query.page - 1) * query.limit;
+      const to = from + query.limit - 1;
+      req = req.range(from, to);
+    } else if (query.limit) {
+      req = req.limit(query.limit);
+    }
+
+    const { data, error, count } = await req;
+    const items = data ? data.map(r => this.mapRecord(r)) : [];
+    return {
+      webhooks: items,
+      pagination: {
+        page: query.page ?? 1,
+        pageSize: query.limit ?? items.length,
+        totalItems: count ?? items.length,
+        totalPages: query.limit ? Math.ceil((count ?? items.length) / query.limit) : 1,
+        hasNextPage: query.limit ? (query.page ?? 1) * query.limit < (count ?? items.length) : false,
+        hasPreviousPage: query.limit ? (query.page ?? 1) > 1 : false
+      }
+    };
+  }
+
+  /** @inheritdoc */
+  async getWebhook(userId: string, id: string): Promise<Webhook | null> {
+    const { data, error } = await this.supabase
+      .from('webhooks')
+      .select('*')
+      .eq('id', id)
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error || !data) return null;
+    return this.mapRecord(data);
+  }
+
+  /** @inheritdoc */
+  async createWebhook(
+    userId: string,
+    payload: WebhookCreatePayload
+  ): Promise<{ success: boolean; webhook?: Webhook; error?: string }> {
+    const { data, error } = await this.supabase
+      .from('webhooks')
+      .insert({
+        user_id: userId,
+        name: payload.name,
+        url: payload.url,
+        events: payload.events,
+        secret: '',
+        is_active: payload.isActive ?? true,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString()
+      })
+      .select('*')
+      .single();
+
+    if (error || !data) {
+      return { success: false, error: error?.message || 'Failed to create webhook' };
+    }
+    return { success: true, webhook: this.mapRecord(data) };
+  }
+
+  /** @inheritdoc */
+  async updateWebhook(
+    userId: string,
+    id: string,
+    payload: WebhookUpdatePayload
+  ): Promise<{ success: boolean; webhook?: Webhook; error?: string }> {
+    const { data, error } = await this.supabase
+      .from('webhooks')
+      .update({
+        name: payload.name,
+        url: payload.url,
+        events: payload.events,
+        is_active: payload.isActive,
+        updated_at: new Date().toISOString()
+      })
+      .eq('id', id)
+      .eq('user_id', userId)
+      .select('*')
+      .maybeSingle();
+
+    if (error || !data) return { success: false, error: error?.message };
+    return { success: true, webhook: this.mapRecord(data) };
+  }
+
+  /** @inheritdoc */
+  async deleteWebhook(
+    userId: string,
+    id: string
+  ): Promise<{ success: boolean; error?: string }> {
+    const { error } = await this.supabase
+      .from('webhooks')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', userId);
+
+    if (error) {
+      return { success: false, error: error.message };
+    }
+    return { success: true };
+  }
+
+  /** @inheritdoc */
+  async listDeliveries(
+    userId: string,
+    webhookId: string,
+    query: number | WebhookDeliveryQuery = 10
+  ): Promise<{ deliveries: WebhookDelivery[]; pagination?: PaginationMeta }> {
+    const limit = typeof query === 'number' ? query : query.limit ?? 10;
+    const { data } = await this.supabase
+      .from('webhook_deliveries')
+      .select('*')
+      .eq('webhook_id', webhookId)
+      .eq('user_id', userId)
+      .order('created_at', {
+        ascending: typeof query === 'object' ? query.sortOrder === 'asc' : false
+      })
+      .limit(limit);
+
+    const deliveries = (data || []) as WebhookDelivery[];
+    return {
+      deliveries,
+      pagination:
+        typeof query === 'object'
+          ? {
+              page: query.page ?? 1,
+              pageSize: limit,
+              totalItems: deliveries.length,
+              totalPages: 1,
+              hasNextPage: false,
+              hasPreviousPage: false
+            }
+          : undefined
+    };
+  }
+
+  /** @inheritdoc */
+  async recordDelivery(delivery: WebhookDelivery): Promise<void> {
+    await this.supabase.from('webhook_deliveries').insert({
+      id: delivery.id,
+      webhook_id: delivery.webhookId,
+      event_type: delivery.eventType,
+      payload: delivery.payload,
+      status_code: delivery.statusCode,
+      response: delivery.response,
+      error: delivery.error,
+      created_at: delivery.createdAt
+    });
+  }
+
+  /** Map database record to domain model */
+  private mapRecord(record: any): Webhook {
+    return {
+      id: record.id,
+      userId: record.user_id,
+      url: record.url,
+      events: record.events,
+      secret: record.secret,
+      isActive: record.is_active,
+      createdAt: record.created_at,
+      updatedAt: record.updated_at
+    };
+  }
+}
+
+export default SupabaseWebhookProvider;

--- a/src/adapters/webhooks/index.ts
+++ b/src/adapters/webhooks/index.ts
@@ -1,4 +1,4 @@
-import { SupabaseWebhookProvider } from './SupabaseWebhookProvider';
+import { SupabaseWebhookProvider } from './supabase/supabase-webhook.provider';
 import type { IWebhookDataProvider } from './IWebhookDataProvider';
 
 export function createSupabaseWebhookProvider(options: {


### PR DESCRIPTION
## Summary
- add comprehensive Supabase webhook provider implementation
- add Supabase subscription provider implementation
- update factories, indexes and API route to use new providers
- update unit tests to use new provider classes

## Testing
- `vitest run --coverage` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*