### PR TITLE
Update env mocks in adapter tests

### DIFF
--- a/src/lib/__tests__/config.test.js
+++ b/src/lib/__tests__/config.test.js
@@ -13,10 +13,10 @@ describe('Environment Variables', () => {
   });
 
   test('required environment variables are defined in development', async () => {
-    process.env.NODE_ENV = 'development';
-    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test-url.supabase.co';
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key';
-    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-key';
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://test-url.supabase.co');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'test-anon-key');
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'test-service-key');
 
     // Check if the environment variables are correctly set
     expect(process.env.NEXT_PUBLIC_SUPABASE_URL).toBe('https://test-url.supabase.co');
@@ -25,9 +25,9 @@ describe('Environment Variables', () => {
   });
 
   test('public variables are accessible but service key is not in client-side code', () => {
-    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test-url.supabase.co';
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key';
-    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-key';
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://test-url.supabase.co');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'test-anon-key');
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'test-service-key');
 
     // Simulate client-side environment
     const clientEnv = {

--- a/src/lib/database/__tests__/supabase.test.tsx
+++ b/src/lib/database/__tests__/supabase.test.tsx
@@ -12,15 +12,13 @@ describe('Supabase Client', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.NEXT_PUBLIC_SUPABASE_URL = mockSupabaseUrl;
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = mockSupabaseAnonKey;
-    process.env.SUPABASE_SERVICE_ROLE_KEY = mockSupabaseServiceKey;
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', mockSupabaseUrl);
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', mockSupabaseAnonKey);
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', mockSupabaseServiceKey);
   });
 
   afterEach(() => {
-    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
-    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    vi.unstubAllEnvs();
   });
 
   it('should have a valid Supabase client instance', () => {
@@ -44,8 +42,8 @@ describe('Supabase Client', () => {
   });
 
   it('should throw error when SUPABASE_SERVICE_ROLE_KEY is missing', async () => {
-    // Delete the environment variable
-    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    // Remove the environment variable
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', '');
     
     // Import getServiceSupabase function from the actual module
     const { getServiceSupabase } = await import('@/lib/database/supabase');
@@ -56,8 +54,8 @@ describe('Supabase Client', () => {
   });
 
   it('should throw error when NEXT_PUBLIC_SUPABASE_URL is missing', async () => {
-    // Delete the environment variable
-    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    // Remove the environment variable
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', '');
     
     // Import getServiceSupabase function from the actual module
     const { getServiceSupabase } = await import('@/lib/database/supabase');


### PR DESCRIPTION
## Summary
- update Supabase adapter tests to use `vi.stubEnv`
- update config environment tests to use `vi.stubEnv`

## Testing
- `vitest run --coverage` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*