### PR TITLE
Implement webhook trigger service

### DIFF
--- a/src/adapters/webhooks/__tests__/supabase-webhook-provider.test.ts
+++ b/src/adapters/webhooks/__tests__/supabase-webhook-provider.test.ts
@@ -44,6 +44,7 @@ describe('SupabaseWebhookProvider', () => {
       isActive: true
     });
     expect(result.success).toBe(true);
+    expect(result.webhook?.secret).toBeDefined();
   });
 
   it('updates a webhook', async () => {

--- a/src/adapters/webhooks/supabase/supabase-webhook.provider.ts
+++ b/src/adapters/webhooks/supabase/supabase-webhook.provider.ts
@@ -1,4 +1,5 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import * as crypto from 'crypto';
 import type { IWebhookDataProvider } from '@/core/webhooks/IWebhookDataProvider';
 import type {
   Webhook,
@@ -96,6 +97,8 @@ export class SupabaseWebhookProvider implements IWebhookDataProvider {
     userId: string,
     payload: WebhookCreatePayload
   ): Promise<{ success: boolean; webhook?: Webhook; error?: string }> {
+    const secret = crypto.randomBytes(32).toString('hex');
+
     const { data, error } = await this.supabase
       .from('webhooks')
       .insert({
@@ -103,7 +106,7 @@ export class SupabaseWebhookProvider implements IWebhookDataProvider {
         name: payload.name,
         url: payload.url,
         events: payload.events,
-        secret: '',
+        secret,
         is_active: payload.isActive ?? true,
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString()

--- a/src/services/webhooks/__tests__/webhook-service.test.ts
+++ b/src/services/webhooks/__tests__/webhook-service.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { WebhookService } from '../WebhookService';
+import type { IWebhookDataProvider } from '@/core/webhooks';
+
+(global as any).fetch = vi.fn();
+
+describe('WebhookService.triggerEvent', () => {
+  let provider: IWebhookDataProvider & Record<string, any>;
+  let service: WebhookService;
+
+  beforeEach(() => {
+    (global.fetch as any).mockReset();
+    provider = {
+      listWebhooks: vi.fn(),
+      getWebhook: vi.fn(),
+      createWebhook: vi.fn(),
+      updateWebhook: vi.fn(),
+      deleteWebhook: vi.fn(),
+      listDeliveries: vi.fn(),
+      recordDelivery: vi.fn(),
+    } as unknown as IWebhookDataProvider & Record<string, any>;
+    service = new WebhookService(provider);
+  });
+
+  it('sends events to user webhooks', async () => {
+    provider.listWebhooks.mockResolvedValueOnce([
+      { id: 'w1', url: 'https://a.com', secret: 's', events: ['e'], isActive: true },
+    ]);
+    provider.recordDelivery.mockResolvedValue(undefined);
+    (global.fetch as any).mockResolvedValue({ ok: true, status: 200, text: async () => 'ok' });
+
+    const deliveries = await service.triggerEvent('e', { id: 1 }, 'user-1');
+
+    expect(provider.listWebhooks).toHaveBeenCalledWith('user-1');
+    expect((global.fetch as any)).toHaveBeenCalledTimes(1);
+    expect(provider.recordDelivery).toHaveBeenCalled();
+    expect(deliveries[0].webhookId).toBe('w1');
+  });
+
+  it('returns empty array when userId is missing', async () => {
+    const deliveries = await service.triggerEvent('e', {});
+    expect(deliveries).toEqual([]);
+    expect(provider.listWebhooks).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- hook up WebhookService with webhook-sender
- generate webhook secret in Supabase provider
- ensure provider tests expect secret
- add unit tests for WebhookService

## Testing
- `npm test` *(fails: Authentication, OAuth and other unrelated tests)*