### PR TITLE
Fix gdpr and retention tests

### DIFF
--- a/src/lib/services/__tests__/retention.service.test.ts
+++ b/src/lib/services/__tests__/retention.service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { RetentionStatus, RetentionType } from '../../database/schemas/retention';
-import { retentionService } from '../retention.service';
+import { RetentionService } from '../retention.service';
 import { getServiceSupabase } from '../../database/supabase';
 
 vi.mock('../../database/supabase');
@@ -14,11 +14,13 @@ const supabase = {
   update: vi.fn(() => ({ eq: vi.fn(), error: null })),
 };
 
+let service: RetentionService;
 (getServiceSupabase as unknown as vi.Mock).mockReturnValue(supabase);
 
 describe('RetentionService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    service = new RetentionService();
   });
 
   it('reactivates account successfully', async () => {
@@ -30,7 +32,7 @@ describe('RetentionService', () => {
       });
     supabase.update.mockReturnValueOnce({ eq: vi.fn().mockResolvedValue({ error: null }) });
 
-    const result = await retentionService.reactivateAccount('123');
+    const result = await service.reactivateAccount('123');
 
     expect(result).toBe(true);
     expect(supabase.update).toHaveBeenCalled();
@@ -44,13 +46,13 @@ describe('RetentionService', () => {
         error: null,
       });
 
-    await expect(retentionService.reactivateAccount('123')).rejects.toThrow('Cannot reactivate an anonymized account');
+    await expect(service.reactivateAccount('123')).rejects.toThrow('Cannot reactivate an anonymized account');
   });
 
   it('gets user retention status', async () => {
     supabase.maybeSingle.mockResolvedValueOnce({ data: { id: '1' }, error: null });
 
-    const result = await retentionService.getUserRetentionStatus('123');
+    const result = await service.getUserRetentionStatus('123');
 
     expect(result).toEqual({ id: '1' });
     expect(supabase.from).toHaveBeenCalledWith('retention_records');
@@ -59,6 +61,6 @@ describe('RetentionService', () => {
   it('throws on getUserRetentionStatus error', async () => {
     supabase.maybeSingle.mockResolvedValueOnce({ data: null, error: { message: 'fail' } });
 
-    await expect(retentionService.getUserRetentionStatus('123')).rejects.toThrow('fail');
+    await expect(service.getUserRetentionStatus('123')).rejects.toThrow('fail');
   });
 });

--- a/src/services/gdpr/__tests__/factory.test.ts
+++ b/src/services/gdpr/__tests__/factory.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { AdapterRegistry } from '@/adapters/registry';
-import { UserManagementConfiguration } from '@/core/config';
+let AdapterRegistry: typeof import('@/adapters/registry').AdapterRegistry;
+let UserManagementConfiguration: typeof import('@/core/config').UserManagementConfiguration;
 
 let getApiGdprService: typeof import('../factory').getApiGdprService;
 let DefaultGdprService: typeof import('../default-gdpr.service').DefaultGdprService;
@@ -8,6 +8,8 @@ let DefaultGdprService: typeof import('../default-gdpr.service').DefaultGdprServ
 describe('getApiGdprService', () => {
   beforeEach(async () => {
     vi.resetModules();
+    ({ AdapterRegistry } = await import('@/adapters/registry'));
+    ({ UserManagementConfiguration } = await import('@/core/config'));
     (AdapterRegistry as any).instance = null;
     UserManagementConfiguration.reset();
     ({ getApiGdprService } = await import('../factory'));

--- a/src/ui/headless/gdpr/ConsentManagement.tsx
+++ b/src/ui/headless/gdpr/ConsentManagement.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { usePreferencesStore } from '@/lib/stores/preferences.store';
 
 export interface ConsentManagementProps {
@@ -16,12 +16,18 @@ export interface ConsentManagementProps {
 
 export function ConsentManagement({ render }: ConsentManagementProps) {
   const { preferences, fetchPreferences, updatePreferences, isLoading, error } = usePreferencesStore();
-  const [marketing, setMarketing] = useState(false);
+  const [marketing, setMarketingState] = useState(false);
+  const marketingRef = useRef(marketing);
+  const setMarketing = (val: boolean) => {
+    marketingRef.current = val;
+    setMarketingState(val);
+  };
   const [submitted, setSubmitted] = useState(false);
 
   useEffect(() => {
     if (!preferences) fetchPreferences();
   }, [preferences, fetchPreferences]);
+
 
   useEffect(() => {
     if (preferences) {
@@ -34,7 +40,7 @@ export function ConsentManagement({ render }: ConsentManagementProps) {
     await updatePreferences({
       notifications: {
         ...preferences?.notifications,
-        marketing,
+        marketing: marketingRef.current,
       },
     });
     setSubmitted(true);

--- a/src/ui/headless/gdpr/__tests__/DataDeletionRequest.test.tsx
+++ b/src/ui/headless/gdpr/__tests__/DataDeletionRequest.test.tsx
@@ -7,11 +7,13 @@ import { useDataDeletion } from '@/hooks/gdpr/useDataDeletion';
 vi.mock('@/hooks/gdpr/useDataDeletion', () => ({ useDataDeletion: vi.fn() }));
 
 const mockHook = useDataDeletion as unknown as ReturnType<typeof vi.fn>;
+let requestDeletionFn: ReturnType<typeof vi.fn>;
 
 describe('DataDeletionRequest', () => {
   beforeEach(() => {
+    requestDeletionFn = vi.fn();
     mockHook.mockReturnValue({
-      requestDeletion: vi.fn(),
+      requestDeletion: requestDeletionFn,
       isLoading: false,
       success: false,
       error: null,
@@ -19,7 +21,6 @@ describe('DataDeletionRequest', () => {
   });
 
   it('calls requestDeletion', () => {
-    const { requestDeletion } = mockHook.mock.results[0].value;
     const { getByRole } = render(
       <DataDeletionRequest
         render={({ requestDeletion: del }) => (
@@ -28,6 +29,6 @@ describe('DataDeletionRequest', () => {
       />
     );
     fireEvent.click(getByRole('button'));
-    expect(requestDeletion).toHaveBeenCalled();
+    expect(requestDeletionFn).toHaveBeenCalled();
   });
 });

--- a/src/ui/headless/gdpr/__tests__/DataExportRequest.test.tsx
+++ b/src/ui/headless/gdpr/__tests__/DataExportRequest.test.tsx
@@ -7,11 +7,13 @@ import { useDataExport } from '@/hooks/gdpr/useDataExport';
 vi.mock('@/hooks/gdpr/useDataExport', () => ({ useDataExport: vi.fn() }));
 
 const mockHook = useDataExport as unknown as ReturnType<typeof vi.fn>;
+let requestExportFn: ReturnType<typeof vi.fn>;
 
 describe('DataExportRequest', () => {
   beforeEach(() => {
+    requestExportFn = vi.fn();
     mockHook.mockReturnValue({
-      requestExport: vi.fn(),
+      requestExport: requestExportFn,
       isLoading: false,
       error: null,
       downloadUrl: null,
@@ -19,7 +21,6 @@ describe('DataExportRequest', () => {
   });
 
   it('calls requestExport', () => {
-    const { requestExport } = mockHook.mock.results[0].value;
     const { getByRole } = render(
       <DataExportRequest
         render={({ requestExport: req }) => (
@@ -28,6 +29,6 @@ describe('DataExportRequest', () => {
       />
     );
     fireEvent.click(getByRole('button'));
-    expect(requestExport).toHaveBeenCalled();
+    expect(requestExportFn).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- update retention service tests to create new service instance
- stabilize gdpr hook tests
- ensure ConsentManagement saves latest value
- fix gdpr factory tests module imports

## Testing
- `npx vitest run --coverage src/ui/styled/gdpr/__tests__/DataDeletionRequest.test.tsx src/ui/styled/gdpr/__tests__/DataExportRequest.test.tsx src/ui/styled/gdpr/__tests__/ConsentManager.test.tsx src/ui/styled/gdpr/__tests__/PrivacyPreferences.test.tsx src/ui/headless/gdpr/__tests__/DataDeletionRequest.test.tsx src/ui/headless/gdpr/__tests__/DataExportRequest.test.tsx src/ui/headless/gdpr/__tests__/ConsentManagement.test.tsx src/hooks/gdpr/__tests__/useDataDeletion.test.ts src/hooks/gdpr/__tests__/useDataExport.test.ts src/services/gdpr/__tests__/factory.test.ts src/lib/services/__tests__/retention.service.test.ts`