### PR TITLE
Add tests for data export hook and team creator

### DIFF
--- a/src/hooks/user/__tests__/useDataExport.test.ts
+++ b/src/hooks/user/__tests__/useDataExport.test.ts
@@ -1,0 +1,73 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useDataExport } from '../useDataExport';
+import { useAuth } from '@/hooks/auth/useAuth';
+import * as exportService from '@/lib/exports/export.service';
+
+vi.mock('@/hooks/auth/useAuth');
+vi.mock('@/lib/exports/export.service', () => ({
+  isUserRateLimited: vi.fn(),
+  createUserDataExport: vi.fn(),
+  processUserDataExport: vi.fn(),
+  checkUserExportStatus: vi.fn(),
+  ExportStatus: { COMPLETED: 'completed', PENDING: 'pending' },
+  ExportFormat: { JSON: 'json' }
+}));
+
+const { ExportStatus, ExportFormat } = exportService as any;
+
+describe('useDataExport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns error when user not authenticated', async () => {
+    (useAuth as unknown as vi.Mock).mockReturnValue({ user: null });
+    const { result } = renderHook(() => useDataExport());
+    await act(async () => {
+      await result.current.requestExport();
+    });
+    expect(result.current.error).toBe('User not authenticated');
+  });
+
+  it('handles export flow for small dataset', async () => {
+    (useAuth as unknown as vi.Mock).mockReturnValue({ user: { id: 'u1' } });
+    vi.mocked(exportService.isUserRateLimited).mockResolvedValue(false);
+    vi.mocked(exportService.createUserDataExport).mockResolvedValue({ id: 'e1', isLargeDataset: false } as any);
+    vi.mocked(exportService.processUserDataExport).mockResolvedValue();
+    vi.mocked(exportService.checkUserExportStatus).mockResolvedValue({
+      id: 'e1', status: ExportStatus.COMPLETED, isLargeDataset: false, message: 'done', format: ExportFormat.JSON
+    });
+
+    const { result } = renderHook(() => useDataExport());
+    await act(async () => {
+      await result.current.requestExport();
+    });
+
+    expect(exportService.createUserDataExport).toHaveBeenCalledWith('u1', undefined);
+    expect(exportService.processUserDataExport).toHaveBeenCalledWith('e1', 'u1');
+    expect(result.current.status?.status).toBe(ExportStatus.COMPLETED);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('refreshStatus calls checkUserExportStatus', async () => {
+    (useAuth as unknown as vi.Mock).mockReturnValue({ user: { id: 'u1' } });
+    vi.mocked(exportService.isUserRateLimited).mockResolvedValue(false);
+    vi.mocked(exportService.createUserDataExport).mockResolvedValue({ id: 'e1', isLargeDataset: true } as any);
+    vi.mocked(exportService.checkUserExportStatus)
+      .mockResolvedValueOnce({ id: 'e1', status: ExportStatus.PENDING, isLargeDataset: true, message: '', format: ExportFormat.JSON })
+      .mockResolvedValueOnce({ id: 'e1', status: ExportStatus.COMPLETED, isLargeDataset: true, message: 'done', format: ExportFormat.JSON });
+
+    const { result } = renderHook(() => useDataExport());
+    await act(async () => {
+      await result.current.requestExport();
+    });
+
+    await act(async () => {
+      await result.current.refreshStatus();
+    });
+
+    expect(exportService.checkUserExportStatus).toHaveBeenLastCalledWith('e1');
+    expect(result.current.status?.status).toBe(ExportStatus.COMPLETED);
+  });
+});

--- a/src/ui/headless/team/__tests__/TeamCreator.test.tsx
+++ b/src/ui/headless/team/__tests__/TeamCreator.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { TeamCreator } from '../TeamCreator';
+import { useTeams } from '@/hooks/team/useTeams';
+import { useAuth } from '@/hooks/auth/useAuth';
+
+vi.mock('@/hooks/team/useTeams');
+vi.mock('@/hooks/auth/useAuth');
+
+const renderWithProps = () => {
+  let props: any;
+  render(
+    <TeamCreator
+      render={(p) => {
+        props = p;
+        return <div />;
+      }}
+    />
+  );
+  return props;
+};
+
+describe('TeamCreator', () => {
+  const createTeam = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createTeam.mockResolvedValue({ success: true, team: { id: 't1', name: 'My Team' } });
+    (useTeams as unknown as vi.Mock).mockReturnValue({
+      createTeam,
+      isLoading: false,
+      error: null,
+      successMessage: null,
+    });
+    (useAuth as unknown as vi.Mock).mockReturnValue({ user: { id: 'u1' } });
+  });
+
+  it('calls createTeam with user id when submitted', async () => {
+    const props = renderWithProps();
+
+    act(() => {
+      props.setNameValue('My Team');
+    });
+
+    await act(async () => {
+      await props.handleSubmit({ preventDefault() {} } as any);
+    });
+
+    expect(createTeam).toHaveBeenCalledTimes(1);
+    expect(createTeam.mock.calls[0][0]).toBe('u1');
+    expect(createTeam.mock.calls[0][1]).toEqual({
+      name: 'My Team',
+      description: undefined,
+      isPublic: false,
+    });
+  });
+
+  it('uses custom onSubmit when provided', async () => {
+    const onSubmit = vi.fn();
+    let props: any;
+    render(
+      <TeamCreator
+        onSubmit={onSubmit}
+        render={(p) => {
+          props = p;
+          return <div />;
+        }}
+      />
+    );
+
+    act(() => {
+      props.setNameValue('Custom');
+    });
+
+    await act(async () => {
+      await props.handleSubmit({ preventDefault() {} } as any);
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      name: 'Custom',
+      description: undefined,
+      isPublic: false,
+    });
+    expect(createTeam).not.toHaveBeenCalled();
+  });
+
+  it('reports validation state via onValidationChange', () => {
+    const onValidationChange = vi.fn();
+    let props: any;
+    render(
+      <TeamCreator
+        onValidationChange={onValidationChange}
+        render={(p) => {
+          props = p;
+          return <div />;
+        }}
+      />
+    );
+
+    expect(onValidationChange).toHaveBeenCalledWith(false);
+
+    act(() => {
+      props.setNameValue('ok');
+      props.handleBlur('name');
+    });
+
+    expect(onValidationChange).toHaveBeenLastCalledWith(true);
+  });
+});


### PR DESCRIPTION
## Summary
- cover headless TeamCreator interactions
- test useDataExport hook async flows

## Testing
- `npx vitest run src/hooks/user/__tests__/useDataExport.test.ts --coverage`
- `npx vitest run src/ui/headless/team/__tests__/TeamCreator.test.tsx --coverage`
