### PR TITLE
Refactor tests to use useAuth hook

### DIFF
--- a/src/tests/integration/password-reset-flow.test.tsx
+++ b/src/tests/integration/password-reset-flow.test.tsx
@@ -16,11 +16,11 @@ vi.mock('@/hooks/auth/useAuth', () => {
     clearError: vi.fn(),
     clearSuccessMessage: vi.fn()
   };
-  const useAuthStoreMock: any = vi.fn((selector: any) => (typeof selector === 'function' ? selector(store) : store));
-  useAuthStoreMock.setState = (newState: any) => {
+  const useAuthMock: any = vi.fn((selector: any) => (typeof selector === 'function' ? selector(store) : store));
+  useAuthMock.setState = (newState: any) => {
     Object.assign(store, newState);
   };
-  return { useAuth: useAuthStoreMock };
+  return { useAuth: useAuthMock };
 });
 
 // Then mock the Supabase client
@@ -56,7 +56,6 @@ const apiPostSpy = vi.spyOn(apiModule.api, 'post');
 
 // Import after mocks
 import { useAuth } from '@/hooks/auth/useAuth';
-import { useAuthStore } from '@/lib/stores/auth.store';
 
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -86,9 +85,9 @@ describe('Password Reset Flow', () => {
       configurable: true
     });
 
