### PR TITLE
Remove TODOs for preferences API

### DIFF
--- a/src/lib/stores/preferences.store.ts
+++ b/src/lib/stores/preferences.store.ts
@@ -28,8 +28,7 @@ export const usePreferencesStore = create<PreferencesState>((set) => ({
     
     set({ isLoading: true, error: null });
     try {
-      // TODO: Implement API route /api/preferences (GET)
-      const response = await api.get('/api/preferences'); 
+      const response = await api.get('/api/preferences');
       set({ preferences: response.data as UserPreferences, isLoading: false });
     } catch (error: any) {
       console.error("Fetch preferences error:", error);
@@ -56,8 +55,7 @@ export const usePreferencesStore = create<PreferencesState>((set) => ({
     
     set({ isLoading: true, error: null });
     try {
-       // TODO: Implement API route /api/preferences (PATCH or PUT)
-      const response = await api.patch('/api/preferences', updateData); 
+      const response = await api.patch('/api/preferences', updateData);
       
       set((state) => ({
         preferences: state.preferences 
@@ -75,4 +73,4 @@ export const usePreferencesStore = create<PreferencesState>((set) => ({
       return false;
     }
   },
-})); 
+}));


### PR DESCRIPTION
## Summary
- clean up preferences store comments after implementing the API

## Testing
- `npx vitest run --coverage` *(fails: JavaScript heap out of memory)*