### PR TITLE
Add audit logs API endpoint

### DIFF
--- a/app/api/audit/__tests__/route.test.ts
+++ b/app/api/audit/__tests__/route.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GET } from '../route';
+import { getApiAuditService } from '@/services/audit/factory';
+import { getUserFromRequest } from '@/lib/auth/utils';
+import { hasPermission } from '@/lib/auth/hasPermission';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/services/audit/factory', () => ({
+  getApiAuditService: vi.fn(),
+}));
+vi.mock('@/lib/auth/utils', () => ({
+  getUserFromRequest: vi.fn(),
+}));
+vi.mock('@/lib/auth/hasPermission', () => ({
+  hasPermission: vi.fn(),
+}));
+
+describe('GET /api/audit', () => {
+  const createRequest = (url: string) => new NextRequest(url);
+  const mockService = { getLogs: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiAuditService as unknown as vi.Mock).mockReturnValue(mockService);
+    mockService.getLogs.mockResolvedValue({ logs: [], count: 0 });
+    (hasPermission as unknown as vi.Mock).mockResolvedValue(true);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    (getUserFromRequest as unknown as vi.Mock).mockResolvedValue(null);
+    const res = await GET(createRequest('http://localhost/api/audit'));
+    expect(res.status).toBe(401);
+  });
+
+  it('validates query parameters', async () => {
+    (getUserFromRequest as unknown as vi.Mock).mockResolvedValue({ id: 'u1' });
+    const res = await GET(createRequest('http://localhost/api/audit?page=bad'));
+    expect(res.status).toBe(400);
+  });
+
+  it('checks permissions when requesting another user', async () => {
+    (getUserFromRequest as unknown as vi.Mock).mockResolvedValue({ id: 'u1' });
+    (hasPermission as unknown as vi.Mock).mockResolvedValue(false);
+    const res = await GET(createRequest('http://localhost/api/audit?userId=u2'));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns logs from service', async () => {
+    (getUserFromRequest as unknown as vi.Mock).mockResolvedValue({ id: 'u1' });
+    mockService.getLogs.mockResolvedValueOnce({ logs: [{ id: '1' }], count: 1 });
+    const res = await GET(createRequest('http://localhost/api/audit?page=1&limit=10'));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(mockService.getLogs).toHaveBeenCalled();
+    expect(data.logs.length).toBe(1);
+    expect(data.pagination.total).toBe(1);
+  });
+});

--- a/app/api/audit/route.ts
+++ b/app/api/audit/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getUserFromRequest } from '@/lib/auth/utils';
+import { hasPermission } from '@/lib/auth/hasPermission';
+import { getApiAuditService } from '@/services/audit/factory';
+
+const querySchema = z.object({
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  userId: z.string().uuid().optional(),
+  action: z.string().optional(),
+  status: z.enum(['SUCCESS', 'FAILURE', 'INITIATED', 'COMPLETED']).optional(),
+  resourceType: z.string().optional(),
+  resourceId: z.string().optional(),
+  ipAddress: z.string().optional(),
+  userAgent: z.string().optional(),
+  search: z.string().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  sortBy: z.enum(['created_at', 'action', 'status']).default('created_at'),
+  sortOrder: z.enum(['asc', 'desc']).default('desc'),
+});
+
+export async function GET(req: NextRequest) {
+  const user = await getUserFromRequest(req);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const raw = Object.fromEntries(new URL(req.url).searchParams.entries());
+  const result = querySchema.safeParse({
+    ...raw,
+    page: raw.page ? parseInt(raw.page) : undefined,
+    limit: raw.limit ? parseInt(raw.limit) : undefined,
+  });
+
+  if (!result.success) {
+    return NextResponse.json(
+      { error: 'Invalid query parameters', details: result.error.errors },
+      { status: 400 }
+    );
+  }
+
+  const { userId, page, limit, ...filters } = result.data;
+  const targetUserId = userId ?? user.id;
+
+  if (userId && userId !== user.id) {
+    const allowed = await hasPermission(user.id, 'VIEW_ALL_USER_ACTION_LOGS');
+    if (!allowed) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+  }
+
+  const service = getApiAuditService();
+  const { logs, count } = await service.getLogs({
+    ...filters,
+    page,
+    limit,
+    userId: targetUserId,
+  });
+
+  return NextResponse.json({
+    logs,
+    pagination: {
+      page,
+      limit,
+      total: count,
+      totalPages: Math.ceil(count / limit),
+    },
+  });
+}

--- a/docs/Project documentation/UserManagementModule_APIs_Services_Checklist.md
+++ b/docs/Project documentation/UserManagementModule_APIs_Services_Checklist.md
@@ -154,12 +154,12 @@
 ## 10. Audit Logging
 
 **API Endpoints:**
-- [ ] `/api/audit` (GET)
+- [x] `/api/audit` (GET)
 
 **Core Implementation:**
-- [ ] `AuditService`
-- [ ] `auditServiceFactory`
-- [ ] `AuditDataProvider`
+- [x] `AuditService`
+- [x] `auditServiceFactory`
+- [x] `AuditDataProvider`
 
 ---
 


### PR DESCRIPTION
## Summary
- implement `/api/audit` route for retrieving audit logs
- add unit tests for the new route
- mark Audit Logging section in checklist as complete

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*