### PR TITLE
Add missing subscription billing routes

### DIFF
--- a/app/api/subscriptions/cancel/__tests__/route.test.ts
+++ b/app/api/subscriptions/cancel/__tests__/route.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+import { getApiSubscriptionService } from '@/services/subscription/factory';
+
+vi.mock('@/services/subscription/factory', () => ({
+  getApiSubscriptionService: vi.fn(),
+}));
+
+describe('subscriptions cancel API', () => {
+  const service = {
+    cancelSubscription: vi.fn(),
+  } as any;
+
+  beforeEach(() => {
+    vi.mocked(getApiSubscriptionService).mockReturnValue(service);
+    vi.clearAllMocks();
+  });
+
+  it('cancels subscription', async () => {
+    service.cancelSubscription.mockResolvedValue({ success: true });
+    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({ subscriptionId: 'sub1' }) });
+    req.headers.set('x-user-id', 'u1');
+    const res = await POST(req as any);
+    expect(res.status).toBe(200);
+    expect(service.cancelSubscription).toHaveBeenCalledWith('sub1', undefined);
+  });
+
+  it('returns 400 for invalid payload', async () => {
+    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({}) });
+    req.headers.set('x-user-id', 'u1');
+    const res = await POST(req as any);
+    expect(res.status).toBe(400);
+  });
+
+  it('requires auth', async () => {
+    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({ subscriptionId: 'sub1' }) });
+    const res = await POST(req as any);
+    expect(res.status).toBe(401);
+  });
+});

