### PR TITLE
Add minimal organization service and API

### DIFF
--- a/app/api/organizations/__tests__/route.test.ts
+++ b/app/api/organizations/__tests__/route.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET, POST } from '../route';
+import { getApiOrganizationService } from '@/services/organization/factory';
+
+vi.mock('@/services/organization/factory', () => ({
+  getApiOrganizationService: vi.fn()
+}));
+
+describe('organizations API', () => {
+  const service = {
+    getUserOrganizations: vi.fn(async () => []),
+    createOrganization: vi.fn(async () => ({ success: true, organization: { id: 'o' } }))
+  } as any;
+
+  beforeEach(() => {
+    vi.mocked(getApiOrganizationService).mockReturnValue(service);
+    vi.clearAllMocks();
+  });
+
+  it('GET returns organizations', async () => {
+    const req = new NextRequest('http://test');
+    req.headers.set('x-user-id', 'u1');
+    const res = await GET(req as any);
+    expect(res.status).toBe(200);
+    expect(service.getUserOrganizations).toHaveBeenCalledWith('u1');
+  });
+
+  it('POST creates organization', async () => {
+    const req = new NextRequest('http://test', { method: 'POST', body: JSON.stringify({ name: 'Org' }) });
+    req.headers.set('x-user-id', 'u1');
+    (req as any).json = async () => ({ name: 'Org' });
+    const res = await POST(req as any);
+    expect(res.status).toBe(201);
+    expect(service.createOrganization).toHaveBeenCalled();
+  });
+});

--- a/app/api/organizations/route.ts
+++ b/app/api/organizations/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getApiOrganizationService } from '@/services/organization/factory';
+
+const CreateOrgSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional()
+});
+
+export async function GET(req: NextRequest) {
+  const userId = req.headers.get('x-user-id');
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const service = getApiOrganizationService();
+  const orgs = await service.getUserOrganizations(userId);
+  return NextResponse.json({ organizations: orgs });
+}
+
+export async function POST(req: NextRequest) {
+  const userId = req.headers.get('x-user-id');
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+  const parsed = CreateOrgSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.message }, { status: 400 });
+  }
+  const result = await getApiOrganizationService().createOrganization(userId, parsed.data);
+  if (!result.success || !result.organization) {
+    return NextResponse.json({ error: result.error || 'Failed to create organization' }, { status: 400 });
+  }
+  return NextResponse.json({ organization: result.organization }, { status: 201 });
+}

--- a/src/adapters/organization/factory.ts
+++ b/src/adapters/organization/factory.ts
@@ -1,0 +1,15 @@
+import type { IOrganizationDataProvider } from '@/core/organization/IOrganizationDataProvider';
+import { SupabaseOrganizationProvider } from './supabase-organization-provider';
+
+export function createSupabaseOrganizationProvider(url: string, key: string): IOrganizationDataProvider {
+  return new SupabaseOrganizationProvider(url, key);
+}
+
+export function createOrganizationProvider(config: { type: 'supabase' | string; options: Record<string, any> }): IOrganizationDataProvider {
+  switch (config.type) {
+    case 'supabase':
+      return createSupabaseOrganizationProvider(config.options.supabaseUrl, config.options.supabaseKey);
+    default:
+      throw new Error(`Unsupported organization provider type: ${config.type}`);
+  }
+}

