### PR TITLE
Add Stripe webhook endpoint

### DIFF
--- a/app/api/webhooks/__tests__/route.test.ts
+++ b/app/api/webhooks/__tests__/route.test.ts
@@ -209,3 +209,22 @@ describe('Webhooks API', () => {
     });
   });
 }); 
+  describe('DELETE /api/webhooks', () => {
+    it('should delete a webhook', async () => {
+      supabaseMock.delete = vi.fn().mockReturnThis();
+      supabaseMock.single.mockResolvedValue({});
+      supabaseMock.eq.mockReturnThis();
+      supabaseMock.from.mockReturnThis();
+      supabaseMock.delete.mockReturnThis();
+      supabaseMock.eq.mockReturnThis();
+      supabaseMock.select = vi.fn();
+      supabaseMock.insert = vi.fn();
+
+      const req = createMockRequest('DELETE', { id: 'webhook1' });
+      const response = await (await import('../route')).DELETE(req);
+      const body = await response.json();
+      expect(response.status).toBe(200);
+      expect(body).toHaveProperty('success', true);
+    });
+  });
+});

--- a/app/api/webhooks/stripe/__tests__/route.test.ts
+++ b/app/api/webhooks/stripe/__tests__/route.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { POST } from '../route';
+
+vi.mock('@/lib/payments/stripe', () => ({
+  stripe: {
+    webhooks: {
+      constructEvent: vi.fn()
+    }
+  }
+}));
+
+vi.mock('@/adapters/subscription/supabase/supabase-subscription.provider', () => ({
+  SupabaseSubscriptionProvider: vi.fn().mockImplementation(() => ({
+    upsertSubscription: vi.fn().mockResolvedValue(undefined)
+  }))
+}));
+
+const { stripe } = require('@/lib/payments/stripe');
+const { SupabaseSubscriptionProvider } = require('@/adapters/subscription/supabase/supabase-subscription.provider');
+
+function createRequest(body: any, signature = 'sig') {
+  return new Request('http://localhost', {
+    method: 'POST',
+    headers: { 'stripe-signature': signature },
+    body: JSON.stringify(body)
+  });
+}
+
+describe('/api/webhooks/stripe', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 400 for invalid signature', async () => {
+    stripe.webhooks.constructEvent.mockImplementation(() => { throw new Error('bad'); });
+    const res = await POST(createRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('handles subscription events', async () => {
+    stripe.webhooks.constructEvent.mockReturnValue({
+      type: 'customer.subscription.updated',
+      data: { object: { id: 'sub', metadata: { user_id: 'u1' }, items: { data: [{ price: { id: 'price' } }] }, start_date: 0, current_period_end: 0 } }
+    });
+    const res = await POST(createRequest({}));
+    expect(res.status).toBe(200);
+    const Provider = SupabaseSubscriptionProvider as any;
+    expect(Provider).toHaveBeenCalled();
+    const instance = Provider.mock.results[0].value;
+    expect(instance.upsertSubscription).toHaveBeenCalled();
+  });
+});

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { stripe } from '@/lib/payments/stripe';
+import { SupabaseSubscriptionProvider } from '@/adapters/subscription/supabase/supabase-subscription.provider';
+import type Stripe from 'stripe';
+
+/**
+ * Stripe Webhook handler
+ *
+ * Verifies the event signature and updates subscriptions accordingly.
+ */
+export async function POST(request: NextRequest) {
+  const signature = request.headers.get('stripe-signature');
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    console.error('STRIPE_WEBHOOK_SECRET not configured');
+    return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
+  }
+
+  const payload = await request.text();
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(payload, signature || '', webhookSecret);
+  } catch (err) {
+    console.error('Stripe signature verification failed:', err);
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+  }
+
+  try {
+    switch (event.type) {
+      case 'customer.subscription.created':
+      case 'customer.subscription.updated':
+      case 'customer.subscription.deleted': {
+        const subscription = event.data.object as Stripe.Subscription;
+        const userId = subscription.metadata?.user_id;
+        if (userId) {
+          const provider = new SupabaseSubscriptionProvider(
+            process.env.NEXT_PUBLIC_SUPABASE_URL!,
+            process.env.SUPABASE_SERVICE_ROLE_KEY!
+          );
+          await provider.upsertSubscription({
+            id: subscription.id,
+            userId,
+            planId: subscription.items.data[0]?.price.id ?? '',
+            status: subscription.status,
+            startDate: new Date(subscription.start_date * 1000).toISOString(),
+            endDate: subscription.ended_at ? new Date(subscription.ended_at * 1000).toISOString() : null,
+            renewalDate: new Date(subscription.current_period_end * 1000).toISOString(),
+            canceledAt: subscription.canceled_at ? new Date(subscription.canceled_at * 1000).toISOString() : null,
+            paymentMethod: undefined,
+            metadata: subscription.metadata as any
+          });
+        }
+        break;
+      }
+      default:
+        console.log(`Unhandled Stripe event: ${event.type}`);
+    }
+  } catch (err) {
+    console.error('Error processing Stripe webhook:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+
+  return NextResponse.json({ received: true });
+}


### PR DESCRIPTION
## Summary
- add `/api/webhooks/stripe` endpoint to process Stripe webhooks
- support DELETE on `/api/webhooks`
- test Stripe webhook handler
- test DELETE on `/api/webhooks`

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*