--- a/app/api/subscriptions/cancel/route.ts
+++ b/app/api/subscriptions/cancel/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getApiSubscriptionService } from '@/services/subscription/factory';
+
+const bodySchema = z.object({
+  subscriptionId: z.string(),
+  immediate: z.boolean().optional(),
+});
+
+/**
+ * Cancel a user's subscription.
+ */
+export async function POST(req: NextRequest) {
+  const userId = req.headers.get('x-user-id');
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const parse = bodySchema.safeParse(body);
+  if (!parse.success) {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  const service = getApiSubscriptionService();
+  const result = await service.cancelSubscription(
+    parse.data.subscriptionId,
+    parse.data.immediate
+  );
+
+  if (!result.success) {
+    return NextResponse.json({ error: result.error || 'Failed to cancel' }, { status: 400 });
+  }
+  return NextResponse.json({ success: true });
+}

--- a/app/api/subscriptions/checkout/__tests__/route.test.ts
+++ b/app/api/subscriptions/checkout/__tests__/route.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+import { createCheckoutSession } from '@/lib/payments/stripe';
+
+vi.mock('@/lib/payments/stripe', () => ({
+  createCheckoutSession: vi.fn(),
+}));
+
+describe('subscriptions checkout API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates checkout session', async () => {
+    vi.mocked(createCheckoutSession).mockResolvedValue({ url: 'https://stripe.test' } as any);
+    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({ plan: 'price_123' }) });
+    const res = await POST(req as any);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.url).toBe('https://stripe.test');
+    expect(createCheckoutSession).toHaveBeenCalled();
+  });
+
+  it('returns 400 on invalid payload', async () => {
+    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({}) });
+    const res = await POST(req as any);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/subscriptions/checkout/route.ts
+++ b/app/api/subscriptions/checkout/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { createCheckoutSession } from '@/lib/payments/stripe';
+
+const bodySchema = z.object({ plan: z.string() });
+
+/**
+ * Create a Stripe checkout session for a subscription plan.
+ */
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+  const parse = bodySchema.safeParse(body);
+  if (!parse.success) {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  try {
+    const session = await createCheckoutSession({
+      mode: 'subscription',
+      line_items: [{ price: parse.data.plan, quantity: 1 }],
+      success_url: `${process.env.NEXT_PUBLIC_APP_URL}/billing/success`,
+      cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/billing/cancel`,
+    });
+    return NextResponse.json({ url: session.url });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/app/api/subscriptions/portal/__tests__/route.test.ts
+++ b/app/api/subscriptions/portal/__tests__/route.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+import { createBillingPortalSession } from '@/lib/payments/stripe';
+
+vi.mock('@/lib/payments/stripe', () => ({
+  createBillingPortalSession: vi.fn(),
+}));
+
+describe('subscriptions portal API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates portal session', async () => {
+    vi.mocked(createBillingPortalSession).mockResolvedValue({ url: 'https://portal.test' } as any);
+    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({ customerId: 'cus_123' }) });
+    const res = await POST(req as any);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.url).toBe('https://portal.test');
+    expect(createBillingPortalSession).toHaveBeenCalled();
+  });
+
+  it('returns 400 on invalid payload', async () => {
+    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({}) });
+    const res = await POST(req as any);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/subscriptions/portal/route.ts
+++ b/app/api/subscriptions/portal/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { createBillingPortalSession } from '@/lib/payments/stripe';
+
+const bodySchema = z.object({ customerId: z.string() });
+
+/**
+ * Create a Stripe billing portal session for the given customer.
+ */
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+  const parse = bodySchema.safeParse(body);
+  if (!parse.success) {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  try {
+    const session = await createBillingPortalSession({
+      customer: parse.data.customerId,
+      return_url: `${process.env.NEXT_PUBLIC_APP_URL}/billing`,
+    });
+    return NextResponse.json({ url: session.url });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/app/api/subscriptions/status/__tests__/route.test.ts
+++ b/app/api/subscriptions/status/__tests__/route.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from '../route';
+import { getApiSubscriptionService } from '@/services/subscription/factory';
+
+vi.mock('@/services/subscription/factory', () => ({
+  getApiSubscriptionService: vi.fn(),
+}));
+
+describe('subscriptions status API', () => {
+  const service = {
+    getUserSubscription: vi.fn(),
+  } as any;
+
+  beforeEach(() => {
+    vi.mocked(getApiSubscriptionService).mockReturnValue(service);
+    vi.clearAllMocks();
+  });
+
+  it('returns subscription', async () => {
+    service.getUserSubscription.mockResolvedValue({ id: 'sub1' });
+    const req = new Request('http://test');
+    req.headers.set('x-user-id', 'u1');
+    const res = await GET(req as any);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.id).toBe('sub1');
+  });
+
+  it('unauthorized without header', async () => {
+    const req = new Request('http://test');
+    const res = await GET(req as any);
+    expect(res.status).toBe(401);
+  });
+});

--- a/app/api/subscriptions/status/route.ts
+++ b/app/api/subscriptions/status/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getApiSubscriptionService } from '@/services/subscription/factory';
+
+/**
+ * Retrieve the current user's subscription status.
+ */
+export async function GET(req: NextRequest) {
+  const userId = req.headers.get('x-user-id');
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const service = getApiSubscriptionService();
+  const subscription = await service.getUserSubscription(userId);
+  return NextResponse.json(subscription ?? null);
+}

--- a/docs/Project documentation/UserManagementModule_APIs_Services_Checklist.md
+++ b/docs/Project documentation/UserManagementModule_APIs_Services_Checklist.md
@@ -139,10 +139,10 @@
 ## 9. Subscription & Billing
 
 **API Endpoints:**
-- [ ] `/api/subscriptions/checkout`
-- [ ] `/api/subscriptions/portal`
-- [ ] `/api/subscriptions/status`
-- [ ] `/api/subscriptions/cancel`
+- [x] `/api/subscriptions/checkout`
+- [x] `/api/subscriptions/portal`
+- [x] `/api/subscriptions/status`
+- [x] `/api/subscriptions/cancel`
 
 **Core Implementation:**
 - [ ] `SubscriptionService`

--- a/src/lib/payments/stripe.ts
+++ b/src/lib/payments/stripe.ts
@@ -31,4 +31,11 @@ export async function createCheckoutSession(params: Stripe.Checkout.SessionCreat
   return stripe.checkout.sessions.create(params);
 }
 
+// Example: Create a billing portal session
+export async function createBillingPortalSession(
+  params: Stripe.BillingPortal.SessionCreateParams
+) {
+  return stripe.billingPortal.sessions.create(params);
+}
+
 // Add more helpers as needed for your flows 


### PR DESCRIPTION
## Summary
- implement `/api/subscriptions` endpoints: checkout, portal, status, cancel
- add corresponding unit tests
- extend Stripe helper for billing portal session
- mark subscription endpoints as implemented in documentation

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*