--- a/src/adapters/organization/supabase-organization-provider.ts
+++ b/src/adapters/organization/supabase-organization-provider.ts
@@ -1,0 +1,75 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import type { IOrganizationDataProvider } from '@/core/organization/IOrganizationDataProvider';
+import type {
+  Organization,
+  OrganizationCreatePayload,
+  OrganizationUpdatePayload,
+  OrganizationResult
+} from '@/core/organization/models';
+
+export class SupabaseOrganizationProvider implements IOrganizationDataProvider {
+  private supabase: SupabaseClient;
+
+  constructor(url: string, key: string) {
+    this.supabase = createClient(url, key);
+  }
+
+  private map(record: any): Organization {
+    return {
+      id: record.id,
+      name: record.name,
+      description: record.description ?? undefined,
+      createdAt: new Date(record.created_at),
+      updatedAt: new Date(record.updated_at)
+    };
+  }
+
+  async createOrganization(ownerId: string, data: OrganizationCreatePayload): Promise<OrganizationResult> {
+    const { data: org, error } = await this.supabase
+      .from('organizations')
+      .insert({ name: data.name, description: data.description })
+      .select()
+      .single();
+    if (error || !org) {
+      return { success: false, error: error?.message || 'Failed to create organization' };
+    }
+    await this.supabase
+      .from('organization_members')
+      .insert({ organization_id: org.id, user_id: ownerId, role: 'owner', is_owner: true });
+    return { success: true, organization: this.map(org) };
+  }
+
+  async getOrganization(id: string): Promise<Organization | null> {
+    const { data, error } = await this.supabase.from('organizations').select('*').eq('id', id).single();
+    if (error || !data) return null;
+    return this.map(data);
+  }
+
+  async getUserOrganizations(userId: string): Promise<Organization[]> {
+    const { data, error } = await this.supabase
+      .from('organization_members')
+      .select('organizations(*)')
+      .eq('user_id', userId);
+    if (error || !data) return [];
+    return data.map((r: any) => this.map(r.organizations));
+  }
+
+  async updateOrganization(id: string, data: OrganizationUpdatePayload): Promise<OrganizationResult> {
+    const { data: org, error } = await this.supabase
+      .from('organizations')
+      .update({ name: data.name, description: data.description })
+      .eq('id', id)
+      .select()
+      .single();
+    if (error || !org) {
+      return { success: false, error: error?.message || 'Failed to update organization' };
+    }
+    return { success: true, organization: this.map(org) };
+  }
+
+  async deleteOrganization(id: string): Promise<{ success: boolean; error?: string }> {
+    const { error } = await this.supabase.from('organizations').delete().eq('id', id);
+    if (error) return { success: false, error: error.message };
+    return { success: true };
+  }
+}

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -18,6 +18,7 @@ import { SsoDataProvider } from '@/core/sso/ISsoDataProvider';
 import { SubscriptionDataProvider } from '@/core/subscription/ISubscriptionDataProvider';
 import { ApiKeyDataProvider } from '@/core/api-keys/IApiKeyDataProvider';
 import { IWebhookDataProvider } from '@/core/webhooks/IWebhookDataProvider';
+import { IOrganizationDataProvider } from '@/core/organization/IOrganizationDataProvider';
 
 
 /**
@@ -46,6 +47,11 @@ export interface AdapterFactory {
    * Create a team data provider
    */
   createTeamProvider(): TeamDataProvider;
