### PR TITLE
Fix hook import path and add mock user service

### DIFF
--- a/src/hooks/user/useUserProfile.ts
+++ b/src/hooks/user/useUserProfile.ts
@@ -14,7 +14,7 @@ import {
   ProfileVisibility 
 } from '@/core/user/models';
 import { UserManagementConfiguration } from '@/core/config';
-import { useAuth } from './useAuth';
+import { useAuth } from '../auth/useAuth';
 
 /**
  * Hook for user profile management functionality

--- a/src/tests/mocks/user.service.mock.ts
+++ b/src/tests/mocks/user.service.mock.ts
@@ -1,0 +1,78 @@
+import { vi } from "vitest";
+import type {
+  UserService,
+  UserProfile,
+  ProfileUpdatePayload,
+  UserProfileResult,
+  ProfileVisibility,
+  UserSearchParams,
+  UserSearchResult,
+} from "@/core/user/interfaces";
+
+export function createMockUserService(
+  overrides: Partial<UserService> = {},
+): UserService {
+  const defaultProfile: UserProfile = {
+    id: "user-1",
+    email: "user@example.com",
+    name: "Test User",
+    bio: "",
+    location: "",
+    website: "",
+    profilePictureUrl: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    visibility: { showEmail: false, showLocation: false },
+    type: "personal",
+  } as UserProfile;
+
+  const service: UserService = {
+    getUserProfile: vi.fn(async () => defaultProfile),
+    updateUserProfile: vi.fn(
+      async (
+        _id: string,
+        data: ProfileUpdatePayload,
+      ): Promise<UserProfileResult> => ({
+        success: true,
+        profile: { ...defaultProfile, ...data },
+      }),
+    ),
+    getUserPreferences: vi.fn(async () => ({
+      notifications: { email: true },
+    })) as any,
+    updateUserPreferences: vi.fn(async () => ({
+      success: true,
+      preferences: { notifications: { email: true } },
+    })) as any,
+    uploadProfilePicture: vi.fn(async () => ({
+      success: true,
+      imageUrl: "http://example.com/avatar.png",
+    })),
+    deleteProfilePicture: vi.fn(async () => ({ success: true })),
+    updateProfileVisibility: vi.fn(
+      async (_id: string, visibility: ProfileVisibility) => ({
+        success: true,
+        visibility,
+      }),
+    ),
+    searchUsers: vi.fn(async (_params: UserSearchParams) => ({
+      users: [],
+      total: 0,
+      page: 1,
+      limit: 10,
+      totalPages: 1,
+    })) as any,
+    deactivateUser: vi.fn(async () => ({ success: true })),
+    reactivateUser: vi.fn(async () => ({ success: true })),
+    convertUserType: vi.fn(async () => ({
+      success: true,
+      profile: defaultProfile,
+    })),
+    onUserProfileChanged: vi.fn(() => () => {}),
+    ...overrides,
+  } as UserService;
+
+  return service;
+}
+
+export default createMockUserService;


### PR DESCRIPTION
## Summary
- correct the import path in `useUserProfile`
- add a reusable `createMockUserService` test helper

## Testing
- `vitest run src/ui/styled/profile/__tests__/ProfileEditor.test.tsx` *(fails: Found multiple elements with the text of: /name/i)*