### PR TITLE
Add missing authentication endpoints

### DIFF
--- a/app/api/auth/delete-account/__tests__/route.test.ts
+++ b/app/api/auth/delete-account/__tests__/route.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DELETE } from '../route';
+import { getApiAuthService } from '@/services/auth/factory';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+
+vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
+vi.mock('@/middleware/with-auth-rate-limit', () => ({
+  withAuthRateLimit: vi.fn((_req, handler) => handler(_req))
+}));
+vi.mock('@/middleware/with-security', () => ({
+  withSecurity: (handler: any) => handler
+}));
+
+describe('DELETE /api/auth/delete-account', () => {
+  const mockAuthService = { deleteAccount: vi.fn() };
+  const createRequest = (password?: string) => new Request('http://localhost/api/auth/delete-account', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: password ? JSON.stringify({ password }) : undefined
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    mockAuthService.deleteAccount.mockResolvedValue(undefined);
+  });
+
+  it('returns 400 when password missing', async () => {
+    const res = await DELETE(createRequest() as any);
+    expect(res.status).toBe(400);
+  });
+
+  it('calls service and returns success', async () => {
+    const res = await DELETE(createRequest('pass') as any);
+    expect(res.status).toBe(200);
+    expect(mockAuthService.deleteAccount).toHaveBeenCalledWith('pass');
+  });
+});

--- a/app/api/auth/delete-account/route.ts
+++ b/app/api/auth/delete-account/route.ts
@@ -1,0 +1,60 @@
+import { type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+import { getApiAuthService } from '@/services/auth/factory';
+import { logUserAction } from '@/lib/audit/auditLogger';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+  withValidation,
+  ApiError,
+  ERROR_CODES
+} from '@/lib/api/common';
+
+const DeleteAccountSchema = z.object({ password: z.string().min(1) });
+
+async function handleDeleteAccount(
+  req: NextRequest,
+  data: z.infer<typeof DeleteAccountSchema>
+) {
+  const ipAddress = req.headers.get('x-forwarded-for') || 'unknown';
+  const userAgent = req.headers.get('user-agent') || 'unknown';
+  try {
+    const authService = getApiAuthService();
+    await authService.deleteAccount(data.password);
+    await logUserAction({
+      action: 'ACCOUNT_DELETED',
+      status: 'SUCCESS',
+      ipAddress,
+      userAgent,
+      targetResourceType: 'auth'
+    });
+    return createSuccessResponse({ message: 'Account successfully deleted' });
+  } catch (error) {
+    await logUserAction({
+      action: 'ACCOUNT_DELETE_FAILED',
+      status: 'FAILURE',
+      ipAddress,
+      userAgent,
+      targetResourceType: 'auth',
+      details: { error: error instanceof Error ? error.message : String(error) }
+    });
+    throw new ApiError(
+      ERROR_CODES.INTERNAL_ERROR,
+      error instanceof Error ? error.message : 'Account deletion failed',
+      500
+    );
+  }
+}
+
+async function handler(req: NextRequest) {
+  return withErrorHandling(
+    async (r) => withValidation(DeleteAccountSchema, handleDeleteAccount, r),
+    req
+  );
+}
+
+export const DELETE = withSecurity(async (request: NextRequest) =>
+  withAuthRateLimit(request, handler)
+);

--- a/app/api/auth/disable-mfa/__tests__/route.test.ts
+++ b/app/api/auth/disable-mfa/__tests__/route.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+import { getApiAuthService } from '@/services/auth/factory';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+
+vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
+vi.mock('@/middleware/with-auth-rate-limit', () => ({
+  withAuthRateLimit: vi.fn((_req, handler) => handler(_req))
+}));
+vi.mock('@/middleware/with-security', () => ({
+  withSecurity: (handler: any) => handler
+}));
+
+describe('POST /api/auth/disable-mfa', () => {
+  const mockAuthService = { disableMFA: vi.fn() };
+  const createRequest = (code?: string) => new Request('http://localhost/api/auth/disable-mfa', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: code ? JSON.stringify({ code }) : undefined
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    mockAuthService.disableMFA.mockResolvedValue({ success: true });
+  });
+
+  it('returns 400 when code missing', async () => {
+    const res = await POST(createRequest() as any);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns success when MFA disabled', async () => {
+    const res = await POST(createRequest('123') as any);
+    expect(res.status).toBe(200);
+    expect(mockAuthService.disableMFA).toHaveBeenCalledWith('123');
+  });
+});

