### PR TITLE
Inject storage into auth service

### DIFF
--- a/src/core/initialization/initialize-adapters.ts
+++ b/src/core/initialization/initialize-adapters.ts
@@ -6,7 +6,8 @@
  */
 
 import { createAdapterFactory, validateAdapterConfig } from '@/core/config/adapter-config';
-import { DefaultAuthService } from '@/services/auth/default-auth-service';
+import { DefaultAuthService } from '@/services/auth/default-auth.service';
+import { BrowserAuthStorage } from '@/services/auth/auth-storage';
 import { DefaultUserService } from '@/services/user/default-user-service';
 import { DefaultTeamService } from '@/services/team/default-team-service';
 import { DefaultOrganizationService } from '@/services/organization/default-organization.service';
@@ -90,7 +91,8 @@ export function initializeAdapters(
     registry.registerAdapter('sso', ssoAdapter);
     
     // Create service instances with the adapters
-    const authService = new DefaultAuthService(authAdapter);
+    const storage = new BrowserAuthStorage();
+    const authService = new DefaultAuthService(authAdapter, storage);
     const userService = new DefaultUserService(userAdapter);
     const teamService = new DefaultTeamService(teamAdapter);
     const organizationService = organizationAdapter ? new DefaultOrganizationService(organizationAdapter) : undefined;

--- a/src/hooks/auth/__tests__/useAuth.integration.test.ts
+++ b/src/hooks/auth/__tests__/useAuth.integration.test.ts
@@ -5,6 +5,7 @@ import { UserManagementConfiguration } from '@/core/config';
 import type { AuthService } from '@/core/auth/interfaces';
 import type { AuthDataProvider } from '@/core/auth/IAuthDataProvider';
 import { DefaultAuthService } from '@/services/auth/default-auth.service';
+import type { AuthStorage } from '@/services/auth/auth-storage';
 
 // helper to build minimal auth service mocks
 function createMockAuthService(): AuthService {
@@ -95,14 +96,17 @@ describe('useAuth integration', () => {
 
   it('handles API responses and errors from the service', async () => {
     const adapter = createMockAdapter();
-    const apiClient = {
-      post: vi
-        .fn()
-        .mockResolvedValueOnce({ data: { user: { id: '3', email: 'c@test.com' }, token: 'tok' } })
-        .mockRejectedValueOnce({ response: { data: { error: 'Invalid credentials' } } }),
-    } as any;
+    const storage: AuthStorage = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn()
+    };
 
-    const service = new DefaultAuthService(apiClient, adapter);
+    (adapter.login as any)
+      .mockResolvedValueOnce({ success: true, user: { id: '3', email: 'c@test.com' }, token: 'tok' })
+      .mockResolvedValueOnce({ success: false, error: 'Invalid credentials' });
+
+    const service = new DefaultAuthService(adapter, storage);
     UserManagementConfiguration.configureServiceProviders({ authService: service });
 
     const { result } = renderHook(() => useAuth());
@@ -114,7 +118,7 @@ describe('useAuth integration', () => {
       await result.current.login({ email: 'c@test.com', password: 'good' });
     });
 
-    expect(apiClient.post).toHaveBeenCalledWith('/api/auth/login', { email: 'c@test.com', password: 'good' });
+    expect(adapter.login).toHaveBeenCalledWith({ email: 'c@test.com', password: 'good' });
 
     await act(async () => {
       await result.current.login({ email: 'c@test.com', password: 'bad' });

--- a/src/services/auth/__tests__/auth.store.test.ts
+++ b/src/services/auth/__tests__/auth.store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DefaultAuthService } from '../default-auth.service';
+import type { AuthStorage } from '../auth-storage';
 import type { IAuthDataProvider } from '@/core/auth/IAuthDataProvider';
 import type { AuthResult, LoginPayload } from '@/core/auth/models';
 
@@ -29,7 +30,12 @@ describe('DefaultAuthService', () => {
 
   beforeEach(() => {
     adapter = createAdapter();
-    service = new DefaultAuthService(adapter);
+    const storage: AuthStorage = {
+      setItem: vi.fn(),
+      getItem: vi.fn(),
+      removeItem: vi.fn()
+    };
+    service = new DefaultAuthService(adapter, storage);
     Object.defineProperty(global, 'localStorage', {
       value: { setItem: vi.fn(), getItem: vi.fn(), removeItem: vi.fn() },
       writable: true

--- a/src/services/auth/auth-storage.ts
+++ b/src/services/auth/auth-storage.ts
@@ -1,0 +1,34 @@
+export interface AuthStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export class BrowserAuthStorage implements AuthStorage {
+  getItem(key: string): string | null {
+    if (typeof window === 'undefined' || !window.localStorage) return null;
+    try {
+      return window.localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  }
+
+  setItem(key: string, value: string): void {
+    if (typeof window === 'undefined' || !window.localStorage) return;
+    try {
+      window.localStorage.setItem(key, value);
+    } catch {
+      // ignore write errors
+    }
+  }
+
+  removeItem(key: string): void {
+    if (typeof window === 'undefined' || !window.localStorage) return;
+    try {
+      window.localStorage.removeItem(key);
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/src/services/auth/factory.ts
+++ b/src/services/auth/factory.ts
@@ -8,6 +8,8 @@
 import { AuthService } from '@/core/auth/interfaces';
 import type { IAuthDataProvider } from '@/core/auth/IAuthDataProvider';
 import { DefaultAuthService } from './default-auth.service';
+import type { AuthStorage } from './auth-storage';
+import { BrowserAuthStorage } from './auth-storage';
 import { AdapterRegistry } from '@/adapters/registry';
 
 /**
@@ -15,9 +17,11 @@ import { AdapterRegistry } from '@/adapters/registry';
  *
  * @returns New AuthService instance
  */
-export function getApiAuthService(): AuthService {
+export function getApiAuthService(
+  storage: AuthStorage = new BrowserAuthStorage()
+): AuthService {
   const authDataProvider =
     AdapterRegistry.getInstance().getAdapter<IAuthDataProvider>('auth');
 
-  return new DefaultAuthService(authDataProvider);
+  return new DefaultAuthService(authDataProvider, storage);
 }

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -8,6 +8,8 @@
 import { AuthService } from '@/core/auth/interfaces';
 import { DefaultAuthService } from './default-auth.service';
 import type { IAuthDataProvider } from '@/core/auth/IAuthDataProvider';
+import type { AuthStorage } from './auth-storage';
+import { BrowserAuthStorage } from './auth-storage';
 
 /**
  * Configuration options for creating an AuthService
@@ -17,6 +19,7 @@ export interface AuthServiceConfig {
    * Auth data provider for database operations
    */
   authDataProvider: IAuthDataProvider;
+  storage?: AuthStorage;
 }
 
 /**
@@ -26,7 +29,10 @@ export interface AuthServiceConfig {
  * @returns An instance of the AuthService
  */
 export function createAuthService(config: AuthServiceConfig): AuthService {
-  return new DefaultAuthService(config.authDataProvider);
+  return new DefaultAuthService(
+    config.authDataProvider,
+    config.storage ?? new BrowserAuthStorage()
+  );
 }
 
 /**
@@ -35,3 +41,6 @@ export function createAuthService(config: AuthServiceConfig): AuthService {
 export default {
   createAuthService
 };
+
+export { BrowserAuthStorage };
+export type { AuthStorage };


### PR DESCRIPTION
## Summary
- add AuthStorage interface and BrowserAuthStorage
- replace direct localStorage usage in DefaultAuthService
- update auth factory and index to accept storage
- initialize default storage in adapter initialization
- adjust tests for new storage dependency

## Testing
- `npx vitest run --coverage` *(fails: Adapter 'address' not registered in AdapterRegistry, etc.)*