### PR TITLE
Refactor auth store usages

### DIFF
--- a/src/lib/hooks/useAuth.ts
+++ b/src/lib/hooks/useAuth.ts
@@ -1,0 +1,1 @@
+export * from '../../hooks/auth/useAuth';

--- a/src/lib/stores/oauth.store.ts
+++ b/src/lib/stores/oauth.store.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { OAuthProvider, OAuthState } from '@/types/oauth';
 import { useUserManagement } from '../auth/UserManagementProvider';
 import { api } from '@/lib/api/axios';
-import { useAuth } from '@/hooks/auth/useAuth';
+import { useAuth } from '@/lib/hooks/useAuth';
 
 export const useOAuthStore = create<OAuthState>((set, get) => ({
   isLoading: false,
@@ -94,7 +94,7 @@ export const useOAuthStore = create<OAuthState>((set, get) => ({
       });
       
       // Get auth store and update user
-      const authStore = useAuthStore.getState();
+      const authStore = useAuth();
       
       if (response.data.user) {
         // User logged in or account linked

--- a/src/lib/stores/preferences.store.ts
+++ b/src/lib/stores/preferences.store.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { api } from '@/lib/api/axios';
 import type { UserPreferences } from '@/types/database';
-import { useAuth } from '@/hooks/auth/useAuth'; // To ensure user is authenticated
+import { useAuth } from '@/lib/hooks/useAuth'; // To ensure user is authenticated
 
 export interface PreferencesState {
   preferences: UserPreferences | null;
@@ -17,7 +17,7 @@ export const usePreferencesStore = create<PreferencesState>((set) => ({
   error: null,
 
   fetchPreferences: async () => {
-    const userId = useAuthStore.getState().user?.id;
+    const userId = useAuth().user?.id;
     if (!userId) {
       // Don't set error, maybe just log or handle silently 
       // as this might be called when user is not logged in yet.
@@ -41,7 +41,7 @@ export const usePreferencesStore = create<PreferencesState>((set) => ({
   },
 
   updatePreferences: async (data: Partial<UserPreferences>): Promise<boolean> => {
-    const userId = useAuthStore.getState().user?.id;
+    const userId = useAuth().user?.id;
     if (!userId) {
        set({ error: 'User not authenticated to update preferences' });
        return false;

--- a/src/lib/stores/profile.store.ts
+++ b/src/lib/stores/profile.store.ts
@@ -6,7 +6,7 @@ import {
     Profile,
 } from '@/types/profile';
 import { fileToBase64 } from '@/lib/utils/file-upload';
-import { useAuth } from '@/hooks/auth/useAuth';
+import { useAuth } from '@/lib/hooks/useAuth';
 
 import { Profile as DbProfile } from '@/types/database';
 import type { ProfileVerification } from '@/types/profile';
@@ -40,7 +40,7 @@ export const useProfileStore = create<ExtendedProfileState & {
 
   fetchProfile: async () => {
     set({ isLoading: true, error: null });
-    const userId = useAuthStore.getState().user?.id;
+    const userId = useAuth().user?.id;
     if (!userId) {
       set({ error: 'User not authenticated', isLoading: false });
       return;

--- a/src/lib/stores/rbac.store.ts
+++ b/src/lib/stores/rbac.store.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { api } from '@/lib/api/axios';
 import { RBACState, Role, Permission, RoleSchema, UserRoleSchema } from '../../types/rbac';
-import { useAuth } from '@/hooks/auth/useAuth';
+import { useAuth } from '@/lib/hooks/useAuth';
 
 export const useRBACStore = create<RBACState>()((set, get) => ({
   roles: [],
@@ -75,7 +75,7 @@ export const useRBACStore = create<RBACState>()((set, get) => ({
 
   hasPermission: (permission: Permission): boolean => {
     const state = get();
-    const user = useAuthStore.getState().user;
+    const user = useAuth().user;
     
     if (!user) return false;
 
@@ -94,7 +94,7 @@ export const useRBACStore = create<RBACState>()((set, get) => ({
 
   hasRole: (role: Role): boolean => {
     const state = get();
-    const user = useAuthStore.getState().user;
+    const user = useAuth().user;
     
     if (!user) return false;
 


### PR DESCRIPTION
## Summary
- add `src/lib/hooks/useAuth.ts` that re-exports existing auth hook
- switch store modules to import from `@/lib/hooks/useAuth`
- replace direct `useAuthStore` state access with `useAuth()`

## Testing
- `git status --short`