### PR TITLE
Add missing webhooks adapter factory

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -18,7 +18,7 @@ export * from './consent';
 export * from './session';
 export * from './subscription';
 export * from './csrf';
-export * from './webhook';
+export * from './webhooks';
 
 
 // Import and register the Supabase adapter factory by default

--- a/src/adapters/supabase-factory.ts
+++ b/src/adapters/supabase-factory.ts
@@ -17,7 +17,7 @@ import { SessionDataProvider } from './session/interfaces';
 import { SsoDataProvider } from './sso/interfaces';
 import { SubscriptionDataProvider } from './subscription/interfaces';
 import { ApiKeyDataProvider } from './api-keys/interfaces';
-import { IWebhookDataProvider } from './webhook/IWebhookDataProvider';
+import { IWebhookDataProvider } from '@/core/webhooks/IWebhookDataProvider';
 import { IOrganizationDataProvider } from '@/core/organization/IOrganizationDataProvider';
 
 
@@ -33,7 +33,7 @@ import { createSupabaseSessionProvider } from './session/factory';
 import createSupabaseSsoProvider from './sso/supabase/factory';
 import createSupabaseSubscriptionProvider from './subscription/factory';
 import createSupabaseApiKeyProvider from './api-keys/supabase/factory';
-import { createSupabaseWebhookProvider } from './webhook';
+import { createSupabaseWebhookProvider } from './webhooks';
 
 
 /**

--- a/src/adapters/webhooks/factory.ts
+++ b/src/adapters/webhooks/factory.ts
@@ -1,0 +1,44 @@
+/**
+ * Webhook Data Provider Factory
+ *
+ * Provides factory functions for creating webhook data providers.
+ * Enables dependency injection and easy swapping of implementations.
+ */
+
+import type { IWebhookDataProvider } from '@/core/webhooks/IWebhookDataProvider';
+import { SupabaseWebhookProvider } from './supabase/supabase-webhook.provider';
+
+/**
+ * Create a Supabase webhook data provider
+ *
+ * @param supabaseUrl Supabase project URL
+ * @param supabaseKey Supabase API key
+ * @returns Supabase webhook provider instance
+ */
+export function createSupabaseWebhookProvider(options: {
+  supabaseUrl: string;
+  supabaseKey: string;
+  [key: string]: any;
+}): IWebhookDataProvider {
+  return new SupabaseWebhookProvider(options.supabaseUrl, options.supabaseKey);
+}
+
+/**
+ * Create a webhook data provider based on configuration
+ *
+ * @param config Configuration object with provider type and options
+ * @returns Webhook data provider instance
+ */
+export function createWebhookProvider(config: {
+  type: 'supabase' | string;
+  options: Record<string, any>;
+}): IWebhookDataProvider {
+  switch (config.type) {
+    case 'supabase':
+      return createSupabaseWebhookProvider(config.options);
+    default:
+      throw new Error(`Unsupported webhook provider type: ${config.type}`);
+  }
+}
+
+export default createSupabaseWebhookProvider;

--- a/src/adapters/webhooks/index.ts
+++ b/src/adapters/webhooks/index.ts
@@ -1,27 +1,9 @@
+/**
+ * Webhook Adapter Exports
+ *
+ * Exposes webhook-related types and factory functions.
+ */
+
 export * from '@/core/webhooks/IWebhookDataProvider';
+export * from './factory';
 export * from './supabase/supabase-webhook.provider';
-
-import { IWebhookDataProvider } from '@/core/webhooks/IWebhookDataProvider';
-import { SupabaseWebhookProvider } from './supabase/supabase-webhook.provider';
-
-export function createSupabaseWebhookProvider(options: {
-  supabaseUrl: string;
-  supabaseKey: string;
-  [key: string]: any;
-}): IWebhookDataProvider {
-  return new SupabaseWebhookProvider(options.supabaseUrl, options.supabaseKey);
-}
-
-export function createWebhookProvider(config: {
-  type: 'supabase' | string;
-  options: Record<string, any>;
-}): IWebhookDataProvider {
-  switch (config.type) {
-    case 'supabase':
-      return createSupabaseWebhookProvider(config.options);
-    default:
-      throw new Error(`Unsupported webhook provider type: ${config.type}`);
-  }
-}
-
-export default createSupabaseWebhookProvider;


### PR DESCRIPTION
## Summary
- create factory for webhooks adapter
- re-export factory from index file
- update adapter registry imports

## Testing
- `npm run test:coverage` *(fails: Cannot read properties of undefined (reading 'toLowerCase'))*
- `npm run lint` *(fails: numerous lint warnings and errors)*