--- a/app/api/auth/disable-mfa/route.ts
+++ b/app/api/auth/disable-mfa/route.ts
@@ -1,0 +1,54 @@
+import { type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+import { getApiAuthService } from '@/services/auth/factory';
+import { logUserAction } from '@/lib/audit/auditLogger';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+  withValidation,
+  ApiError,
+  ERROR_CODES
+} from '@/lib/api/common';
+
+const DisableMfaSchema = z.object({ code: z.string().min(4) });
+
+async function handleDisableMfa(
+  req: NextRequest,
+  data: z.infer<typeof DisableMfaSchema>
+) {
+  const ipAddress = req.headers.get('x-forwarded-for') || 'unknown';
+  const userAgent = req.headers.get('user-agent') || 'unknown';
+  const authService = getApiAuthService();
+  const result = await authService.disableMFA(data.code);
+
+  await logUserAction({
+    action: 'MFA_DISABLE',
+    status: result.success ? 'SUCCESS' : 'FAILURE',
+    ipAddress,
+    userAgent,
+    targetResourceType: 'auth'
+  });
+
+  if (!result.success) {
+    throw new ApiError(
+      ERROR_CODES.INVALID_REQUEST,
+      result.error || 'MFA disable failed',
+      400
+    );
+  }
+
+  return createSuccessResponse(result);
+}
+
+async function handler(req: NextRequest) {
+  return withErrorHandling(
+    async (r) => withValidation(DisableMfaSchema, handleDisableMfa, r),
+    req
+  );
+}
+
+export const POST = withSecurity(async (request: NextRequest) =>
+  withAuthRateLimit(request, handler)
+);

--- a/app/api/auth/mfa/disable/__tests__/route.test.ts
+++ b/app/api/auth/mfa/disable/__tests__/route.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+import { getApiAuthService } from '@/services/auth/factory';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+
+vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
+vi.mock('@/middleware/with-auth-rate-limit', () => ({
+  withAuthRateLimit: vi.fn((_req, handler) => handler(_req))
+}));
+vi.mock('@/middleware/with-security', () => ({
+  withSecurity: (handler: any) => handler
+}));
+
+describe('POST /api/auth/mfa/disable', () => {
+  const mockAuthService = { disableMFA: vi.fn() };
+  const createRequest = (code?: string) => new Request('http://localhost/api/auth/mfa/disable', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: code ? JSON.stringify({ code }) : undefined
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    mockAuthService.disableMFA.mockResolvedValue({ success: true });
+  });
+
+  it('returns 400 when code missing', async () => {
+    const res = await POST(createRequest() as any);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns success when MFA disabled', async () => {
+    const res = await POST(createRequest('123') as any);
+    expect(res.status).toBe(200);
+  });
+});

--- a/app/api/auth/mfa/disable/route.ts
+++ b/app/api/auth/mfa/disable/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+import { getApiAuthService } from '@/services/auth/factory';
+import { createSuccessResponse, withErrorHandling, withValidation, ApiError, ERROR_CODES } from '@/lib/api/common';
+
+const DisableSchema = z.object({ code: z.string().min(4) });
+
+async function handleDisable(req: NextRequest, data: z.infer<typeof DisableSchema>) {
+  const authService = getApiAuthService();
+  const result = await authService.disableMFA(data.code);
+  if (!result.success) {
+    throw new ApiError(ERROR_CODES.INVALID_REQUEST, result.error || 'MFA disable failed', 400);
+  }
+  return createSuccessResponse(result);
+}
+
+async function handler(req: NextRequest) {
+  return withErrorHandling(async r => withValidation(DisableSchema, handleDisable, r), req);
+}
+
+export const POST = withSecurity(async (request: NextRequest) =>
+  withAuthRateLimit(request, handler)
+);

