### PR TITLE
Add team roles API routes

### DIFF
--- a/app/api/team/roles/[roleId]/__tests__/route.test.ts
+++ b/app/api/team/roles/[roleId]/__tests__/route.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { GET } from '../route';
+
+describe('team role id API', () => {
+  it('GET returns role for valid id', async () => {
+    const res = await GET({} as any, { params: { roleId: 'ADMIN' } } as any);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.role.id).toBe('ADMIN');
+  });
+
+  it('GET returns 404 for invalid id', async () => {
+    const res = await GET({} as any, { params: { roleId: 'unknown' } } as any);
+    expect(res.status).toBe(404);
+  });
+});

--- a/app/api/team/roles/[roleId]/route.ts
+++ b/app/api/team/roles/[roleId]/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from 'next/server';
+import { createSuccessResponse } from '@/lib/api/common';
+import { RoleDefinition, isRole, RoleType } from '@/lib/rbac/roles';
+import { createRoleNotFoundError } from '@/lib/api/permission/error-handler';
+import { withErrorHandling } from '@/middleware/error-handling';
+
+async function handleGet(roleId: string) {
+  if (!isRole(roleId)) {
+    throw createRoleNotFoundError(roleId);
+  }
+  const role = { id: roleId, ...RoleDefinition[roleId as RoleType] };
+  return createSuccessResponse({ role });
+}
+
+export async function GET(req: NextRequest, ctx: { params: { roleId: string } }) {
+  return withErrorHandling(() => handleGet(ctx.params.roleId), req);
+}

--- a/app/api/team/roles/__tests__/route.test.ts
+++ b/app/api/team/roles/__tests__/route.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GET } from '../route';
+import * as rolesUtil from '@/lib/rbac/roles';
+
+describe('team roles API', () => {
+  it('GET returns roles', async () => {
+    vi.spyOn(rolesUtil, 'getAllRoles').mockReturnValue([{ id: 'ADMIN' }] as any);
+    const res = await GET({} as any);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.roles).toEqual([{ id: 'ADMIN' }]);
+  });
+});

--- a/app/api/team/roles/route.ts
+++ b/app/api/team/roles/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest } from 'next/server';
+import { createSuccessResponse } from '@/lib/api/common';
+import { getAllRoles } from '@/lib/rbac/roles';
+import { withErrorHandling } from '@/middleware/error-handling';
+
+async function handleGet() {
+  const roles = getAllRoles();
+  return createSuccessResponse({ roles });
+}
+
+export async function GET(req: NextRequest) {
+  return withErrorHandling(() => handleGet(), req);
+}


### PR DESCRIPTION
## Summary
- implement missing `/api/team/roles` and `/api/team/roles/[roleId]` routes
- add unit tests for the new routes

## Testing
- `npx vitest run --coverage app/api/team/roles/__tests__/route.test.ts app/api/team/roles/[roleId]/__tests__/route.test.ts`