+
+  /**
+   * Create an organization data provider
+   */
+  createOrganizationProvider?(): IOrganizationDataProvider;
 
   /**
    * Create a permission data provider

--- a/src/adapters/supabase-factory.ts
+++ b/src/adapters/supabase-factory.ts
@@ -18,12 +18,14 @@ import { SsoDataProvider } from './sso/interfaces';
 import { SubscriptionDataProvider } from './subscription/interfaces';
 import { ApiKeyDataProvider } from './api-keys/interfaces';
 import { IWebhookDataProvider } from './webhook/IWebhookDataProvider';
+import { IOrganizationDataProvider } from '@/core/organization/IOrganizationDataProvider';
 
 
 // Import domain-specific factories
 import createSupabaseAuthProvider from './auth/supabase/factory';
 import createSupabaseUserProvider from './user/supabase/factory';
 import createSupabaseTeamProvider from './team/supabase/factory';
+import { createSupabaseOrganizationProvider } from './organization/factory';
 import createSupabasePermissionProvider from './permission/supabase/factory';
 import createSupabaseGdprProvider from './gdpr/factory';
 import createSupabaseConsentProvider from './consent/factory';
@@ -79,6 +81,13 @@ export class SupabaseAdapterFactory implements AdapterFactory {
    */
   createTeamProvider(): TeamDataProvider {
     return createSupabaseTeamProvider(this.options);
+  }
+
+  /**
+   * Create a Supabase organization provider
+   */
+  createOrganizationProvider(): IOrganizationDataProvider {
+    return createSupabaseOrganizationProvider(this.options);
   }
 
   /**

--- a/src/core/initialization/initialize-adapters.ts
+++ b/src/core/initialization/initialize-adapters.ts
@@ -9,6 +9,7 @@ import { createAdapterFactory, validateAdapterConfig } from '@/core/config/adapt
 import { DefaultAuthService } from '@/services/auth/default-auth-service';
 import { DefaultUserService } from '@/services/user/default-user-service';
 import { DefaultTeamService } from '@/services/team/default-team-service';
+import { DefaultOrganizationService } from '@/services/organization/default-organization.service';
 import { DefaultPermissionService } from '@/services/permission/default-permission-service';
 import { DefaultGdprService } from '@/services/gdpr/default-gdpr.service';
 import { DefaultSsoService } from '@/services/sso/default-sso.service';
@@ -74,6 +75,7 @@ export function initializeAdapters(
     const authAdapter = factory.createAuthProvider();
     const userAdapter = factory.createUserProvider();
     const teamAdapter = factory.createTeamProvider();
+    const organizationAdapter = factory.createOrganizationProvider?.();
     const permissionAdapter = factory.createPermissionProvider();
     const gdprAdapter = factory.createGdprProvider?.();
     const ssoAdapter = factory.createSsoProvider();
@@ -82,6 +84,7 @@ export function initializeAdapters(
     registry.registerAdapter('auth', authAdapter);
     registry.registerAdapter('user', userAdapter);
     registry.registerAdapter('team', teamAdapter);
+    if (organizationAdapter) registry.registerAdapter('organization', organizationAdapter);
     registry.registerAdapter('permission', permissionAdapter);
     if (gdprAdapter) registry.registerAdapter('gdpr', gdprAdapter);
     registry.registerAdapter('sso', ssoAdapter);
@@ -90,6 +93,7 @@ export function initializeAdapters(
     const authService = new DefaultAuthService(authAdapter);
     const userService = new DefaultUserService(userAdapter);
     const teamService = new DefaultTeamService(teamAdapter);
+    const organizationService = organizationAdapter ? new DefaultOrganizationService(organizationAdapter) : undefined;
     const permissionService = new DefaultPermissionService(permissionAdapter);
     const gdprService = gdprAdapter ? new DefaultGdprService(gdprAdapter) : undefined;
     const ssoService = new DefaultSsoService(ssoAdapter);
@@ -98,6 +102,7 @@ export function initializeAdapters(
       authService,
       userService,
       teamService,
+      organizationService,
       permissionService,
       gdprService,
       ssoService,
@@ -105,6 +110,7 @@ export function initializeAdapters(
         authAdapter,
         userAdapter,
         teamAdapter,
+        organizationAdapter,
         permissionAdapter,
         gdprAdapter,
         ssoAdapter

--- a/src/core/organization/IOrganizationDataProvider.ts
+++ b/src/core/organization/IOrganizationDataProvider.ts
@@ -1,0 +1,14 @@
+import type {
+  Organization,
+  OrganizationCreatePayload,
+  OrganizationUpdatePayload,
+  OrganizationResult
+} from './models';
+
+export interface IOrganizationDataProvider {
+  createOrganization(ownerId: string, data: OrganizationCreatePayload): Promise<OrganizationResult>;
+  getOrganization(id: string): Promise<Organization | null>;
+  getUserOrganizations(userId: string): Promise<Organization[]>;
+  updateOrganization(id: string, data: OrganizationUpdatePayload): Promise<OrganizationResult>;
+  deleteOrganization(id: string): Promise<{ success: boolean; error?: string }>;
+}

--- a/src/core/organization/interfaces.ts
+++ b/src/core/organization/interfaces.ts
@@ -1,0 +1,14 @@
+import type {
+  Organization,
+  OrganizationCreatePayload,
+  OrganizationUpdatePayload,
+  OrganizationResult
+} from './models';
+
+export interface OrganizationService {
+  createOrganization(ownerId: string, data: OrganizationCreatePayload): Promise<OrganizationResult>;
+  getOrganization(id: string): Promise<Organization | null>;
+  getUserOrganizations(userId: string): Promise<Organization[]>;
+  updateOrganization(id: string, data: OrganizationUpdatePayload): Promise<OrganizationResult>;
+  deleteOrganization(id: string): Promise<{ success: boolean; error?: string }>;
+}

--- a/src/core/organization/models.ts
+++ b/src/core/organization/models.ts
@@ -1,0 +1,23 @@
+export interface Organization {
+  id: string;
+  name: string;
+  description?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface OrganizationCreatePayload {
+  name: string;
+  description?: string;
+}
+
+export interface OrganizationUpdatePayload {
+  name?: string;
+  description?: string;
+}
+
+export interface OrganizationResult {
+  success: boolean;
+  organization?: Organization;
+  error?: string;
+}

--- a/src/services/organization/__tests__/factory.test.ts
+++ b/src/services/organization/__tests__/factory.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AdapterRegistry } from '@/adapters/registry';
+import { getApiOrganizationService } from '../factory';
+import { DefaultOrganizationService } from '../default-organization.service';
+
+describe('getApiOrganizationService', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    (AdapterRegistry as any).instance = null;
+  });
+
+  it('returns new service instance using adapter from registry', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('organization', adapter);
+    const svc1 = getApiOrganizationService();
+    const svc2 = getApiOrganizationService();
+    expect(svc1).toBeInstanceOf(DefaultOrganizationService);
+    expect(svc2).toBeInstanceOf(DefaultOrganizationService);
+    expect(svc1).not.toBe(svc2);
+  });
+});

--- a/src/services/organization/default-organization.service.ts
+++ b/src/services/organization/default-organization.service.ts
@@ -1,0 +1,32 @@
+import type { OrganizationService } from '@/core/organization/interfaces';
+import type { IOrganizationDataProvider } from '@/core/organization/IOrganizationDataProvider';
+import type {
+  Organization,
+  OrganizationCreatePayload,
+  OrganizationUpdatePayload,
+  OrganizationResult
+} from '@/core/organization/models';
+
+export class DefaultOrganizationService implements OrganizationService {
+  constructor(private provider: IOrganizationDataProvider) {}
+
+  createOrganization(ownerId: string, data: OrganizationCreatePayload): Promise<OrganizationResult> {
+    return this.provider.createOrganization(ownerId, data);
+  }
+
+  getOrganization(id: string): Promise<Organization | null> {
+    return this.provider.getOrganization(id);
+  }
+
+  getUserOrganizations(userId: string): Promise<Organization[]> {
+    return this.provider.getUserOrganizations(userId);
+  }
+
+  updateOrganization(id: string, data: OrganizationUpdatePayload): Promise<OrganizationResult> {
+    return this.provider.updateOrganization(id, data);
+  }
+
+  deleteOrganization(id: string): Promise<{ success: boolean; error?: string }> {
+    return this.provider.deleteOrganization(id);
+  }
+}

--- a/src/services/organization/factory.ts
+++ b/src/services/organization/factory.ts
@@ -1,0 +1,9 @@
+import type { OrganizationService } from '@/core/organization/interfaces';
+import type { IOrganizationDataProvider } from '@/core/organization/IOrganizationDataProvider';
+import { AdapterRegistry } from '@/adapters/registry';
+import { DefaultOrganizationService } from './default-organization.service';
+
+export function getApiOrganizationService(): OrganizationService {
+  const provider = AdapterRegistry.getInstance().getAdapter<IOrganizationDataProvider>('organization');
+  return new DefaultOrganizationService(provider);
+}


### PR DESCRIPTION
## Summary
- implement core organization models and interfaces
- add Supabase organization provider and service
- expose organization service via factory and initialization
- register organization adapter in registry and supabase factory
- add API route `/api/organizations` with tests

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*