--- a/app/api/auth/mfa/enable/__tests__/route.test.ts
+++ b/app/api/auth/mfa/enable/__tests__/route.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+import { getApiAuthService } from '@/services/auth/factory';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+
+vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
+vi.mock('@/middleware/with-auth-rate-limit', () => ({
+  withAuthRateLimit: vi.fn((_req, handler) => handler(_req))
+}));
+vi.mock('@/middleware/with-security', () => ({
+  withSecurity: (handler: any) => handler
+}));
+
+describe('POST /api/auth/mfa/enable', () => {
+  const mockAuthService = { setupMFA: vi.fn() };
+  const createRequest = () => new Request('http://localhost/api/auth/mfa/enable', { method: 'POST' });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    mockAuthService.setupMFA.mockResolvedValue({ success: true });
+  });
+
+  it('returns success when MFA enabled', async () => {
+    const res = await POST(createRequest() as any);
+    expect(res.status).toBe(200);
+  });
+});

--- a/app/api/auth/mfa/enable/route.ts
+++ b/app/api/auth/mfa/enable/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest } from 'next/server';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+import { getApiAuthService } from '@/services/auth/factory';
+import { createSuccessResponse, withErrorHandling, ApiError, ERROR_CODES } from '@/lib/api/common';
+
+async function handleEnableMfa(req: NextRequest) {
+  const authService = getApiAuthService();
+  const result = await authService.setupMFA();
+  if (!result.success) {
+    throw new ApiError(ERROR_CODES.INVALID_REQUEST, result.error || 'MFA setup failed', 400);
+  }
+  return createSuccessResponse(result);
+}
+
+async function handler(req: NextRequest) {
+  return withErrorHandling(handleEnableMfa, req);
+}
+
+export const POST = withSecurity(async (request: NextRequest) =>
+  withAuthRateLimit(request, handler)
+);

--- a/app/api/auth/refresh-token/__tests__/route.test.ts
+++ b/app/api/auth/refresh-token/__tests__/route.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+import { getApiAuthService } from '@/services/auth/factory';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+
+vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
+vi.mock('@/middleware/with-auth-rate-limit', () => ({
+  withAuthRateLimit: vi.fn((_req, handler) => handler(_req))
+}));
+vi.mock('@/middleware/with-security', () => ({
+  withSecurity: (handler: any) => handler
+}));
+
+describe('POST /api/auth/refresh-token', () => {
+  const mockAuthService = { refreshToken: vi.fn() };
+  const createRequest = () => new Request('http://localhost/api/auth/refresh-token', { method: 'POST' });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    mockAuthService.refreshToken.mockResolvedValue(true);
+  });
+
+  it('returns success when token is refreshed', async () => {
+    const res = await POST(createRequest() as any);
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.data.success).toBe(true);
+    expect(mockAuthService.refreshToken).toHaveBeenCalled();
+  });
+
+  it('returns 401 when refresh fails', async () => {
+    mockAuthService.refreshToken.mockResolvedValue(false);
+    const res = await POST(createRequest() as any);
+    expect(res.status).toBe(401);
+  });
+});

--- a/app/api/auth/refresh-token/route.ts
+++ b/app/api/auth/refresh-token/route.ts
@@ -1,0 +1,41 @@
+import { type NextRequest } from 'next/server';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+import { getApiAuthService } from '@/services/auth/factory';
+import { logUserAction } from '@/lib/audit/auditLogger';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+  ApiError,
+  ERROR_CODES
+} from '@/lib/api/common';
+
+async function handleRefreshToken(req: NextRequest) {
+  const ipAddress = req.headers.get('x-forwarded-for') || 'unknown';
+  const userAgent = req.headers.get('user-agent') || 'unknown';
+  const authService = getApiAuthService();
+  const success = await authService.refreshToken();
+
+  await logUserAction({
+    action: 'TOKEN_REFRESH',
+    status: success ? 'SUCCESS' : 'FAILURE',
+    ipAddress,
+    userAgent,
+    targetResourceType: 'auth',
+    targetResourceId: 'current'
+  });
+
+  if (!success) {
+    throw new ApiError(ERROR_CODES.UNAUTHORIZED, 'Token refresh failed', 401);
+  }
+
+  return createSuccessResponse({ success: true });
+}
+
+async function handler(req: NextRequest) {
+  return withErrorHandling(handleRefreshToken, req);
+}
+
+export const POST = withSecurity(async (request: NextRequest) =>
+  withAuthRateLimit(request, handler)
+);

