### PR TITLE
Fix notification tests

### DIFF
--- a/src/lib/services/__tests__/notification.service.marketing.test.ts
+++ b/src/lib/services/__tests__/notification.service.marketing.test.ts
@@ -1,16 +1,20 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { notificationService } from '../notification.service';
-import { notificationQueue } from '../notification-queue.service';
+let notificationService: typeof import('../notification.service').notificationService;
+let notificationQueue: { enqueue: any; registerProcessor: any };
 
 vi.mock('../notification-queue.service', () => ({
   notificationQueue: {
     enqueue: vi.fn(),
+    registerProcessor: vi.fn(),
   },
 }));
 
 describe('NotificationService marketing & SMS', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    vi.resetModules();
+    ({ notificationService } = await import('../notification.service'));
+    ({ notificationQueue } = await import('../notification-queue.service'));
     notificationService.setConfig({
       enabled: true,
       providers: { marketing: true, sms: true },

--- a/src/services/notification/__tests__/factory.test.ts
+++ b/src/services/notification/__tests__/factory.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { AdapterRegistry } from '@/adapters/registry';
-import { UserManagementConfiguration } from '@/core/config';
+let AdapterRegistry: typeof import('@/adapters/registry').AdapterRegistry;
+let UserManagementConfiguration: typeof import('@/core/config').UserManagementConfiguration;
 
 let getApiNotificationService: typeof import('../factory').getApiNotificationService;
 let DefaultNotificationService: typeof import('../default-notification.service').DefaultNotificationService;
@@ -8,6 +8,8 @@ let DefaultNotificationService: typeof import('../default-notification.service')
 describe('getApiNotificationService', () => {
   beforeEach(async () => {
     vi.resetModules();
+    ({ AdapterRegistry } = await import('@/adapters/registry'));
+    ({ UserManagementConfiguration } = await import('@/core/config'));
     (AdapterRegistry as any).instance = null;
     UserManagementConfiguration.reset();
     ({ getApiNotificationService } = await import('../factory'));


### PR DESCRIPTION
## Summary
- fix notification service factory test to reload config and registry per test
- ensure notification marketing test works in isolation

## Testing
- `npx vitest run --coverage src/services/notification/__tests__/factory.test.ts src/services/notification/__tests__/push-setup.test.ts src/hooks/notification/__tests__/useNotifications.test.tsx src/adapters/notification/__tests__/in-memory-provider.test.ts src/lib/services/__tests__/notification.service.marketing.test.ts`