### PR TITLE
Add service-based API handlers

### DIFF
--- a/src/pages/api/address/[...address].ts
+++ b/src/pages/api/address/[...address].ts
@@ -1,0 +1,97 @@
+import { createApiHandler } from '@/lib/api-utils/api-handler';
+import { getApiAddressService } from '@/services/address/factory';
+import { ApiError } from '@/lib/api/common';
+import { addressSchema } from '@/core/address/validation';
+import { z } from 'zod';
+
+const userSchema = z.object({ userId: z.string().uuid() });
+const idSchema = z.string();
+const createSchema = addressSchema.extend({ userId: z.string().uuid() });
+const updateSchema = addressSchema.partial().extend({ userId: z.string().uuid() });
+
+/** List addresses */
+const listHandler = createApiHandler({
+  methods: ['GET'],
+  requiresAuth: true,
+  async handler(req) {
+    const parse = userSchema.safeParse(req.query);
+    if (!parse.success) throw new ApiError(400, 'Invalid parameters');
+    const service = getApiAddressService();
+    const addresses = await service.getAddresses(parse.data.userId);
+    return { addresses };
+  }
+});
+
+/** Create address */
+const createHandler = createApiHandler({
+  methods: ['POST'],
+  requiresAuth: true,
+  async handler(req) {
+    const parse = createSchema.safeParse(req.body);
+    if (!parse.success) throw new ApiError(400, 'Invalid payload', { details: parse.error.flatten() });
+    const service = getApiAddressService();
+    const address = await service.createAddress(parse.data as any);
+    return { address };
+  }
+});
+
+/** Get single address */
+const getHandler = createApiHandler({
+  methods: ['GET'],
+  requiresAuth: true,
+  async handler(req) {
+    const segments = (req.query.address as string[]) || [];
+    const id = segments[0];
+    const parse = userSchema.safeParse(req.query);
+    if (!parse.success || !id) throw new ApiError(400, 'Invalid parameters');
+    const service = getApiAddressService();
+    const address = await service.getAddress(id, parse.data.userId);
+    return { address };
+  }
+});
+
+/** Update address */
+const updateHandler = createApiHandler({
+  methods: ['PUT'],
+  requiresAuth: true,
+  async handler(req) {
+    const segments = (req.query.address as string[]) || [];
+    const id = segments[0];
+    const parseQuery = userSchema.safeParse(req.query);
+    const parseBody = updateSchema.safeParse(req.body);
+    if (!parseQuery.success || !parseBody.success || !id) {
+      throw new ApiError(400, 'Invalid parameters');
+    }
+    const service = getApiAddressService();
+    const updated = await service.updateAddress(id, parseBody.data, parseQuery.data.userId);
+    return { address: updated };
+  }
+});
+
+/** Delete address */
+const deleteHandler = createApiHandler({
+  methods: ['DELETE'],
+  requiresAuth: true,
+  async handler(req) {
+    const segments = (req.query.address as string[]) || [];
+    const id = segments[0];
+    const parse = userSchema.safeParse(req.query);
+    if (!parse.success || !id) throw new ApiError(400, 'Invalid parameters');
+    const service = getApiAddressService();
+    await service.deleteAddress(id, parse.data.userId);
+    return { success: true };
+  }
+});
+
+export default function handler(req: any, res: any) {
+  const segments = (req.query.address as string[]) || [];
+  if (segments.length === 0) {
+    if (req.method === 'GET') return listHandler(req, res);
+    if (req.method === 'POST') return createHandler(req, res);
+  } else if (segments.length === 1) {
+    if (req.method === 'GET') return getHandler(req, res);
+    if (req.method === 'PUT') return updateHandler(req, res);
+    if (req.method === 'DELETE') return deleteHandler(req, res);
+  }
+  res.status(405).json({ error: 'Method Not Allowed' });
+}

