### PR TITLE
Enforce subscription tier access on premium features

### DIFF
--- a/src/services/subscription/subscription-access.ts
+++ b/src/services/subscription/subscription-access.ts
@@ -1,0 +1,41 @@
+import { SubscriptionTier, SubscriptionStatus } from '@/core/subscription/models';
+import { getApiSubscriptionService } from './factory';
+import { ApiError } from '@/lib/api/common';
+import { ERROR_CODES } from '@/lib/api/common/error-codes';
+
+/**
+ * Ensure the user has the required subscription tier.
+ * Throws {@link ApiError} if the tier requirement is not met.
+ */
+export async function ensureSubscriptionTier(
+  userId: string,
+  requiredTier: SubscriptionTier
+): Promise<void> {
+  const service = getApiSubscriptionService();
+  const [plans, subscription] = await Promise.all([
+    service.getPlans(),
+    service.getUserSubscription(userId)
+  ]);
+
+  let userTier = SubscriptionTier.FREE;
+
+  if (
+    subscription &&
+    (subscription.status === SubscriptionStatus.ACTIVE ||
+      subscription.status === SubscriptionStatus.TRIAL)
+  ) {
+    const plan = plans.find(p => p.id === subscription.planId);
+    if (plan) {
+      userTier = plan.tier;
+    }
+  }
+
+  const tiers = Object.values(SubscriptionTier);
+  if (tiers.indexOf(userTier) < tiers.indexOf(requiredTier)) {
+    throw new ApiError(
+      ERROR_CODES.FORBIDDEN,
+      'Upgrade your plan to access this feature',
+      403
+    );
+  }
+}

--- a/src/services/webhooks/WebhookService.ts
+++ b/src/services/webhooks/WebhookService.ts
@@ -7,6 +7,8 @@ import type {
   WebhookDelivery,
 } from '@/core/webhooks/models';
 import { createWebhookSender } from '@/lib/webhooks/webhook-sender';
+import { SubscriptionTier } from '@/core/subscription/models';
+import { ensureSubscriptionTier } from '@/services/subscription/subscription-access';
 
 export class WebhookService implements IWebhookService {
   private sender;
@@ -16,10 +18,12 @@ export class WebhookService implements IWebhookService {
   }
 
   async getWebhooks(userId: string): Promise<Webhook[]> {
+    await ensureSubscriptionTier(userId, SubscriptionTier.PREMIUM);
     return this.dataProvider.listWebhooks(userId);
   }
 
   async getWebhook(userId: string, webhookId: string): Promise<Webhook | null> {
+    await ensureSubscriptionTier(userId, SubscriptionTier.PREMIUM);
     return this.dataProvider.getWebhook(userId, webhookId);
   }
 
@@ -27,6 +31,7 @@ export class WebhookService implements IWebhookService {
     userId: string,
     payload: WebhookCreatePayload
   ): Promise<{ success: boolean; webhook?: Webhook; error?: string }> {
+    await ensureSubscriptionTier(userId, SubscriptionTier.PREMIUM);
     return this.dataProvider.createWebhook(userId, payload);
   }
 
@@ -35,6 +40,7 @@ export class WebhookService implements IWebhookService {
     webhookId: string,
     payload: WebhookUpdatePayload
   ): Promise<{ success: boolean; webhook?: Webhook; error?: string }> {
+    await ensureSubscriptionTier(userId, SubscriptionTier.PREMIUM);
     return this.dataProvider.updateWebhook(userId, webhookId, payload);
   }
 
@@ -42,6 +48,7 @@ export class WebhookService implements IWebhookService {
     userId: string,
     webhookId: string
   ): Promise<{ success: boolean; error?: string }> {
+    await ensureSubscriptionTier(userId, SubscriptionTier.PREMIUM);
     return this.dataProvider.deleteWebhook(userId, webhookId);
   }
 
@@ -50,6 +57,7 @@ export class WebhookService implements IWebhookService {
     webhookId: string,
     limit?: number
   ): Promise<WebhookDelivery[]> {
+    await ensureSubscriptionTier(userId, SubscriptionTier.PREMIUM);
     return this.dataProvider.listDeliveries(userId, webhookId, limit);
   }
 
@@ -61,6 +69,8 @@ export class WebhookService implements IWebhookService {
     if (!userId) {
       return [];
     }
+
+    await ensureSubscriptionTier(userId, SubscriptionTier.PREMIUM);
 
     const results = await this.sender.sendWebhookEvent(eventType, payload, userId);
     // Strip success field before returning


### PR DESCRIPTION
## Summary
- add a helper to verify a user's subscription plan
- gate API key and webhook services by required tier

## Testing
- `git status --short`