### PR TITLE
Add service-based API handlers

### DIFF
--- a/src/lib/api-utils/api-handler.ts
+++ b/src/lib/api-utils/api-handler.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { ApiError } from '@/lib/errors';
+import { ApiError } from '@/lib/api/common';
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 

--- a/src/pages/api/auth/[...auth].ts
+++ b/src/pages/api/auth/[...auth].ts
@@ -1,0 +1,63 @@
+import { createApiHandler } from '@/lib/api-utils/api-handler';
+import { getApiAuthService } from '@/services/auth/factory';
+import { ApiError } from '@/lib/api/common';
+import { z } from 'zod';
+
+/**
+ * Zod schema for login
+ */
+const LoginSchema = z.object({
+  email: z.string().email('Invalid email'),
+  password: z.string().min(1, 'Password required'),
+  rememberMe: z.boolean().optional()
+});
+
+/**
+ * POST /api/auth/login
+ * Delegates login logic to AuthService
+ */
+const loginHandler = createApiHandler({
+  methods: ['POST'],
+  async handler(req, res) {
+    const parse = LoginSchema.safeParse(req.body);
+    if (!parse.success) {
+      throw new ApiError(400, 'Invalid credentials input', { details: parse.error.flatten() });
+    }
+    const authService = getApiAuthService();
+    const result = await authService.login({
+      email: parse.data.email,
+      password: parse.data.password,
+      rememberMe: parse.data.rememberMe ?? false
+    });
+    if (!result.success || !result.user) {
+      throw new ApiError(401, result.error || 'Authentication failed');
+    }
+    return { user: result.user, token: result.token, expiresAt: result.expiresAt };
+  }
+});
+
+/**
+ * POST /api/auth/logout
+ * Requires authentication
+ */
+const logoutHandler = createApiHandler({
+  methods: ['POST'],
+  requiresAuth: true,
+  async handler() {
+    const authService = getApiAuthService();
+    await authService.logout();
+    return { success: true };
+  }
+});
+
+export default function handler(req: any, res: any) {
+  const [action] = (req.query.auth as string[]) || [];
+  switch (action) {
+    case 'login':
+      return loginHandler(req, res);
+    case 'logout':
+      return logoutHandler(req, res);
+    default:
+      return res.status(404).json({ error: 'Not Found' });
+  }
+}

--- a/src/pages/api/auth/__tests__/auth.test.ts
+++ b/src/pages/api/auth/__tests__/auth.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import handler from '../[...auth]';
+import { getApiAuthService } from '@/services/auth/factory';
+import { testPost } from '@/tests/utils/api-testing-utils';
+
+vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
+
+describe('POST /api/auth/login', () => {
+  const mockService = { login: vi.fn(), logout: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockService);
+    mockService.login.mockResolvedValue({ success: true, user: { id: '1' }, token: 't', expiresAt: 'x' });
+  });
+
+  it('returns 200 on success', async () => {
+    const { status, data } = await testPost(handler, { email: 'a@b.com', password: 'p' }, { query: { auth: ['login'] } });
+    expect(status).toBe(200);
+    expect(data.data.user.id).toBe('1');
+  });
+
+  it('validates body', async () => {
+    const { status } = await testPost(handler, { email: 'bad' }, { query: { auth: ['login'] } });
+    expect(status).toBe(400);
+  });
+});

--- a/src/pages/api/notification/[...notification].ts
+++ b/src/pages/api/notification/[...notification].ts
@@ -1,0 +1,33 @@
+import { createApiHandler } from '@/lib/api-utils/api-handler';
+import { getApiNotificationService } from '@/services/notification/factory';
+import { ApiError } from '@/lib/api/common';
+import { z } from 'zod';
+
+const listSchema = z.object({ userId: z.string().uuid() });
+
+/**
+ * GET /api/notification/list
+ */
+const listNotificationsHandler = createApiHandler({
+  methods: ['GET'],
+  requiresAuth: true,
+  async handler(req) {
+    const parse = listSchema.safeParse(req.query);
+    if (!parse.success) {
+      throw new ApiError(400, 'Invalid parameters');
+    }
+    const service = getApiNotificationService();
+    const batch = await service.getUserNotifications(parse.data.userId);
+    return batch;
+  }
+});
+
+export default function handler(req: any, res: any) {
+  const [action] = (req.query.notification as string[]) || [];
+  switch (action) {
+    case 'list':
+      return listNotificationsHandler(req, res);
+    default:
+      return res.status(404).json({ error: 'Not Found' });
+  }
+}

