### PR TITLE
Implement public subscription plans endpoint

### DIFF
--- a/app/api/subscriptions/plans/__tests__/route.test.ts
+++ b/app/api/subscriptions/plans/__tests__/route.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from '../route';
+import { getApiSubscriptionService } from '@/services/subscription/factory';
+
+vi.mock('@/services/subscription/factory', () => ({
+  getApiSubscriptionService: vi.fn(),
+}));
+
+describe('subscriptions plans API', () => {
+  const service = { getPlans: vi.fn() } as any;
+
+  beforeEach(() => {
+    vi.mocked(getApiSubscriptionService).mockReturnValue(service);
+    vi.clearAllMocks();
+  });
+
+  it('returns plans list', async () => {
+    service.getPlans.mockResolvedValue([{ id: 'plan1' }]);
+    const req = new Request('http://test');
+    const res = await GET(req as any);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json[0].id).toBe('plan1');
+    expect(service.getPlans).toHaveBeenCalled();
+  });
+});

--- a/app/api/subscriptions/plans/route.ts
+++ b/app/api/subscriptions/plans/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getApiSubscriptionService } from '@/services/subscription/factory';
+
+/**
+ * Public endpoint to list available subscription plans.
+ */
+export async function GET(_req: NextRequest) {
+  const service = getApiSubscriptionService();
+  const plans = await service.getPlans();
+  return NextResponse.json(plans);
+}

--- a/src/lib/utils/routes.ts
+++ b/src/lib/utils/routes.ts
@@ -280,7 +280,7 @@ export const API_ROUTES = {
   // Subscription management domain
   SUBSCRIPTION: {
     BASE: '/api/subscription',
-    PLANS: '/api/subscription/plans',
+    PLANS: '/api/subscriptions/plans',
   },
 
   // Tax ID domain


### PR DESCRIPTION
## Summary
- add GET `/api/subscriptions/plans` endpoint
- expose subscription routes constant for new path
- test subscription plans endpoint

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*