### PR TITLE
Improve middleware error handling

### DIFF
--- a/src/middleware/__tests__/csrf.test.ts
+++ b/src/middleware/__tests__/csrf.test.ts
@@ -92,7 +92,9 @@ describe('CSRF Middleware', () => {
       await middleware(req, res, next);
 
       expect(res.status).toHaveBeenCalledWith(403);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Invalid CSRF token' });
+      expect(res.json).toHaveBeenCalledWith({
+        error: { code: 'auth/forbidden', message: 'Invalid CSRF token' }
+      });
       expect(next).not.toHaveBeenCalled();
     });
 
@@ -107,7 +109,9 @@ describe('CSRF Middleware', () => {
       await middleware(req, res, next);
 
       expect(res.status).toHaveBeenCalledWith(403);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Invalid CSRF token' });
+      expect(res.json).toHaveBeenCalledWith({
+        error: { code: 'auth/forbidden', message: 'Invalid CSRF token' }
+      });
       expect(next).not.toHaveBeenCalled();
     });
   });

--- a/src/middleware/__tests__/rate-limit.test.ts
+++ b/src/middleware/__tests__/rate-limit.test.ts
@@ -265,7 +265,10 @@ describe('Rate Limiting', () => {
 
       expect(res.status).toHaveBeenCalledWith(429);
       expect(res.json).toHaveBeenCalledWith({
-        error: 'Too many requests, please try again later.',
+        error: {
+          code: 'server/operation_failed',
+          message: 'Too many requests, please try again later.'
+        }
       });
       expect(next).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary
- refine CSRF middleware with ApiError responses and docs
- refine rate limiting middleware to use ApiError
- adjust tests for new error objects

## Testing
- `npx vitest run --coverage src/middleware/__tests__/csrf.test.ts src/middleware/__tests__/rate-limit.test.ts src/middleware/__tests__/auth.test.js src/middleware/__tests__/security-headers.test.ts src/middleware/__tests__/index.test.ts src/middleware/__tests__/audit-log.test.ts src/middleware/__tests__/permissions.test.ts`
