### PR TITLE
Fix and run webhook tests

### DIFF
--- a/src/hooks/webhooks/__tests__/useWebhooks.test.tsx
+++ b/src/hooks/webhooks/__tests__/useWebhooks.test.tsx
@@ -1,8 +1,20 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { UserManagementConfiguration } from '@/core/config';
 import { useWebhooks } from '../useWebhooks';
 import type { IWebhookService } from '@/core/webhooks';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
 
 const mockService: IWebhookService = {
   createWebhook: vi.fn(async () => ({ success: true, webhook: { id: '1', userId: 'u1', name: 'n', url: 'url', events: [], secret: '', isActive: true, createdAt: '' } })),
@@ -22,21 +34,27 @@ beforeEach(() => {
 
 describe('useWebhooks', () => {
   it('fetches webhooks', async () => {
-    (mockService.getWebhooks as any).mockResolvedValueOnce([{ id: '1', userId: 'u1', name: 'n', url: 'u', events: [], secret: '', isActive: true, createdAt: '' }]);
-    const { result } = renderHook(() => useWebhooks('u1'));
+    (mockService.getWebhooks as any).mockResolvedValueOnce([
+      { id: '1', userId: 'u1', name: 'n', url: 'u', events: [], secret: '', isActive: true, createdAt: '' }
+    ]);
+    const { result } = renderHook(() => useWebhooks('u1'), { wrapper: createWrapper() });
     await act(async () => {
       await result.current.fetchWebhooks();
     });
     expect(mockService.getWebhooks).toHaveBeenCalledWith('u1');
-    expect(result.current.webhooks.length).toBe(1);
+    await waitFor(() => expect(result.current.webhooks.length).toBe(1));
   });
 
   it('creates webhook', async () => {
-    const { result } = renderHook(() => useWebhooks('u1'));
+    (mockService.getWebhooks as any).mockResolvedValueOnce([]); // initial load
+    (mockService.getWebhooks as any).mockResolvedValueOnce([
+      { id: '1', userId: 'u1', name: 'n', url: 'u', events: [], secret: '', isActive: true, createdAt: '' }
+    ]);
+    const { result } = renderHook(() => useWebhooks('u1'), { wrapper: createWrapper() });
     await act(async () => {
-      await result.current.createWebhook({ name: 'n', url: 'u', events: [] });
+      await result.current.createWebhook.mutateAsync({ name: 'n', url: 'u', events: [] });
     });
     expect(mockService.createWebhook).toHaveBeenCalled();
-    expect(result.current.webhooks.length).toBe(1);
+    await waitFor(() => expect(result.current.webhooks.length).toBe(1));
   });
 });

--- a/src/lib/webhooks/__tests__/webhook-sender.test.ts
+++ b/src/lib/webhooks/__tests__/webhook-sender.test.ts
@@ -6,12 +6,22 @@ import crypto from 'crypto';
 // Mock fetch
 (global.fetch as any) = vi.fn();
 
-vi.mock('crypto', () => ({
-  createHmac: vi.fn().mockReturnValue({
+vi.mock('crypto', () => {
+  const createHmacMock = vi.fn().mockReturnValue({
     update: vi.fn().mockReturnThis(),
     digest: vi.fn().mockReturnValue('mocked-signature')
-  })
-}));
+  });
+  return {
+    default: {
+      createHmac: createHmacMock,
+      randomBytes: vi.fn(() => Buffer.from('1234567890abcdef')),
+      randomUUID: vi.fn(() => 'uuid')
+    },
+    createHmac: createHmacMock,
+    randomBytes: vi.fn(() => Buffer.from('1234567890abcdef')),
+    randomUUID: vi.fn(() => 'uuid')
+  };
+});
 
 describe('webhook sender', () => {
   let provider: IWebhookDataProvider & Record<string, any>;
@@ -88,7 +98,6 @@ describe('webhook sender', () => {
     expect(provider.listDeliveries).toHaveBeenCalledWith('user', 'w', 10);
     expect(res.length).toBe(1);
   });
-});
 
   it('returns empty array when no active webhooks match event', async () => {
     provider.listWebhooks.mockResolvedValueOnce([

--- a/src/services/webhooks/__tests__/factory.test.ts
+++ b/src/services/webhooks/__tests__/factory.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { AdapterRegistry } from '@/adapters/registry';
-import { UserManagementConfiguration } from '@/core/config';
+let AdapterRegistry: typeof import('@/adapters/registry').AdapterRegistry;
+let UserManagementConfiguration: typeof import('@/core/config').UserManagementConfiguration;
 
 let getApiWebhookService: typeof import('../factory').getApiWebhookService;
 let WebhookServiceClass: typeof import('../WebhookService').WebhookService;
@@ -8,7 +8,9 @@ let WebhookServiceClass: typeof import('../WebhookService').WebhookService;
 describe('getApiWebhookService', () => {
   beforeEach(async () => {
     vi.resetModules();
+    ({ AdapterRegistry } = await import('@/adapters/registry'));
     (AdapterRegistry as any).instance = null;
+    ({ UserManagementConfiguration } = await import('@/core/config'));
     UserManagementConfiguration.reset();
     ({ getApiWebhookService } = await import('../factory'));
     ({ WebhookService: WebhookServiceClass } = await import('../WebhookService'));

--- a/src/services/webhooks/__tests__/webhook-service.test.ts
+++ b/src/services/webhooks/__tests__/webhook-service.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { WebhookService } from '../WebhookService';
 import type { IWebhookDataProvider } from '@/core/webhooks';
 
+vi.mock('@/services/subscription/subscription-access', () => ({
+  ensureSubscriptionTier: vi.fn()
+}));
+
 (global as any).fetch = vi.fn();
 
 describe('WebhookService.triggerEvent', () => {


### PR DESCRIPTION
## Summary
- wrap webhook hook tests in QueryClientProvider and add waitFor
- fix webhook sender tests mocking crypto correctly
- import configuration and registry dynamically in webhook service factory tests
- mock subscription access in webhook service tests

## Testing
- `npx vitest run --coverage src/hooks/webhooks/__tests__/useWebhooks.test.tsx src/ui/headless/webhooks/__tests__/WebhookManager.test.tsx src/adapters/webhooks/__tests__/supabase-webhook-provider.test.ts src/lib/webhooks/__tests__/webhook-sender.test.ts src/services/webhooks/__tests__/factory.test.ts src/services/webhooks/__tests__/webhook-service.test.ts src/core/webhooks/__tests__/models.test.ts`