### PR TITLE
Fix mocks for notification flow tests

### DIFF
--- a/src/tests/mocks/notification.service.mock.ts
+++ b/src/tests/mocks/notification.service.mock.ts
@@ -1,0 +1,39 @@
+import { vi } from 'vitest';
+import type { NotificationService, NotificationBatch, NotificationChannel } from '@/core/notification/interfaces';
+
+export function createMockNotificationService(overrides: Partial<NotificationService> = {}): NotificationService {
+  const defaultBatch: NotificationBatch = {
+    notifications: [],
+    total: 0,
+    page: 1,
+    limit: 10,
+    totalPages: 1,
+    unreadCount: 0,
+  };
+
+  const service: NotificationService = {
+    initialize: vi.fn(async () => {}),
+    sendNotification: vi.fn(),
+    sendBulkNotification: vi.fn(),
+    scheduleNotification: vi.fn(),
+    cancelScheduledNotification: vi.fn(),
+    createTemplate: vi.fn(),
+    updateTemplate: vi.fn(),
+    deleteTemplate: vi.fn(),
+    sendTemplatedNotification: vi.fn(),
+    getUserPreferences: vi.fn(),
+    updateUserPreferences: vi.fn(),
+    getUserNotifications: vi.fn(async () => defaultBatch),
+    markAsRead: vi.fn(async () => ({ success: true })),
+    markAllAsRead: vi.fn(async () => ({ success: true, count: defaultBatch.notifications.length })),
+    deleteNotification: vi.fn(),
+    getDeliveryStatus: vi.fn(),
+    registerDevice: vi.fn(),
+    unregisterDevice: vi.fn(),
+    isChannelEnabled: vi.fn(async () => true),
+    onNotificationEvent: vi.fn(() => () => {}),
+    ...overrides,
+  } as NotificationService;
+
+  return service;
+}


### PR DESCRIPTION
## Summary
- add a reusable notification service mock
- update notification-flow integration tests to use store, API and notification service mocks

## Testing
- `npx vitest run --coverage` *(fails: environment lacks full test support)*