--- a/src/pages/api/notification/__tests__/notification.test.ts
+++ b/src/pages/api/notification/__tests__/notification.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import handler from '../[...notification]';
+import { getApiNotificationService } from '@/services/notification/factory';
+import { testGet } from '@/tests/utils/api-testing-utils';
+
+vi.mock('@/services/notification/factory', () => ({ getApiNotificationService: vi.fn() }));
+
+describe('GET /api/notification/list', () => {
+  const mockService = { getUserNotifications: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiNotificationService as unknown as vi.Mock).mockReturnValue(mockService);
+    mockService.getUserNotifications.mockResolvedValue([]);
+  });
+
+  it('returns notifications', async () => {
+    const { status } = await testGet(handler, { query: { notification: ['list'], userId: '123e4567-e89b-12d3-a456-426614174000' } });
+    expect(status).toBe(200);
+  });
+
+  it('invalid params', async () => {
+    const { status } = await testGet(handler, { query: { notification: ['list'] } });
+    expect(status).toBe(400);
+  });
+});

--- a/src/pages/api/permission/[...permission].ts
+++ b/src/pages/api/permission/[...permission].ts
@@ -1,0 +1,36 @@
+import { createApiHandler } from '@/lib/api-utils/api-handler';
+import { getApiPermissionService } from '@/services/permission/factory';
+import { ApiError } from '@/lib/api/common';
+import { z } from 'zod';
+
+const checkSchema = z.object({
+  userId: z.string().uuid(),
+  permission: z.string().min(1)
+});
+
+/**
+ * GET /api/permission/check
+ */
+const checkHandler = createApiHandler({
+  methods: ['GET'],
+  requiresAuth: true,
+  async handler(req) {
+    const parse = checkSchema.safeParse(req.query);
+    if (!parse.success) {
+      throw new ApiError(400, 'Invalid parameters');
+    }
+    const service = getApiPermissionService();
+    const has = await service.hasPermission(parse.data.userId, parse.data.permission as any);
+    return { hasPermission: has };
+  }
+});
+
+export default function handler(req: any, res: any) {
+  const [action] = (req.query.permission as string[]) || [];
+  switch (action) {
+    case 'check':
+      return checkHandler(req, res);
+    default:
+      return res.status(404).json({ error: 'Not Found' });
+  }
+}

--- a/src/pages/api/permission/__tests__/permission.test.ts
+++ b/src/pages/api/permission/__tests__/permission.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import handler from '../[...permission]';
+import { getApiPermissionService } from '@/services/permission/factory';
+import { testGet } from '@/tests/utils/api-testing-utils';
+
+vi.mock('@/services/permission/factory', () => ({ getApiPermissionService: vi.fn() }));
+
+describe('GET /api/permission/check', () => {
+  const mockService = { hasPermission: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiPermissionService as unknown as vi.Mock).mockReturnValue(mockService);
+    mockService.hasPermission.mockResolvedValue(true);
+  });
+
+  it('returns result', async () => {
+    const { status } = await testGet(handler, {
+      query: {
+        permission: ['check', 'READ'],
+        userId: '123e4567-e89b-12d3-a456-426614174000'
+      }
+    });
+    expect(status).toBe(200);
+  });
+
+  it('invalid params', async () => {
+    const { status } = await testGet(handler, { query: { permission: ['check'] } });
+    expect(status).toBe(400);
+  });
+});

--- a/src/pages/api/session/[...session].ts
+++ b/src/pages/api/session/[...session].ts
@@ -1,0 +1,33 @@
+import { createApiHandler } from '@/lib/api-utils/api-handler';
+import { getApiSessionService } from '@/services/session/factory';
+import { ApiError } from '@/lib/api/common';
+import { z } from 'zod';
+
+const listSchema = z.object({ userId: z.string().uuid() });
+
+/**
+ * GET /api/session/list
+ */
+const listHandler = createApiHandler({
+  methods: ['GET'],
+  requiresAuth: true,
+  async handler(req) {
+    const parse = listSchema.safeParse(req.query);
+    if (!parse.success) {
+      throw new ApiError(400, 'Invalid parameters');
+    }
+    const service = getApiSessionService();
+    const sessions = await service.listUserSessions(parse.data.userId);
+    return { sessions };
+  }
+});
+
+export default function handler(req: any, res: any) {
+  const [action] = (req.query.session as string[]) || [];
+  switch (action) {
+    case 'list':
+      return listHandler(req, res);
+    default:
+      return res.status(404).json({ error: 'Not Found' });
+  }
+}

