### PR TITLE
Fix user profile hook imports and vi mock usage

### DIFF
--- a/app/account/profile/page.tsx
+++ b/app/account/profile/page.tsx
@@ -9,8 +9,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/ui/primitives/card';
 
 // Import from our new architecture
 import { ProfileEditor } from '@/ui/styled/profile/ProfileEditor';
-import { useUserProfile } from '@/hooks/useUserProfile';
-import { useAccountSettings } from '@/hooks/useAccountSettings';
+import { useUserProfile } from '@/hooks/user/useUserProfile';
+import { useAccountSettings } from '@/hooks/user/useAccountSettings';
 
 export default function ProfilePage() {
   const { t } = useTranslation();

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -10,8 +10,8 @@ import { Alert, AlertDescription, AlertTitle } from '@/ui/primitives/alert';
 
 // Import from our new architecture
 import { AccountSettings } from '@/ui/styled/profile/AccountSettings';
-import { useAccountSettings } from '@/src/hooks/profile/useAccountSettings';
-import { useUserProfile } from '@/src/hooks/profile/useUserProfile';
+import { useAccountSettings } from '@/hooks/user/useAccountSettings';
+import { useUserProfile } from '@/hooks/user/useUserProfile';
 
 export default function SettingsPage() {
   const { t } = useTranslation();

--- a/src/services/user/__tests__/mocks/user.store.mock.ts
+++ b/src/services/user/__tests__/mocks/user.store.mock.ts
@@ -1,3 +1,5 @@
+import { vi } from 'vitest';
+
 interface UserStoreMockState {
   profile: any;
   settings: any;

--- a/src/tests/mocks/user.store.mock.ts
+++ b/src/tests/mocks/user.store.mock.ts
@@ -1,3 +1,5 @@
+import { vi } from 'vitest';
+
 interface UserStoreMockState {
   profile: any;
   settings: any;

--- a/src/ui/headless/profile/AccountSettings.tsx
+++ b/src/ui/headless/profile/AccountSettings.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useState, FormEvent, useEffect } from 'react';
-import { useUserProfile } from '@/hooks/useUserProfile';
+import { useUserProfile } from '@/hooks/user/useUserProfile';
 import { useAuth } from '@/hooks/auth/useAuth';
 import { UserPreferences, PreferencesUpdatePayload, ProfileVisibility, VisibilityLevel } from '@/core/user/models';
 import { z } from 'zod';

--- a/src/ui/headless/profile/ProfileEditor.tsx
+++ b/src/ui/headless/profile/ProfileEditor.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useState, FormEvent, useEffect } from 'react';
-import { useUserProfile } from '@/hooks/useUserProfile';
+import { useUserProfile } from '@/hooks/user/useUserProfile';
 import { useAuth } from '@/hooks/auth/useAuth';
 import { ProfileUpdatePayload, UserProfile } from '@/core/user/models';
 import { z } from 'zod';

--- a/src/ui/headless/profile/ProfileForm.tsx
+++ b/src/ui/headless/profile/ProfileForm.tsx
@@ -7,7 +7,7 @@
 
 import { useState, useEffect, FormEvent } from 'react';
 import { z } from 'zod';
-import { useUserProfile } from '@/hooks/useUserProfile';
+import { useUserProfile } from '@/hooks/user/useUserProfile';
 import type { UserProfile, ProfileUpdatePayload } from '@/core/user/models';
 
 /** Props for the ProfileForm component */


### PR DESCRIPTION
## Summary
- correct hook import paths for user profile and account settings components
- add missing vitest imports in mock factories

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined, etc.)*