### PR TITLE
Fix billing and subscription test issues

### DIFF
--- a/src/adapters/subscription/__tests__/supabase-adapter.test.ts
+++ b/src/adapters/subscription/__tests__/supabase-adapter.test.ts
@@ -13,7 +13,7 @@ const subRecord = {
   start_date: '2024-01-01T00:00:00Z',
 };
 
-const planRecord = { id: 'plan-1', name: 'Pro', tier: 'premium', price: 10, period: 'monthly', features: [], is_public: true, trial_days: 0 };
+const planRecord = { id: 'plan-1', name: 'Pro', tier: 'premium', price: 10, period: 'monthly', features: [], is_public: true, is_active: true, trial_days: 0 };
 
 describe('SupabaseSubscriptionProvider', () => {
   beforeEach(() => {

--- a/src/services/subscription/__tests__/factory.test.ts
+++ b/src/services/subscription/__tests__/factory.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { AdapterRegistry } from '@/adapters/registry';
-import { UserManagementConfiguration } from '@/core/config';
+
+let AdapterRegistry: typeof import('@/adapters/registry').AdapterRegistry;
+let UserManagementConfiguration: typeof import('@/core/config').UserManagementConfiguration;
 
 let getApiSubscriptionService: typeof import('../factory').getApiSubscriptionService;
 let DefaultSubscriptionService: typeof import('../default-subscription.service').DefaultSubscriptionService;
@@ -8,6 +9,8 @@ let DefaultSubscriptionService: typeof import('../default-subscription.service')
 describe('getApiSubscriptionService', () => {
   beforeEach(async () => {
     vi.resetModules();
+    ({ AdapterRegistry } = await import('@/adapters/registry'));
+    ({ UserManagementConfiguration } = await import('@/core/config'));
     (AdapterRegistry as any).instance = null;
     UserManagementConfiguration.reset();
     ({ getApiSubscriptionService } = await import('../factory'));

--- a/src/tests/smoke/billing.smoke.test.tsx
+++ b/src/tests/smoke/billing.smoke.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import BillingPage from '../../../app/billing/page';
+import BillingPage from '../../../app/account/billing/page';
 import { useSubscription } from '@/hooks/subscription/useSubscription';
 import { useBilling } from '@/hooks/subscription/useBilling';
 


### PR DESCRIPTION
## Summary
- fix path to billing page in smoke test
- ensure subscription adapter test uses active plan
- make subscription factory tests reset modules correctly

## Testing
- `npx vitest run src/lib/stores/__tests__/subscription.store.test.ts src/adapters/subscription/__tests__/supabase-adapter.test.ts src/services/subscription/__tests__/factory.test.ts src/hooks/subscription/__tests__/useBilling.test.ts src/hooks/subscription/__tests__/useSubscription.test.ts src/tests/smoke/billing.smoke.test.tsx`
- `npx vitest run --coverage src/lib/stores/__tests__/subscription.store.test.ts src/adapters/subscription/__tests__/supabase-adapter.test.ts src/services/subscription/__tests__/factory.test.ts src/hooks/subscription/__tests__/useBilling.test.ts src/hooks/subscription/__tests__/useSubscription.test.ts src/tests/smoke/billing.smoke.test.tsx`