### PR TITLE
refactor: use alias for validation middleware import

### DIFF
--- a/src/lib/api/common/__tests__/middleware.test.ts
+++ b/src/lib/api/common/__tests__/middleware.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { withValidation } from '../../../middleware/validation';
+import { withValidation } from '@/middleware/validation';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 


### PR DESCRIPTION
## Summary
- switch middleware test to `@/middleware/validation`

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined)*