--- a/src/pages/api/api-keys/[...api-keys].ts
+++ b/src/pages/api/api-keys/[...api-keys].ts
@@ -1,0 +1,87 @@
+import { createApiHandler } from '@/lib/api-utils/api-handler';
+import { getApiKeyService } from '@/services/api-keys/factory';
+import { ApiError } from '@/lib/api/common';
+import { apiKeyCreateSchema } from '@/core/api-keys/models';
+import { z } from 'zod';
+
+/**
+ * Schema for listing API keys
+ */
+const listSchema = z.object({ userId: z.string().uuid() });
+
+/**
+ * Schema for creating an API key
+ */
+const createSchema = apiKeyCreateSchema.extend({ userId: z.string().uuid() });
+
+/**
+ * GET /api/api-keys
+ * List API keys for a user
+ */
+const listHandler = createApiHandler({
+  methods: ['GET'],
+  requiresAuth: true,
+  async handler(req) {
+    const parse = listSchema.safeParse(req.query);
+    if (!parse.success) {
+      throw new ApiError(400, 'Invalid parameters');
+    }
+    const service = getApiKeyService();
+    const keys = await service.listApiKeys(parse.data.userId);
+    return { keys };
+  }
+});
+
+/**
+ * POST /api/api-keys
+ * Create a new API key
+ */
+const createHandler = createApiHandler({
+  methods: ['POST'],
+  requiresAuth: true,
+  async handler(req) {
+    const parse = createSchema.safeParse(req.body);
+    if (!parse.success) {
+      throw new ApiError(400, 'Invalid payload', { details: parse.error.flatten() });
+    }
+    const { userId, ...payload } = parse.data;
+    const service = getApiKeyService();
+    const result = await service.createApiKey(userId, payload);
+    if (!result.success || !result.key) {
+      throw new ApiError(400, result.error || 'Failed to create key');
+    }
+    return { key: result.key, plaintext: result.plaintext };
+  }
+});
+
+/**
+ * DELETE /api/api-keys/[id]
+ * Revoke an API key
+ */
+const revokeHandler = createApiHandler({
+  methods: ['DELETE'],
+  requiresAuth: true,
+  async handler(req) {
+    const segments = (req.query['api-keys'] as string[]) || [];
+    const keyId = segments[0];
+    const parse = listSchema.safeParse(req.query);
+    if (!parse.success || !keyId) {
+      throw new ApiError(400, 'Invalid parameters');
+    }
+    const service = getApiKeyService();
+    const result = await service.revokeApiKey(parse.data.userId, keyId);
+    if (!result.success) {
+      throw new ApiError(400, result.error || 'Failed to revoke key');
+    }
+    return { key: result.key };
+  }
+});
+
+export default function handler(req: any, res: any) {
+  const method = req.method;
+  const segments = (req.query['api-keys'] as string[]) || [];
+  if (method === 'GET' && segments.length === 0) return listHandler(req, res);
+  if (method === 'POST' && segments.length === 0) return createHandler(req, res);
+  if (method === 'DELETE' && segments.length === 1) return revokeHandler(req, res);
+  res.status(405).json({ error: 'Method Not Allowed' });
+}

--- a/src/pages/api/audit/[...audit].ts
+++ b/src/pages/api/audit/[...audit].ts
@@ -1,0 +1,48 @@
+import { createApiHandler } from '@/lib/api-utils/api-handler';
+import { getApiAuditService } from '@/services/audit/factory';
+import { ApiError } from '@/lib/api/common';
+import { z } from 'zod';
+
+const querySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  userId: z.string().uuid().optional(),
+  action: z.string().optional(),
+  status: z.enum(['SUCCESS','FAILURE','INITIATED','COMPLETED']).optional(),
+  resourceType: z.string().optional(),
+  resourceId: z.string().optional(),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  ipAddress: z.string().optional(),
+  userAgent: z.string().optional(),
+  search: z.string().optional(),
+  sortBy: z.string().optional(),
+  sortOrder: z.enum(['asc','desc']).optional()
+});
+
+/**
+ * GET /api/audit/logs
+ */
+const listHandler = createApiHandler({
+  methods: ['GET'],
+  requiresAuth: true,
+  async handler(req) {
+    const parse = querySchema.safeParse(req.query);
+    if (!parse.success) {
+      throw new ApiError(400, 'Invalid query');
+    }
+    const service = getApiAuditService();
+    const result = await service.getLogs(parse.data);
+    return result;
+  }
+});
+
+export default function handler(req: any, res: any) {
+  const [action] = (req.query.audit as string[]) || [];
+  switch(action){
+    case 'logs':
+      return listHandler(req,res);
+    default:
+      return res.status(404).json({ error: 'Not Found' });
+  }
+}

