### PR TITLE
Fix missing auth mocks

### DIFF
--- a/src/ui/headless/auth/__tests__/login-form.test.tsx
+++ b/src/ui/headless/auth/__tests__/login-form.test.tsx
@@ -88,6 +88,10 @@ function setupAuth(overrides: Record<string, any> = {}) {
   return { mockLogin };
 }
 
+function setupAuthStoreMock(authMock: any) {
+  (useAuth as any).mockImplementation(() => authMock);
+}
+
 describe('LoginForm', () => {
   const mockLogin = vi.fn();
 

--- a/src/ui/styled/auth/__tests__/LoginForm.test.tsx
+++ b/src/ui/styled/auth/__tests__/LoginForm.test.tsx
@@ -133,17 +133,17 @@ describe('LoginForm', () => {
     });
     
     // Always provide clearError as a function
-    const authMock = {
-      login: mockLogin,
-      isLoading: false,
-      error: null,
-      clearError: vi.fn(),
-      sendVerificationEmail: vi.fn(),
-      setUser: vi.fn(),
-      setToken: vi.fn(),
-      ...authState
-    };
-    setupAuthStoreMock(authMock);
+      const authMock = {
+        login: mockLogin,
+        isLoading: false,
+        error: null,
+        clearError: vi.fn(),
+        sendVerificationEmail: vi.fn(),
+        setUser: vi.fn(),
+        setToken: vi.fn(),
+        ...authState
+      };
+      setupAuthMock(authMock);
   };
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- fix login form tests to provide auth mocks

## Testing
- `npx vitest run --coverage` *(fails: environment not configured)*