-    // Always reset useAuthStore mock to have successMessage: null before each test
-    if ((useAuthStore as any).setState) {
-      (useAuthStore as any).setState({
+    // Always reset mocked auth state before each test
+    if ((useAuth as any).setState) {
+      (useAuth as any).setState({
         resetPassword: vi.fn().mockResolvedValue({ success: true, message: 'Reset email sent' }),
         isLoading: false,
         error: null,
@@ -113,8 +112,8 @@ describe('Password Reset Flow', () => {
     const mockResetPassword = vi.fn().mockResolvedValue({ success: true, message: 'Reset email sent' });
     
     // Update the mock to return our specific function
-    if ((useAuthStore as any).setState) {
-      (useAuthStore as any).setState({
+    if ((useAuth as any).setState) {
+      (useAuth as any).setState({
         resetPassword: mockResetPassword,
         isLoading: false,
         error: null,
@@ -151,8 +150,8 @@ describe('Password Reset Flow', () => {
     expect(mockResetPassword).toHaveBeenCalledWith('user@example.com');
 
     // After form submission, update the mock to show success message
-    if ((useAuthStore as any).setState) {
-      (useAuthStore as any).setState({
+    if ((useAuth as any).setState) {
+      (useAuth as any).setState({
         resetPassword: mockResetPassword,
         isLoading: false,
         error: null,
@@ -186,8 +185,8 @@ describe('Password Reset Flow', () => {
       error: 'Email not found' 
     });
     
-    if ((useAuthStore as any).setState) {
-      (useAuthStore as any).setState({
+    if ((useAuth as any).setState) {
+      (useAuth as any).setState({
         resetPassword: mockResetPassword,
         isLoading: false,
         error: 'Email not found',
@@ -281,9 +280,9 @@ describe('Password Reset Flow', () => {
     // Mock updatePassword function that we can check if it was called
     const mockUpdatePassword = vi.fn().mockResolvedValue(undefined);
     
-    // Set up auth store mock
-    if ((useAuthStore as any).setState) {
-      (useAuthStore as any).setState({
+    // Set up auth hook mock
+    if ((useAuth as any).setState) {
+      (useAuth as any).setState({
         updatePassword: mockUpdatePassword,
         isLoading: false,
         error: null

--- a/src/tests/integration/session-management.integration.test.tsx
+++ b/src/tests/integration/session-management.integration.test.tsx
@@ -3,7 +3,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SessionPolicyEnforcer } from '@/ui/styled/session/SessionPolicyEnforcer';
 import { useAuth } from '@/hooks/auth/useAuth';
-import { useAuthStore } from '@/lib/stores/auth.store';
 import { api } from '@/lib/api/axios';
 
 // Mock the API module
@@ -14,11 +13,9 @@ vi.mock('@/lib/api/axios', () => ({
 }));
 
 // Mock the auth store
+const mockUseAuth = vi.fn();
 vi.mock('@/hooks/auth/useAuth', () => ({
-  useAuth: vi.fn(() => ({
-    isAuthenticated: true,
-    logout: vi.fn(),
-  })),
+  useAuth: mockUseAuth,
 }));
 
 // Mock the router
@@ -33,9 +30,9 @@ describe('Session Management', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.useFakeTimers();
-    
-    // Setup default auth store mock
-    (useAuthStore as any).mockReturnValue({
+
+    // Setup default auth hook mock
+    mockUseAuth.mockReturnValue({
       isAuthenticated: true,
       logout: vi.fn(),
     });
@@ -108,7 +105,7 @@ describe('Session Management', () => {
   it('should logout and redirect if API returns 401', async () => {
     // Mock the logout function
     const logoutMock = vi.fn();
-    (useAuthStore as any).mockReturnValue({
+    mockUseAuth.mockReturnValue({
       isAuthenticated: true,
       logout: logoutMock,
     });
@@ -129,7 +126,7 @@ describe('Session Management', () => {
 
   it('should not call API if not authenticated', async () => {
     // Mock user as not authenticated
-    (useAuthStore as any).mockReturnValue({
+    mockUseAuth.mockReturnValue({
       isAuthenticated: false,
       logout: vi.fn(),
     });

--- a/src/tests/integration/user-preferences-flow.test.tsx
+++ b/src/tests/integration/user-preferences-flow.test.tsx
@@ -5,12 +5,12 @@ import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { UserPreferencesComponent } from '@/ui/styled/common/UserPreferences';
 import { useAuth } from '@/hooks/auth/useAuth';
-import { useAuthStore } from '@/lib/stores/auth.store';
 import { usePreferencesStore } from '@/lib/stores/preferences.store';
 
 // Mock Zustand stores
+const mockUseAuth = vi.fn();
 vi.mock('@/hooks/auth/useAuth', () => ({
-  useAuth: vi.fn(),
+  useAuth: mockUseAuth,
 }));
 vi.mock('@/lib/stores/preferences.store', () => ({
   usePreferencesStore: vi.fn(),
@@ -40,24 +40,13 @@ describe('User Preferences Flow', () => {
       configurable: true, // Allow re-definition in tests if needed
     });
 
-    // --- Mock useAuthStore ---
+    // --- Mock useAuth ---
     mockAuthStoreState = {
-      user: { id: 'user-123', email: 'user@example.com', user_metadata: {} }, // Added user_metadata for completeness
-      session: { access_token: 'fake-token', user: { id: 'user-123' } }, // Added session for completeness
+      user: { id: 'user-123', email: 'user@example.com', user_metadata: {} },
+      session: { access_token: 'fake-token', user: { id: 'user-123' } },
       isAuthenticated: true,
-      // Add other state properties from actual useAuthStore if needed, with default mock values
-      // For example:
-      // error: null,
-      // isLoading: false,
-      // initializeAuth: vi.fn(), 
-      // etc.
     };
-    (vi.mocked(useAuthStore) as any).mockImplementation((selector?: (state: any) => any) => {
-      if (typeof selector === 'function') {
-        return selector(mockAuthStoreState);
-      }
-      return mockAuthStoreState;
-    });
+    mockUseAuth.mockReturnValue(mockAuthStoreState);
 
     // --- Mock usePreferencesStore ---
     mockFetchPreferences = vi.fn().mockResolvedValue(true); 


### PR DESCRIPTION
## Summary
- replace deprecated `useAuthStore` with `useAuth` in integration tests

## Testing
- `npx tsc -p tsconfig.json` *(fails: Declaration or statement expected)*