### PR TITLE
Add notification and webhook tests

### DIFF
--- a/src/lib/services/__tests__/notification.service.marketing.test.ts
+++ b/src/lib/services/__tests__/notification.service.marketing.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { notificationService } from '../notification.service';
+import { notificationQueue } from '../notification-queue.service';
+
+vi.mock('../notification-queue.service', () => ({
+  notificationQueue: {
+    enqueue: vi.fn(),
+  },
+}));
+
+describe('NotificationService marketing & SMS', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    notificationService.setConfig({
+      enabled: true,
+      providers: { marketing: true, sms: true },
+      userPreferences: { notifications: { marketing: false } },
+    });
+  });
+
+  it('respects user preference disabling marketing notifications', async () => {
+    const res = await notificationService.sendMarketing('Hi', 'There');
+    expect(res).toEqual({ success: false, reason: 'Disabled by user preference' });
+    expect(notificationQueue.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('queues SMS notifications when enabled', async () => {
+    notificationService.setConfig({ userPreferences: undefined });
+    (notificationQueue.enqueue as any).mockReturnValue('id1');
+    const res = await notificationService.sendSMS('Code', '1234');
+    expect(res).toEqual({ success: true, trackingId: 'id1' });
+    expect(notificationQueue.enqueue).toHaveBeenCalledWith({ type: 'sms', title: 'Code', message: '1234', data: undefined });
+  });
+});

--- a/src/lib/sms/__tests__/sendSms.test.ts
+++ b/src/lib/sms/__tests__/sendSms.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { sendSms } from '../sendSms';
+
+// Helper to reset env vars
+function resetEnv() {
+  delete process.env.TWILIO_AUTH_TOKEN;
+  delete process.env.TWILIO_ACCOUNT_SID;
+  delete process.env.AWS_ACCESS_KEY_ID;
+  delete process.env.AWS_SECRET_ACCESS_KEY;
+  delete process.env.AWS_REGION;
+}
+
+describe('sendSms', () => {
+  beforeEach(() => {
+    resetEnv();
+  });
+
+  it('uses mock provider by default', async () => {
+    const res = await sendSms({ to: '+1', message: 'hi' });
+    expect(res).toEqual({ success: true, provider: 'mock' });
+  });
+
+  it('sends via Twilio when credentials provided', async () => {
+    process.env.TWILIO_AUTH_TOKEN = 'token';
+    process.env.TWILIO_ACCOUNT_SID = 'sid';
+    const res = await sendSms({ to: '+1', message: 'hello', options: { provider: 'twilio' } });
+    expect(res).toEqual({ success: true, provider: 'twilio' });
+  });
+
+  it('throws when Twilio credentials missing', async () => {
+    await expect(
+      sendSms({ to: '+1', message: 'fail', options: { provider: 'twilio' } })
+    ).rejects.toThrow('Twilio credentials not configured');
+  });
+
+  it('sends via AWS when credentials provided', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'id';
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret';
+    const res = await sendSms({ to: '+1', message: 'hi', options: { provider: 'aws-sns', region: 'us-east-1' } });
+    expect(res).toEqual({ success: true, provider: 'aws-sns' });
+  });
+});

--- a/src/services/notification/__tests__/push-setup.test.ts
+++ b/src/services/notification/__tests__/push-setup.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { DefaultNotificationService } from '../default-notification.service';
+
+const createProvider = () => ({
+  registerDevice: vi.fn(),
+  unregisterDevice: vi.fn(),
+});
+
+const createHandler = () => ({
+  registerDevice: vi.fn().mockResolvedValue(true),
+  unregisterDevice: vi.fn().mockResolvedValue(true),
+});
+
+describe('DefaultNotificationService device registration', () => {
+  let provider: any;
+  let handler: any;
+  let service: DefaultNotificationService;
+
+  beforeEach(() => {
+    provider = createProvider();
+    handler = createHandler();
+    service = new DefaultNotificationService(provider, handler);
+  });
+
+  it('registers device via provider and handler on success', async () => {
+    provider.registerDevice.mockResolvedValue({ success: true });
+    const res = await service.registerDevice('u1', 't1');
+    expect(res).toEqual({ success: true });
+    expect(provider.registerDevice).toHaveBeenCalledWith('u1', 't1', undefined);
+    expect(handler.registerDevice).toHaveBeenCalledWith('u1');
+  });
+
+  it('does not call handler when provider fails', async () => {
+    provider.registerDevice.mockResolvedValue({ success: false, error: 'x' });
+    const res = await service.registerDevice('u1', 't1');
+    expect(res).toEqual({ success: false, error: 'x' });
+    expect(handler.registerDevice).not.toHaveBeenCalled();
+  });
+
+  it('unregisters device via provider and handler', async () => {
+    provider.unregisterDevice.mockResolvedValue({ success: true });
+    const res = await service.unregisterDevice('u1', 't1');
+    expect(res).toEqual({ success: true });
+    expect(provider.unregisterDevice).toHaveBeenCalledWith('u1', 't1');
+    expect(handler.unregisterDevice).toHaveBeenCalledWith('u1');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for sending SMS via different providers
- cover push notification registration flows
- test marketing and SMS preferences in NotificationService
- extend webhook sender tests for inactive hooks and failures

## Testing
- `npx vitest run --coverage` *(fails: initializeI18n and smoke tests)*