### PR TITLE
Add consent API endpoints and services

### DIFF
--- a/app/api/consent/route.ts
+++ b/app/api/consent/route.ts
@@ -1,0 +1,62 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { getServiceSupabase } from '@/lib/database/supabase';
+import { getApiConsentService } from '@/services/consent/factory';
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+  const token = authHeader.split(' ')[1];
+  const supabaseService = getServiceSupabase();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabaseService.auth.getUser(token);
+
+  if (userError || !user) {
+    return NextResponse.json({ error: userError?.message || 'Invalid token' }, { status: 401 });
+  }
+
+  const consentService = getApiConsentService();
+  const consent = await consentService.getUserConsent(user.id);
+  if (!consent) {
+    return NextResponse.json({ error: 'Consent not found' }, { status: 404 });
+  }
+  return NextResponse.json(consent);
+}
+
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+  const token = authHeader.split(' ')[1];
+  const supabaseService = getServiceSupabase();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabaseService.auth.getUser(token);
+
+  if (userError || !user) {
+    return NextResponse.json({ error: userError?.message || 'Invalid token' }, { status: 401 });
+  }
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  if (typeof body.marketing !== 'boolean') {
+    return NextResponse.json({ error: 'Missing marketing field' }, { status: 400 });
+  }
+
+  const consentService = getApiConsentService();
+  const result = await consentService.updateUserConsent(user.id, { marketing: body.marketing });
+  if (!result.success || !result.consent) {
+    return NextResponse.json({ error: result.error || 'Failed to save consent' }, { status: 500 });
+  }
+  return NextResponse.json(result.consent);
+}

--- a/docs/Project documentation/UserManagementModule_APIs_Services_Checklist.md
+++ b/docs/Project documentation/UserManagementModule_APIs_Services_Checklist.md
@@ -179,14 +179,14 @@
 ## 12. Compliance & Legal
 
 **API Endpoints:**
-- [ ] `/api/gdpr/export` (POST)
-- [ ] `/api/gdpr/delete` (POST)
-- [ ] `/api/consent` (GET, POST)
+- [x] `/api/gdpr/export` (POST)
+- [x] `/api/gdpr/delete` (POST)
+- [x] `/api/consent` (GET, POST)
 
 **Core Implementation:**
-- [ ] `GdprService`, `ConsentService`
-- [ ] `gdprServiceFactory`, `consentServiceFactory`
-- [ ] `GdprDataProvider`, `ConsentDataProvider`
+- [x] `GdprService`, `ConsentService`
+- [x] `gdprServiceFactory`, `consentServiceFactory`
+- [x] `GdprDataProvider`, `ConsentDataProvider`
 
 ---
 

--- a/src/adapters/consent/factory.ts
+++ b/src/adapters/consent/factory.ts
@@ -1,0 +1,24 @@
+import type { IConsentDataProvider } from '@/core/consent/IConsentDataProvider';
+import { SupabaseConsentProvider } from './supabase/supabase-consent.provider';
+
+export function createSupabaseConsentProvider(options: {
+  supabaseUrl: string;
+  supabaseKey: string;
+  [key: string]: any;
+}): IConsentDataProvider {
+  return new SupabaseConsentProvider(options.supabaseUrl, options.supabaseKey);
+}
+
+export function createConsentProvider(config: {
+  type: 'supabase' | string;
+  options: Record<string, any>;
+}): IConsentDataProvider {
+  switch (config.type) {
+    case 'supabase':
+      return createSupabaseConsentProvider(config.options);
+    default:
+      throw new Error(`Unsupported consent provider type: ${config.type}`);
+  }
+}
+
+export default createSupabaseConsentProvider;

--- a/src/adapters/consent/index.ts
+++ b/src/adapters/consent/index.ts
@@ -1,0 +1,3 @@
+export * from '@/core/consent/IConsentDataProvider';
+export * from './factory';
+export * from './supabase/supabase-consent.provider';

