### PR TITLE
Add feature flags panel

### DIFF
--- a/app/admin/features/page.tsx
+++ b/app/admin/features/page.tsx
@@ -1,0 +1,14 @@
+'use client';
+import { FeatureFlagsPanel } from '@/ui/styled/admin/FeatureFlagsPanel';
+
+export default function FeatureFlagsPage() {
+  return (
+    <div className="container py-6 space-y-4">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Feature Flags</h1>
+        <p className="text-muted-foreground">Toggle module features on or off.</p>
+      </div>
+      <FeatureFlagsPanel />
+    </div>
+  );
+}

--- a/src/ui/headless/admin/FeatureFlagsPanel.tsx
+++ b/src/ui/headless/admin/FeatureFlagsPanel.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import type { FeatureFlags } from '@/core/config/interfaces';
+import { configureFeatures, getConfiguration } from '@/core/config';
+
+export interface FeatureFlagsPanelProps {
+  render: (props: {
+    featureFlags: FeatureFlags;
+    toggleFeature: (name: keyof FeatureFlags, value: boolean) => void;
+  }) => React.ReactNode;
+}
+
+export function FeatureFlagsPanel({ render }: FeatureFlagsPanelProps) {
+  const [featureFlags, setFeatureFlags] = useState<FeatureFlags>(
+    getConfiguration().featureFlags
+  );
+
+  useEffect(() => {
+    setFeatureFlags(getConfiguration().featureFlags);
+  }, []);
+
+  const toggleFeature = (name: keyof FeatureFlags, value: boolean) => {
+    const updated = configureFeatures({ [name]: value });
+    setFeatureFlags(updated);
+  };
+
+  return <>{render({ featureFlags, toggleFeature })}</>;
+}
+
+export default FeatureFlagsPanel;

--- a/src/ui/styled/admin/FeatureFlagsPanel.tsx
+++ b/src/ui/styled/admin/FeatureFlagsPanel.tsx
@@ -1,0 +1,28 @@
+import { Label } from '@/ui/primitives/label';
+import { Switch } from '@/ui/primitives/switch';
+import { FeatureFlagsPanel as HeadlessFeatureFlagsPanel } from '@/ui/headless/admin/FeatureFlagsPanel';
+
+export function FeatureFlagsPanel() {
+  return (
+    <HeadlessFeatureFlagsPanel
+      render={({ featureFlags, toggleFeature }) => (
+        <div className="space-y-4">
+          {Object.entries(featureFlags).map(([key, value]) => (
+            <div key={key} className="flex items-center justify-between">
+              <Label htmlFor={key}>{key}</Label>
+              <Switch
+                id={key}
+                checked={value}
+                onCheckedChange={(checked) =>
+                  toggleFeature(key as keyof typeof featureFlags, checked === true)
+                }
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    />
+  );
+}
+
+export default FeatureFlagsPanel;

--- a/src/ui/styled/admin/__tests__/FeatureFlagsPanel.test.tsx
+++ b/src/ui/styled/admin/__tests__/FeatureFlagsPanel.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FeatureFlagsPanel } from '../FeatureFlagsPanel';
+import * as config from '@/core/config';
+
+vi.mock('@/core/config', async () => {
+  const actual = await vi.importActual<typeof config>('@/core/config');
+  return {
+    ...actual,
+    configureFeatures: vi.fn(actual.configureFeatures),
+  };
+});
+
+describe('FeatureFlagsPanel', () => {
+  beforeEach(() => {
+    config.resetConfiguration();
+    vi.clearAllMocks();
+  });
+
+  it('renders switches for each feature and toggles them', async () => {
+    render(<FeatureFlagsPanel />);
+    const flags = config.getConfiguration().featureFlags;
+    const firstKey = Object.keys(flags)[0] as keyof typeof flags;
+    const toggle = screen.getByLabelText(firstKey);
+    await userEvent.click(toggle);
+    expect((config.configureFeatures as any)).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add headless `FeatureFlagsPanel` with render prop
- add styled panel using switches for each flag
- create admin page to manage feature flags
- test FeatureFlagsPanel toggle behaviour

## Testing
- `npm run test:coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*