--- a/app/api/auth/setup-mfa/__tests__/route.test.ts
+++ b/app/api/auth/setup-mfa/__tests__/route.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+import { getApiAuthService } from '@/services/auth/factory';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+
+vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
+vi.mock('@/middleware/with-auth-rate-limit', () => ({
+  withAuthRateLimit: vi.fn((_req, handler) => handler(_req))
+}));
+vi.mock('@/middleware/with-security', () => ({
+  withSecurity: (handler: any) => handler
+}));
+
+describe('POST /api/auth/setup-mfa', () => {
+  const mockAuthService = { setupMFA: vi.fn() };
+  const createRequest = () => new Request('http://localhost/api/auth/setup-mfa', { method: 'POST' });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    mockAuthService.setupMFA.mockResolvedValue({ success: true });
+  });
+
+  it('returns success when MFA setup succeeds', async () => {
+    const res = await POST(createRequest() as any);
+    expect(res.status).toBe(200);
+    expect(mockAuthService.setupMFA).toHaveBeenCalled();
+  });
+
+  it('returns 400 when setup fails', async () => {
+    mockAuthService.setupMFA.mockResolvedValue({ success: false, error: 'fail' });
+    const res = await POST(createRequest() as any);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/auth/setup-mfa/route.ts
+++ b/app/api/auth/setup-mfa/route.ts
@@ -1,0 +1,44 @@
+import { type NextRequest } from 'next/server';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+import { getApiAuthService } from '@/services/auth/factory';
+import { logUserAction } from '@/lib/audit/auditLogger';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+  ApiError,
+  ERROR_CODES
+} from '@/lib/api/common';
+
+async function handleSetupMfa(req: NextRequest) {
+  const ipAddress = req.headers.get('x-forwarded-for') || 'unknown';
+  const userAgent = req.headers.get('user-agent') || 'unknown';
+  const authService = getApiAuthService();
+  const result = await authService.setupMFA();
+
+  await logUserAction({
+    action: 'MFA_SETUP',
+    status: result.success ? 'SUCCESS' : 'FAILURE',
+    ipAddress,
+    userAgent,
+    targetResourceType: 'auth'
+  });
+
+  if (!result.success) {
+    throw new ApiError(
+      ERROR_CODES.INVALID_REQUEST,
+      result.error || 'MFA setup failed',
+      400
+    );
+  }
+
+  return createSuccessResponse(result);
+}
+
+async function handler(req: NextRequest) {
+  return withErrorHandling(handleSetupMfa, req);
+}
+
+export const POST = withSecurity(async (request: NextRequest) =>
+  withAuthRateLimit(request, handler)
+);

--- a/app/api/auth/verify-email/__tests__/route.test.ts
+++ b/app/api/auth/verify-email/__tests__/route.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+import { getApiAuthService } from '@/services/auth/factory';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+
+vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
+vi.mock('@/middleware/with-auth-rate-limit', () => ({
+  withAuthRateLimit: vi.fn((_req, handler) => handler(_req))
+}));
+vi.mock('@/middleware/with-security', () => ({
+  withSecurity: (handler: any) => handler
+}));
+
+describe('POST /api/auth/verify-email', () => {
+  const mockAuthService = { verifyEmail: vi.fn() };
+  const createRequest = (token?: string) => new Request('http://localhost/api/auth/verify-email', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: token ? JSON.stringify({ token }) : undefined
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    mockAuthService.verifyEmail.mockResolvedValue(undefined);
+  });
+
+  it('returns 400 when body is missing', async () => {
+    const res = await POST(createRequest() as any);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns success when verification succeeds', async () => {
+    const res = await POST(createRequest('abc') as any);
+    expect(res.status).toBe(200);
+    expect(mockAuthService.verifyEmail).toHaveBeenCalledWith('abc');
+  });
+});