--- a/src/adapters/consent/supabase/supabase-consent.provider.ts
+++ b/src/adapters/consent/supabase/supabase-consent.provider.ts
@@ -1,0 +1,61 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import type { IConsentDataProvider } from '@/core/consent/IConsentDataProvider';
+import type { UserConsent, ConsentUpdatePayload } from '@/core/consent/models';
+
+export class SupabaseConsentProvider implements IConsentDataProvider {
+  private supabase: SupabaseClient;
+
+  constructor(private supabaseUrl: string, private supabaseKey: string) {
+    this.supabase = createClient(supabaseUrl, supabaseKey);
+  }
+
+  async getUserConsent(userId: string): Promise<UserConsent | null> {
+    const { data, error } = await this.supabase
+      .from('user_consents')
+      .select('*')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error || !data) {
+      return null;
+    }
+
+    return {
+      userId: data.user_id,
+      marketing: data.marketing,
+      updatedAt: data.updated_at,
+    };
+  }
+
+  async saveUserConsent(
+    userId: string,
+    payload: ConsentUpdatePayload
+  ): Promise<{ success: boolean; consent?: UserConsent; error?: string }> {
+    const record = {
+      user_id: userId,
+      marketing: payload.marketing,
+      updated_at: new Date().toISOString(),
+    };
+
+    const { data, error } = await this.supabase
+      .from('user_consents')
+      .upsert(record, { onConflict: 'user_id' })
+      .select()
+      .single();
+
+    if (error || !data) {
+      return { success: false, error: error?.message || 'Failed to save consent' };
+    }
+
+    return {
+      success: true,
+      consent: {
+        userId: data.user_id,
+        marketing: data.marketing,
+        updatedAt: data.updated_at,
+      },
+    };
+  }
+}
+
+export default SupabaseConsentProvider;

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -14,6 +14,7 @@ export * from './sso';
 export * from './api-keys';
 export * from './notification';
 export * from './gdpr';
+export * from './consent';
 export * from './session';
 export * from './subscription';
 export * from './csrf';

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -12,6 +12,7 @@ import { UserDataProvider } from '@/core/user/IUserDataProvider';
 import { TeamDataProvider } from '@/core/team/ITeamDataProvider';
 import { PermissionDataProvider } from '@/core/permission/IPermissionDataProvider';
 import { GdprDataProvider } from '@/core/gdpr/IGdprDataProvider';
+import { IConsentDataProvider } from '@/core/consent/IConsentDataProvider';
 import { SessionDataProvider } from '@/core/session/ISessionDataProvider';
 import { SsoDataProvider } from '@/core/sso/ISsoDataProvider';
 import { SubscriptionDataProvider } from '@/core/subscription/ISubscriptionDataProvider';