--- a/src/pages/api/session/__tests__/session.test.ts
+++ b/src/pages/api/session/__tests__/session.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import handler from '../[...session]';
+import { getApiSessionService } from '@/services/session/factory';
+import { testGet } from '@/tests/utils/api-testing-utils';
+
+vi.mock('@/services/session/factory', () => ({ getApiSessionService: vi.fn() }));
+
+describe('GET /api/session/list', () => {
+  const mockService = { listUserSessions: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiSessionService as unknown as vi.Mock).mockReturnValue(mockService);
+    mockService.listUserSessions.mockResolvedValue([]);
+  });
+
+  it('returns sessions', async () => {
+    const { status } = await testGet(handler, { query: { session: ['list'], userId: '123e4567-e89b-12d3-a456-426614174000' } });
+    expect(status).toBe(200);
+  });
+
+  it('invalid params', async () => {
+    const { status } = await testGet(handler, { query: { session: ['list'] } });
+    expect(status).toBe(400);
+  });
+});

--- a/src/pages/api/sso/[...sso].ts
+++ b/src/pages/api/sso/[...sso].ts
@@ -1,0 +1,33 @@
+import { createApiHandler } from '@/lib/api-utils/api-handler';
+import { getApiSsoService } from '@/services/sso/factory';
+import { ApiError } from '@/lib/api/common';
+import { z } from 'zod';
+
+const providerSchema = z.object({ organizationId: z.string().uuid() });
+
+/**
+ * GET /api/sso/providers
+ */
+const providersHandler = createApiHandler({
+  methods: ['GET'],
+  requiresAuth: true,
+  async handler(req) {
+    const parse = providerSchema.safeParse(req.query);
+    if (!parse.success) {
+      throw new ApiError(400, 'organizationId required');
+    }
+    const service = getApiSsoService();
+    const providers = await service.getProviders(parse.data.organizationId);
+    return { providers };
+  }
+});
+
+export default function handler(req: any, res: any) {
+  const [action] = (req.query.sso as string[]) || [];
+  switch (action) {
+    case 'providers':
+      return providersHandler(req, res);
+    default:
+      return res.status(404).json({ error: 'Not Found' });
+  }
+}

--- a/src/pages/api/sso/__tests__/sso.test.ts
+++ b/src/pages/api/sso/__tests__/sso.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import handler from '../[...sso]';
+import { getApiSsoService } from '@/services/sso/factory';
+import { testGet } from '@/tests/utils/api-testing-utils';
+
+vi.mock('@/services/sso/factory', () => ({ getApiSsoService: vi.fn() }));
+
+describe('GET /api/sso/providers', () => {
+  const mockService = { getProviders: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiSsoService as unknown as vi.Mock).mockReturnValue(mockService);
+    mockService.getProviders.mockResolvedValue([]);
+  });
+
+  it('returns providers', async () => {
+    const { status } = await testGet(handler, { query: { sso: ['providers'], organizationId: '123e4567-e89b-12d3-a456-426614174000' } });
+    expect(status).toBe(200);
+  });
+
+  it('invalid params', async () => {
+    const { status } = await testGet(handler, { query: { sso: ['providers'] } });
+    expect(status).toBe(400);
+  });
+});

--- a/src/pages/api/team/[...team].ts
+++ b/src/pages/api/team/[...team].ts
@@ -1,0 +1,29 @@
+import { createApiHandler } from '@/lib/api-utils/api-handler';
+import { getApiTeamService } from '@/services/team/factory';
+import { ApiError } from '@/lib/api/common';
+import { z } from 'zod';
+
+const idSchema = z.string().uuid('Invalid team id');
+
+/**
+ * GET /api/team/[id]
+ */
+const getTeamHandler = createApiHandler({
+  methods: ['GET'],
+  requiresAuth: true,
+  async handler(req) {
+    const [id] = (req.query.team as string[]) || [];
+    const parse = idSchema.safeParse(id);
+    if (!parse.success) {
+      throw new ApiError(400, 'Invalid team id');
+    }
+    const teamService = getApiTeamService();
+    const team = await teamService.getTeam(parse.data);
+    if (!team) throw new ApiError(404, 'Team not found');
+    return team;
+  }
+});
+
+export default function handler(req: any, res: any) {
+  return getTeamHandler(req, res);
+}