--- a/app/api/auth/verify-email/route.ts
+++ b/app/api/auth/verify-email/route.ts
@@ -1,0 +1,60 @@
+import { type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+import { getApiAuthService } from '@/services/auth/factory';
+import { logUserAction } from '@/lib/audit/auditLogger';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+  withValidation,
+  ApiError,
+  ERROR_CODES
+} from '@/lib/api/common';
+
+const VerifyEmailSchema = z.object({ token: z.string().min(1) });
+
+async function handleVerifyEmail(
+  req: NextRequest,
+  data: z.infer<typeof VerifyEmailSchema>
+) {
+  const ipAddress = req.headers.get('x-forwarded-for') || 'unknown';
+  const userAgent = req.headers.get('user-agent') || 'unknown';
+  try {
+    const authService = getApiAuthService();
+    await authService.verifyEmail(data.token);
+    await logUserAction({
+      action: 'EMAIL_VERIFIED',
+      status: 'SUCCESS',
+      ipAddress,
+      userAgent,
+      targetResourceType: 'auth'
+    });
+    return createSuccessResponse({ message: 'Email verified successfully' });
+  } catch (error) {
+    await logUserAction({
+      action: 'EMAIL_VERIFICATION_FAILED',
+      status: 'FAILURE',
+      ipAddress,
+      userAgent,
+      targetResourceType: 'auth',
+      details: { error: error instanceof Error ? error.message : String(error) }
+    });
+    throw new ApiError(
+      ERROR_CODES.INTERNAL_ERROR,
+      error instanceof Error ? error.message : 'Verification failed',
+      500
+    );
+  }
+}
+
+async function handler(req: NextRequest) {
+  return withErrorHandling(
+    async (r) => withValidation(VerifyEmailSchema, handleVerifyEmail, r),
+    req
+  );
+}
+
+export const POST = withSecurity(async (request: NextRequest) =>
+  withAuthRateLimit(request, handler)
+);