--- a/src/pages/api/csrf/[...csrf].ts
+++ b/src/pages/api/csrf/[...csrf].ts
@@ -1,0 +1,57 @@
+import { createApiHandler } from '@/lib/api-utils/api-handler';
+import { getApiCsrfService } from '@/services/csrf/factory';
+import { ApiError } from '@/lib/api/common';
+import { z } from 'zod';
+
+const tokenSchema = z.object({ token: z.string() });
+
+/** Generate CSRF token */
+const generateHandler = createApiHandler({
+  methods: ['GET'],
+  async handler() {
+    const service = getApiCsrfService();
+    const result = await service.createToken();
+    if (!result.success || !result.token) {
+      throw new ApiError(500, result.error || 'Failed to create token');
+    }
+    return { token: result.token.token };
+  }
+});
+
+/** Validate CSRF token */
+const validateHandler = createApiHandler({
+  methods: ['POST'],
+  async handler(req) {
+    const parse = tokenSchema.safeParse(req.body);
+    if (!parse.success) throw new ApiError(400, 'Token required');
+    const service = getApiCsrfService();
+    return service.validateToken(parse.data.token);
+  }
+});
+
+/** Revoke CSRF token */
+const revokeHandler = createApiHandler({
+  methods: ['DELETE'],
+  async handler(req) {
+    const parse = tokenSchema.safeParse(req.body);
+    if (!parse.success) throw new ApiError(400, 'Token required');
+    const service = getApiCsrfService();
+    return service.revokeToken(parse.data.token);
+  }
+});
+
+export default function handler(req: any, res: any) {
+  const [action] = (req.query.csrf as string[]) || [];
+  switch (req.method) {
+    case 'GET':
+      return generateHandler(req, res);
+    case 'POST':
+      if (action === 'validate') return validateHandler(req, res);
+      return res.status(404).json({ error: 'Not Found' });
+    case 'DELETE':
+      if (action === 'revoke') return revokeHandler(req, res);
+      return res.status(404).json({ error: 'Not Found' });
+    default:
+      return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+}

--- a/src/pages/api/gdpr/[...gdpr].ts
+++ b/src/pages/api/gdpr/[...gdpr].ts
@@ -1,0 +1,46 @@
+import { createApiHandler } from '@/lib/api-utils/api-handler';
+import { getApiGdprService } from '@/services/gdpr/factory';
+import { ApiError } from '@/lib/api/common';
+import { z } from 'zod';
+
+const userSchema = z.object({ userId: z.string().uuid() });
+
+/** Export user data */
+const exportHandler = createApiHandler({
+  methods: ['GET'],
+  requiresAuth: true,
+  async handler(req) {
+    const parse = userSchema.safeParse(req.query);
+    if (!parse.success) throw new ApiError(400, 'Invalid parameters');
+    const service = getApiGdprService();
+    const data = await service.exportUserData(parse.data.userId);
+    if (!data) throw new ApiError(404, 'Export not found');
+    return data;
+  }
+});
+
+/** Delete user account */
+const deleteHandler = createApiHandler({
+  methods: ['POST'],
+  requiresAuth: true,
+  async handler(req) {
+    const parse = userSchema.safeParse(req.body);
+    if (!parse.success) throw new ApiError(400, 'Invalid parameters');
+    const service = getApiGdprService();
+    const result = await service.deleteAccount(parse.data.userId);
+    if (!result.success) throw new ApiError(400, result.error || 'Deletion failed');
+    return { message: result.message };
+  }
+});
+
+export default function handler(req: any, res: any) {
+  const [action] = (req.query.gdpr as string[]) || [];
+  switch(action){
+    case 'export':
+      return exportHandler(req,res);
+    case 'delete':
+      return deleteHandler(req,res);
+    default:
+      return res.status(404).json({ error: 'Not Found' });
+  }
+}

--- a/src/pages/api/subscription/[...subscription].ts
+++ b/src/pages/api/subscription/[...subscription].ts
@@ -1,0 +1,61 @@
+import { createApiHandler } from '@/lib/api-utils/api-handler';
+import { getApiSubscriptionService } from '@/services/subscription/factory';
+import { ApiError } from '@/lib/api/common';
+import { z } from 'zod';
+
+const createSchema = z.object({ userId: z.string().uuid(), planId: z.string() });
+const subIdSchema = z.object({ subscriptionId: z.string(), immediate: z.boolean().optional() });
+
+/** Get plans */
+const plansHandler = createApiHandler({
+  methods: ['GET'],
+  async handler() {
+    const service = getApiSubscriptionService();
+    const plans = await service.getPlans();
+    return { plans };
+  }
+});
+
+/** Create subscription */
+const createHandler = createApiHandler({
+  methods: ['POST'],
+  requiresAuth: true,
+  async handler(req) {
+    const parse = createSchema.safeParse(req.body);
+    if (!parse.success) throw new ApiError(400, 'Invalid payload');
+    const service = getApiSubscriptionService();
+    const result = await service.createSubscription(parse.data.userId, parse.data.planId);
+    if (!result.success || !result.subscription) {
+      throw new ApiError(400, result.error || 'Failed to create subscription');
+    }
+    return result.subscription;
+  }
+});
+
+/** Cancel subscription */
+const cancelHandler = createApiHandler({
+  methods: ['DELETE'],
+  requiresAuth: true,
+  async handler(req) {
+    const parse = subIdSchema.safeParse(req.body);
+    if (!parse.success) throw new ApiError(400, 'Invalid payload');
+    const service = getApiSubscriptionService();
+    return service.cancelSubscription(parse.data.subscriptionId, parse.data.immediate);
+  }
+});
+
+export default function handler(req: any, res: any) {
+  const [action] = (req.query.subscription as string[]) || [];
+  switch(action){
+    case 'plans':
+      if (req.method === 'GET') return plansHandler(req,res);
+      break;
+    case 'create':
+      if (req.method === 'POST') return createHandler(req,res);
+      break;
+    case 'cancel':
+      if (req.method === 'DELETE') return cancelHandler(req,res);
+      break;
+  }
+  res.status(404).json({ error: 'Not Found' });
+}

--- a/src/pages/api/webhook/[...webhook].ts
+++ b/src/pages/api/webhook/[...webhook].ts
@@ -1,0 +1,86 @@
+import { createApiHandler } from '@/lib/api-utils/api-handler';
+import { getApiWebhookService } from '@/services/webhooks/factory';
+import { ApiError } from '@/lib/api/common';
+import { webhookCreateSchema, webhookUpdateSchema } from '@/core/webhooks/models/webhook';
+import { z } from 'zod';
+
+const userSchema = z.object({ userId: z.string().uuid() });
+
+/** List webhooks */
+const listHandler = createApiHandler({
+  methods: ['GET'],
+  requiresAuth: true,
+  async handler(req) {
+    const parse = userSchema.safeParse(req.query);
+    if (!parse.success) throw new ApiError(400, 'Invalid parameters');
+    const service = getApiWebhookService();
+    const hooks = await service.getWebhooks(parse.data.userId);
+    return { webhooks: hooks };
+  }
+});
+
+/** Create webhook */
+const createHandler = createApiHandler({
+  methods: ['POST'],
+  requiresAuth: true,
+  async handler(req) {
+    const data = webhookCreateSchema.extend({ userId: z.string().uuid() }).safeParse(req.body);
+    if (!data.success) throw new ApiError(400, 'Invalid payload', { details: data.error.flatten() });
+    const { userId, ...payload } = data.data;
+    const service = getApiWebhookService();
+    const result = await service.createWebhook(userId, payload);
+    if (!result.success || !result.webhook) {
+      throw new ApiError(400, result.error || 'Failed to create webhook');
+    }
+    return result.webhook;
+  }
+});
+
+/** Delete webhook */
+const deleteHandler = createApiHandler({
+  methods: ['DELETE'],
+  requiresAuth: true,
+  async handler(req) {
+    const segments = (req.query.webhook as string[]) || [];
+    const id = segments[0];
+    const parse = userSchema.safeParse(req.query);
+    if (!parse.success || !id) throw new ApiError(400, 'Invalid parameters');
+    const service = getApiWebhookService();
+    const result = await service.deleteWebhook(parse.data.userId, id);
+    if (!result.success) throw new ApiError(400, result.error || 'Delete failed');
+    return { success: true };
+  }
+});
+
+/** Update webhook */
+const updateHandler = createApiHandler({
+  methods: ['PATCH'],
+  requiresAuth: true,
+  async handler(req) {
+    const segments = (req.query.webhook as string[]) || [];
+    const id = segments[0];
+    const parseQuery = userSchema.safeParse(req.query);
+    const parseBody = webhookUpdateSchema.safeParse(req.body);
+    if (!parseQuery.success || !parseBody.success || !id) {
+      throw new ApiError(400, 'Invalid parameters');
+    }
+    const service = getApiWebhookService();
+    const result = await service.updateWebhook(parseQuery.data.userId, id, parseBody.data);
+    if (!result.success || !result.webhook) {
+      throw new ApiError(400, result.error || 'Update failed');
+    }
+    return result.webhook;
+  }
+});
+
+export default function handler(req: any, res: any) {
+  const segments = (req.query.webhook as string[]) || [];
+  if (segments.length === 0) {
+    if (req.method === 'GET') return listHandler(req, res);
+    if (req.method === 'POST') return createHandler(req, res);
+  } else if (segments.length === 1) {
+    if (req.method === 'DELETE') return deleteHandler(req, res);
+    if (req.method === 'PATCH') return updateHandler(req, res);
+  }
+  res.status(405).json({ error: 'Method Not Allowed' });
+}


### PR DESCRIPTION
## Summary
- add API route handlers for api-keys
- add API route handlers for address
- add API route handlers for audit
- add API route handlers for csrf
- add API route handlers for gdpr
- add API route handlers for subscription
- add API route handlers for webhook

## Testing
- `npm run test:coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*