--- a/src/pages/api/team/__tests__/team.test.ts
+++ b/src/pages/api/team/__tests__/team.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import handler from '../[...team]';
+import { getApiTeamService } from '@/services/team/factory';
+import { testGet } from '@/tests/utils/api-testing-utils';
+
+vi.mock('@/services/team/factory', () => ({ getApiTeamService: vi.fn() }));
+
+describe('GET /api/team/[id]', () => {
+  const mockService = { getTeam: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiTeamService as unknown as vi.Mock).mockReturnValue(mockService);
+    mockService.getTeam.mockResolvedValue({ id: 't' });
+  });
+
+  it('returns team', async () => {
+    const { status } = await testGet(handler, { query: { team: ['123e4567-e89b-12d3-a456-426614174000'] } });
+    expect(status).toBe(200);
+  });
+
+  it('invalid id', async () => {
+    const { status } = await testGet(handler, { query: { team: ['bad'] } });
+    expect(status).toBe(400);
+  });
+});

--- a/src/pages/api/user/[...user].ts
+++ b/src/pages/api/user/[...user].ts
@@ -1,0 +1,33 @@
+import { createApiHandler } from '@/lib/api-utils/api-handler';
+import { getApiUserService } from '@/services/user/factory';
+import { ApiError } from '@/lib/api/common';
+import { z } from 'zod';
+
+const searchSchema = z.object({ query: z.string().min(1) });
+
+/**
+ * GET /api/user/search
+ */
+const searchHandler = createApiHandler({
+  methods: ['GET'],
+  requiresAuth: true,
+  async handler(req) {
+    const parse = searchSchema.safeParse(req.query);
+    if (!parse.success) {
+      throw new ApiError(400, 'Invalid search query');
+    }
+    const userService = getApiUserService();
+    const result = await userService.searchUsers({ query: parse.data.query });
+    return result;
+  }
+});
+
+export default function handler(req: any, res: any) {
+  const [action] = (req.query.user as string[]) || [];
+  switch (action) {
+    case 'search':
+      return searchHandler(req, res);
+    default:
+      return res.status(404).json({ error: 'Not Found' });
+  }
+}

--- a/src/pages/api/user/__tests__/user.test.ts
+++ b/src/pages/api/user/__tests__/user.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import handler from '../[...user]';
+import { getApiUserService } from '@/services/user/factory';
+import { testGet } from '@/tests/utils/api-testing-utils';
+
+vi.mock('@/services/user/factory', () => ({ getApiUserService: vi.fn() }));
+
+describe('GET /api/user/search', () => {
+  const mockService = { searchUsers: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiUserService as unknown as vi.Mock).mockReturnValue(mockService);
+    mockService.searchUsers.mockResolvedValue({ users: [] });
+  });
+
+  it('returns 200', async () => {
+    const { status } = await testGet(handler, { query: { user: ['search'], query: 'a' } });
+    expect(status).toBe(200);
+  });
+
+  it('invalid query', async () => {
+    const { status } = await testGet(handler, { query: { user: ['search'] } });
+    expect(status).toBe(400);
+  });
+});

--- a/src/pages/api/users/[id].ts
+++ b/src/pages/api/users/[id].ts
@@ -1,6 +1,6 @@
 import { createApiHandler } from '@/lib/api-utils/api-handler';
 import { getApiUserService } from '@/services/user/factory';
-import { ApiError } from '@/lib/errors';
+import { ApiError } from '@/lib/api/common';
 import { z } from 'zod';
 
 // Define validation schemas


### PR DESCRIPTION
## Summary
- implement service-based handlers for several API routes
- add zod validation
- add minimal tests for API handlers
- adjust ApiError imports

## Testing
- `npx vitest run --coverage src/pages/api/auth/__tests__/auth.test.ts src/pages/api/user/__tests__/user.test.ts src/pages/api/team/__tests__/team.test.ts src/pages/api/permission/__tests__/permission.test.ts src/pages/api/session/__tests__/session.test.ts src/pages/api/sso/__tests__/sso.test.ts src/pages/api/notification/__tests__/notification.test.ts` *(fails: Failed to resolve import '@/lib/errors')*