### PR TITLE
Fix DataDeletionRequest styled test import path

### DIFF
--- a/src/ui/styled/gdpr/__tests__/DataDeletionRequest.test.tsx
+++ b/src/ui/styled/gdpr/__tests__/DataDeletionRequest.test.tsx
@@ -3,8 +3,9 @@ import { render, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { DataDeletionRequest } from '../DataDeletionRequest';
 
-vi.mock('../../headless/gdpr/DataDeletionRequest', () => ({
-  DataDeletionRequest: ({ render }: any) => render({ requestDeletion: vi.fn(), isLoading: false, error: null })
+vi.mock('../../../headless/gdpr/DataDeletionRequest', () => ({
+  DataDeletionRequest: ({ render }: any) =>
+    render({ requestDeletion: vi.fn(), isLoading: false, error: null })
 }));
 
 describe('DataDeletionRequest styled', () => {


### PR DESCRIPTION
## Summary
- fix mock path in DataDeletionRequest styled test

## Testing
- `npx vitest run src/ui/headless/gdpr/__tests__/DataDeletionRequest.test.tsx src/ui/styled/gdpr/__tests__/DataDeletionRequest.test.tsx --coverage`