--- a/app/api/auth/verify-mfa/__tests__/route.test.ts
+++ b/app/api/auth/verify-mfa/__tests__/route.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+import { getApiAuthService } from '@/services/auth/factory';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+
+vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
+vi.mock('@/middleware/with-auth-rate-limit', () => ({
+  withAuthRateLimit: vi.fn((_req, handler) => handler(_req))
+}));
+vi.mock('@/middleware/with-security', () => ({
+  withSecurity: (handler: any) => handler
+}));
+
+describe('POST /api/auth/verify-mfa', () => {
+  const mockAuthService = { verifyMFA: vi.fn() };
+  const createRequest = (code?: string) => new Request('http://localhost/api/auth/verify-mfa', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: code ? JSON.stringify({ code }) : undefined
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    mockAuthService.verifyMFA.mockResolvedValue({ success: true });
+  });
+
+  it('returns 400 when code missing', async () => {
+    const res = await POST(createRequest() as any);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns success when verification succeeds', async () => {
+    const res = await POST(createRequest('123') as any);
+    expect(res.status).toBe(200);
+    expect(mockAuthService.verifyMFA).toHaveBeenCalledWith('123');
+  });
+
+  it('returns 400 when verification fails', async () => {
+    mockAuthService.verifyMFA.mockResolvedValue({ success: false, error: 'err' });
+    const res = await POST(createRequest('123') as any);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/auth/verify-mfa/route.ts
+++ b/app/api/auth/verify-mfa/route.ts
@@ -1,0 +1,54 @@
+import { type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+import { getApiAuthService } from '@/services/auth/factory';
+import { logUserAction } from '@/lib/audit/auditLogger';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+  withValidation,
+  ApiError,
+  ERROR_CODES
+} from '@/lib/api/common';
+
+const VerifyMfaSchema = z.object({ code: z.string().min(4) });
+
+async function handleVerifyMfa(
+  req: NextRequest,
+  data: z.infer<typeof VerifyMfaSchema>
+) {
+  const ipAddress = req.headers.get('x-forwarded-for') || 'unknown';
+  const userAgent = req.headers.get('user-agent') || 'unknown';
+  const authService = getApiAuthService();
+  const result = await authService.verifyMFA(data.code);
+
+  await logUserAction({
+    action: 'MFA_VERIFY',
+    status: result.success ? 'SUCCESS' : 'FAILURE',
+    ipAddress,
+    userAgent,
+    targetResourceType: 'auth'
+  });
+
+  if (!result.success) {
+    throw new ApiError(
+      ERROR_CODES.INVALID_REQUEST,
+      result.error || 'MFA verification failed',
+      400
+    );
+  }
+
+  return createSuccessResponse(result);
+}
+
+async function handler(req: NextRequest) {
+  return withErrorHandling(
+    async (r) => withValidation(VerifyMfaSchema, handleVerifyMfa, r),
+    req
+  );
+}
+
+export const POST = withSecurity(async (request: NextRequest) =>
+  withAuthRateLimit(request, handler)
+);

--- a/docs/Project documentation/UserManagementModule_APIs_Services_Checklist.md
+++ b/docs/Project documentation/UserManagementModule_APIs_Services_Checklist.md
@@ -26,26 +26,20 @@ This checklist tracks the existence of API endpoints for the User Management Mod
 ## 1. Authentication
 
 **API Endpoints:**
-- [ ] `/api/auth/login`
-- [ ] `/api/auth/register`
-- [ ] `/api/auth/logout`
-- [ ] `/api/auth/refresh-token`
-- [ ] `/api/auth/send-verification-email`
-- [ ] `/api/auth/verify-email`
-- [ ] `/api/auth/reset-password`
-- [ ] `/api/auth/update-password`
-- [ ] `/api/auth/delete-account`
-- [ ] `/api/auth/setup-mfa`
-- [ ] `/api/auth/verify-mfa`
-- [ ] `/api/auth/disable-mfa`
-- [ ] | `/api/auth/refresh-token` | _(missing)_ | ❌ |
-| `/api/auth/verify-email` | _(missing)_ | ❌ |
-| `/api/auth/delete-account` | _(missing)_ | ❌ |
-| `/api/auth/setup-mfa` | _(missing)_ | ❌ |
-| `/api/auth/verify-mfa` | _(missing)_ | ❌ |
-| `/api/auth/disable-mfa` | _(missing)_ | ❌ |
-| `/api/auth/mfa/enable` | _(missing)_ | ❌ |
-| `/api/auth/mfa/disable` | _(missing)_ | ❌ |
+- [x] `/api/auth/login`
+- [x] `/api/auth/register`
+- [x] `/api/auth/logout`
+- [x] `/api/auth/refresh-token`
+- [x] `/api/auth/send-verification-email`
+- [x] `/api/auth/verify-email`
+- [x] `/api/auth/reset-password`
+- [x] `/api/auth/update-password`
+- [x] `/api/auth/delete-account`
+- [x] `/api/auth/setup-mfa`
+- [x] `/api/auth/verify-mfa`
+- [x] `/api/auth/disable-mfa`
+- [x] `/api/auth/mfa/enable`
+- [x] `/api/auth/mfa/disable`
 
 **Core Implementation:**
 - [ ] `AuthService` (interface & implementation)


### PR DESCRIPTION
## Summary
- add refresh-token, verify-email, delete-account, MFA endpoints
- add matching tests for the new endpoints
- update APIs checklist to mark endpoints present

## Testing
- `npx vitest run --coverage` *(fails: [see logs](https://github.com/openai?tab=overview))*