### PR TITLE
Fix user test suite

### DIFF
--- a/src/lib/api-utils/__tests__/api-handler.test.ts
+++ b/src/lib/api-utils/__tests__/api-handler.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { createApiHandler } from '../api-handler';
+import { ApiError, ERROR_CODES } from '@/lib/api/common';
+import { createApiMocks } from '@/tests/utils/api-testing-utils';
+
+describe('createApiHandler', () => {
+  it('returns 200 for successful handler', async () => {
+    const handler = createApiHandler({
+      methods: ['GET'],
+      async handler() {
+        return { ok: true };
+      }
+    });
+    const { req, res } = createApiMocks({ method: 'GET' });
+    await handler(req as any, res as any);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getJsonData()).toEqual({ success: true, data: { ok: true } });
+  });
+
+  it('returns 400 for invalid method', async () => {
+    const handler = createApiHandler({
+      methods: ['POST'],
+      async handler() {
+        return null;
+      }
+    });
+    const { req, res } = createApiMocks({ method: 'GET' });
+    await handler(req as any, res as any);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res.getHeader('Allow')).toEqual(['POST']);
+  });
+
+  it('handles ApiError', async () => {
+    const handler = createApiHandler({
+      methods: ['GET'],
+      async handler() {
+        throw new ApiError(ERROR_CODES.INVALID_REQUEST, 'oops', 400);
+      }
+    });
+    const { req, res } = createApiMocks({ method: 'GET' });
+    await handler(req as any, res as any);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res.getJsonData().error.code).toBe(ERROR_CODES.INVALID_REQUEST);
+  });
+
+  it('handles unexpected error', async () => {
+    const handler = createApiHandler({
+      methods: ['GET'],
+      async handler() {
+        throw new Error('oops');
+      }
+    });
+    const { req, res } = createApiMocks({ method: 'GET' });
+    await handler(req as any, res as any);
+    expect(res._getStatusCode()).toBe(500);
+    expect(res.getJsonData().error.code).toBe('INTERNAL_SERVER_ERROR');
+  });
+
+  it('does not send response twice if handler already sent', async () => {
+    const handler = createApiHandler({
+      methods: ['GET'],
+      async handler(req, res) {
+        res.status(201).json({ success: true });
+        return { ok: true };
+      }
+    });
+    const { req, res } = createApiMocks({ method: 'GET' });
+    await handler(req as any, res as any);
+    expect(res._getStatusCode()).toBe(201);
+    expect(res.getJsonData()).toEqual({ success: true });
+  });
+
+  it('handles roles and schema options', async () => {
+    const handler = createApiHandler({
+      methods: ['GET'],
+      requiredRoles: ['admin'],
+      schema: {},
+      async handler() {
+        return 'ok';
+      }
+    });
+    const { req, res } = createApiMocks({ method: 'GET' });
+    await handler(req as any, res as any);
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it('falls back to default code when ApiError has no code', async () => {
+    const handler = createApiHandler({
+      methods: ['GET'],
+      async handler() {
+        throw new ApiError(undefined as any, 'bad', 418);
+      }
+    });
+    const { req, res } = createApiMocks({ method: 'GET' });
+    await handler(req as any, res as any);
+    expect(res._getStatusCode()).toBe(418);
+    expect(res.getJsonData().error.code).toBe('API_ERROR');
+  });
+});

--- a/src/lib/api-utils/api-handler.ts
+++ b/src/lib/api-utils/api-handler.ts
@@ -91,7 +91,7 @@ export function createApiHandler<T = any>(config: ApiHandlerConfig<T>) {
     } catch (error) {
       // Handle known ApiError
       if (error instanceof ApiError) {
-        return res.status(error.statusCode).json({
+        return res.status(error.status).json({
           success: false,
           error: {
             code: error.code || 'API_ERROR',

--- a/src/services/user/__tests__/user.store.test.ts
+++ b/src/services/user/__tests__/user.store.test.ts
@@ -6,11 +6,11 @@ vi.mock('@/lib/stores/user.store', () => {
 });
 
 import { useUserStore } from '@/lib/stores/user.store';
-import { supabase } from '../../supabase';
+import { supabase } from '@/lib/supabase';
 import { act } from '@testing-library/react';
 
 // Mock the Supabase client
-vi.mock('../../supabase', () => ({
+vi.mock('@/lib/supabase', () => ({
   supabase: {
     auth: {
       getUser: vi.fn()


### PR DESCRIPTION
## Summary
- fix path for supabase import in user store tests
- fix api handler to use ApiError status property
- add dedicated api-handler tests for better coverage

## Testing
- `npx vitest run --coverage src/lib/api-utils/__tests__/api-handler.test.ts src/services/user/__tests__/factory.test.ts src/services/user/__tests__/user.store.test.ts src/pages/api/user/__tests__/user.test.ts src/lib/stores/__tests__/user.store.test.ts`
