### PR TITLE
Expand admin audit logs & i18n tests

### DIFF
--- a/src/lib/i18n/__tests__/initialize-i18n.test.ts
+++ b/src/lib/i18n/__tests__/initialize-i18n.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import i18n, { initializeI18n, languages } from '../index';
+
+describe('initializeI18n', () => {
+  it('registers custom resources and returns translations', () => {
+    const instance = initializeI18n({
+      resources: { de: { userManagement: { greeting: 'Hallo' } } },
+      defaultLanguage: 'de',
+    });
+
+    expect(instance.t('greeting')).toBe('Hallo');
+  });
+
+  it('exposes the list of supported languages', () => {
+    const codes = languages.map(l => l.code);
+    expect(codes).toContain('en');
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+});

--- a/src/tests/mocks/audit-log-viewer.mock.tsx
+++ b/src/tests/mocks/audit-log-viewer.mock.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function AuditLogViewerMock() {
+  return <div data-testid="audit-log-viewer">Mock AuditLogViewer</div>;
+}

--- a/src/tests/mocks/headless-admin-audit-logs.mock.tsx
+++ b/src/tests/mocks/headless-admin-audit-logs.mock.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { vi } from 'vitest';
+
+let errorState = false;
+export function __setIsError(value: boolean) {
+  errorState = value;
+}
+
+export function AdminAuditLogs({ children }: { children: (props: { isError: boolean; setIsError: (b: boolean) => void }) => React.ReactNode }) {
+  return <>{children({ isError: errorState, setIsError: vi.fn() })}</>;
+}

--- a/src/ui/styled/admin/__tests__/AdminAuditLogs.test.tsx
+++ b/src/ui/styled/admin/__tests__/AdminAuditLogs.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AdminAuditLogs } from '../audit-logs/AdminAuditLogs';
+
+import { __setIsError } from '@/tests/mocks/headless-admin-audit-logs.mock';
+vi.mock('@/ui/headless/admin/audit-logs/AdminAuditLogs', async () => await import('@/tests/mocks/headless-admin-audit-logs.mock'));
+vi.mock('@/ui/styled/audit/AuditLogViewer', async () => await import('@/tests/mocks/audit-log-viewer.mock'));
+
+describe('AdminAuditLogs', () => {
+  beforeEach(() => {
+    __setIsError(false);
+    vi.clearAllMocks();
+  });
+
+  it('renders the audit log viewer when no error occurs', () => {
+    render(<AdminAuditLogs />);
+    expect(screen.getByTestId('audit-log-viewer')).toBeInTheDocument();
+  });
+
+  it('shows an error message when fetching logs fails', () => {
+    __setIsError(true);
+    render(<AdminAuditLogs />);
+    expect(screen.getByText(/failed to fetch audit logs/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for AdminAuditLogs component
- add tests for i18n initialization
- provide mocks for AdminAuditLogs tests

## Testing
- `vitest run --coverage` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*