@@ -56,6 +57,11 @@ export interface AdapterFactory {
    * Create a GDPR data provider
    */
   createGdprProvider?(): GdprDataProvider;
+
+  /**
+   * Create a consent data provider
+   */
+  createConsentProvider?(): IConsentDataProvider;
 
   /**
    * Create a session data provider

--- a/src/adapters/supabase-factory.ts
+++ b/src/adapters/supabase-factory.ts
@@ -12,6 +12,7 @@ import { UserDataProvider } from './user/interfaces';
 import { TeamDataProvider } from './team/interfaces';
 import { PermissionDataProvider } from './permission/interfaces';
 import { GdprDataProvider } from './gdpr/interfaces';
+import { IConsentDataProvider } from './consent/IConsentDataProvider';
 import { SessionDataProvider } from './session/interfaces';
 import { SsoDataProvider } from './sso/interfaces';
 import { SubscriptionDataProvider } from './subscription/interfaces';
@@ -25,6 +26,7 @@ import createSupabaseUserProvider from './user/supabase/factory';
 import createSupabaseTeamProvider from './team/supabase/factory';
 import createSupabasePermissionProvider from './permission/supabase/factory';
 import createSupabaseGdprProvider from './gdpr/factory';
+import createSupabaseConsentProvider from './consent/factory';
 import { createSupabaseSessionProvider } from './session/factory';
 import createSupabaseSsoProvider from './sso/supabase/factory';
 import createSupabaseSubscriptionProvider from './subscription/factory';
@@ -92,6 +94,13 @@ export class SupabaseAdapterFactory implements AdapterFactory {
    */
   createGdprProvider(): GdprDataProvider {
     return createSupabaseGdprProvider(this.options);
+  }
+
+  /**
+   * Create a Supabase consent provider
+   */
+  createConsentProvider(): IConsentDataProvider {
+    return createSupabaseConsentProvider(this.options);
   }
 
   /**

--- a/src/core/consent/IConsentDataProvider.ts
+++ b/src/core/consent/IConsentDataProvider.ts
@@ -1,0 +1,9 @@
+import type { UserConsent, ConsentUpdatePayload } from './models';
+
+export interface IConsentDataProvider {
+  getUserConsent(userId: string): Promise<UserConsent | null>;
+  saveUserConsent(
+    userId: string,
+    payload: ConsentUpdatePayload
+  ): Promise<{ success: boolean; consent?: UserConsent; error?: string }>;
+}

--- a/src/core/consent/index.ts
+++ b/src/core/consent/index.ts
@@ -1,0 +1,3 @@
+export * from './interfaces';
+export * from './IConsentDataProvider';
+export * from './models';

--- a/src/core/consent/interfaces.ts
+++ b/src/core/consent/interfaces.ts
@@ -1,0 +1,9 @@
+import type { UserConsent, ConsentUpdatePayload } from './models';
+
+export interface ConsentService {
+  getUserConsent(userId: string): Promise<UserConsent | null>;
+  updateUserConsent(
+    userId: string,
+    payload: ConsentUpdatePayload
+  ): Promise<{ success: boolean; consent?: UserConsent; error?: string }>;
+}

--- a/src/core/consent/models.ts
+++ b/src/core/consent/models.ts
@@ -1,0 +1,9 @@
+export interface UserConsent {
+  userId: string;
+  marketing: boolean;
+  updatedAt: string;
+}
+
+export interface ConsentUpdatePayload {
+  marketing: boolean;
+}

--- a/src/services/consent/__tests__/factory.test.ts
+++ b/src/services/consent/__tests__/factory.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AdapterRegistry } from '@/adapters/registry';
+import { UserManagementConfiguration } from '@/core/config';
+
+let getApiConsentService: typeof import('../factory').getApiConsentService;
+let DefaultConsentService: typeof import('../default-consent.service').DefaultConsentService;
+
+describe('getApiConsentService', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    (AdapterRegistry as any).instance = null;
+    UserManagementConfiguration.reset();
+    ({ getApiConsentService } = await import('../factory'));
+    ({ DefaultConsentService } = await import('../default-consent.service'));
+  });
+
+  it('returns configured service if registered', () => {
+    const svc = {} as any;
+    UserManagementConfiguration.configureServiceProviders({ consentService: svc });
+    expect(getApiConsentService()).toBe(svc);
+    expect(getApiConsentService()).toBe(svc);
+  });
+
+  it('creates default service with adapter when not configured', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('consent', adapter);
+    const service = getApiConsentService();
+    expect(service).toBeInstanceOf(DefaultConsentService);
+    expect(getApiConsentService()).toBe(service);
+  });
+});

--- a/src/services/consent/default-consent.service.ts
+++ b/src/services/consent/default-consent.service.ts
@@ -1,0 +1,18 @@
+import { ConsentService } from '@/core/consent/interfaces';
+import type { IConsentDataProvider } from '@/core/consent/IConsentDataProvider';
+import type { ConsentUpdatePayload, UserConsent } from '@/core/consent/models';
+
+export class DefaultConsentService implements ConsentService {
+  constructor(private provider: IConsentDataProvider) {}
+
+  getUserConsent(userId: string): Promise<UserConsent | null> {
+    return this.provider.getUserConsent(userId);
+  }
+
+  updateUserConsent(
+    userId: string,
+    payload: ConsentUpdatePayload
+  ): Promise<{ success: boolean; consent?: UserConsent; error?: string }> {
+    return this.provider.saveUserConsent(userId, payload);
+  }
+}

--- a/src/services/consent/factory.ts
+++ b/src/services/consent/factory.ts
@@ -1,0 +1,18 @@
+import { ConsentService } from '@/core/consent/interfaces';
+import { UserManagementConfiguration } from '@/core/config';
+import type { IConsentDataProvider } from '@/core/consent';
+import { AdapterRegistry } from '@/adapters/registry';
+import { DefaultConsentService } from './default-consent.service';
+
+let consentServiceInstance: ConsentService | null = null;
+
+export function getApiConsentService(): ConsentService {
+  if (!consentServiceInstance) {
+    consentServiceInstance = UserManagementConfiguration.getServiceProvider('consentService') as ConsentService | undefined;
+    if (!consentServiceInstance) {
+      const provider = AdapterRegistry.getInstance().getAdapter<IConsentDataProvider>('consent');
+      consentServiceInstance = new DefaultConsentService(provider);
+    }
+  }
+  return consentServiceInstance;
+}


### PR DESCRIPTION
## Summary
- implement ConsentService with pluggable provider
- add SupabaseConsentProvider and adapter factory support
- expose consent adapter from central registry
- create `/api/consent` GET and POST route
- mark Compliance & Legal endpoints as implemented

## Testing
- `npm run lint`