### PR TITLE
Fix PermissionEventTypes export

### DIFF
--- a/src/adapters/permission/supabase-permission-provider.ts
+++ b/src/adapters/permission/supabase-permission-provider.ts
@@ -16,7 +16,11 @@ import {
   RoleUpdatePayload
 } from '../../core/permission/models';
 import type { IPermissionDataProvider } from '@/core/permission/IPermissionDataProvider';
-import { PermissionEventHandler, PermissionEventTypes } from '../../core/permission/events';
+import {
+  PermissionEvent,
+  PermissionEventHandler,
+  PermissionEventTypes,
+} from '../../core/permission/events';
 
 /**
  * Supabase implementation of the PermissionDataProvider interface
@@ -630,7 +634,7 @@ export class SupabasePermissionProvider implements IPermissionDataProvider {
    * 
    * @param event Permission event
    */
-  private notifyEvent(event: any): void {
+  private notifyEvent(event: PermissionEvent): void {
     for (const handler of this.eventHandlers) {
       handler(event);
     }

--- a/src/core/permission/events.ts
+++ b/src/core/permission/events.ts
@@ -9,6 +9,20 @@
 import { Permission, Role, RoleWithPermissions, UserRole } from './models';
 
 /**
+ * Enumeration of all permission event types
+ */
+export enum PermissionEventTypes {
+  ROLE_CREATED = 'ROLE_CREATED',
+  ROLE_UPDATED = 'ROLE_UPDATED',
+  ROLE_DELETED = 'ROLE_DELETED',
+  PERMISSION_ADDED = 'PERMISSION_ADDED',
+  PERMISSION_REMOVED = 'PERMISSION_REMOVED',
+  ROLE_ASSIGNED = 'ROLE_ASSIGNED',
+  ROLE_REMOVED = 'ROLE_REMOVED',
+  ROLE_PERMISSIONS_SYNCED = 'ROLE_PERMISSIONS_SYNCED'
+}
+
+/**
  * Base event interface for all permission events
  */
 export interface PermissionEvent {
@@ -20,7 +34,7 @@ export interface PermissionEvent {
  * Event emitted when a role is created
  */
 export interface RoleCreatedEvent extends PermissionEvent {
-  type: 'ROLE_CREATED';
+  type: PermissionEventTypes.ROLE_CREATED;
   role: RoleWithPermissions;
 }
 
@@ -28,7 +42,7 @@ export interface RoleCreatedEvent extends PermissionEvent {
  * Event emitted when a role is updated
  */
 export interface RoleUpdatedEvent extends PermissionEvent {
-  type: 'ROLE_UPDATED';
+  type: PermissionEventTypes.ROLE_UPDATED;
   role: RoleWithPermissions;
   previousRole: RoleWithPermissions;
 }
@@ -37,7 +51,7 @@ export interface RoleUpdatedEvent extends PermissionEvent {
  * Event emitted when a role is deleted
  */
 export interface RoleDeletedEvent extends PermissionEvent {
-  type: 'ROLE_DELETED';
+  type: PermissionEventTypes.ROLE_DELETED;
   roleId: string;
 }
 
@@ -45,7 +59,7 @@ export interface RoleDeletedEvent extends PermissionEvent {
  * Event emitted when a permission is added to a role
  */
 export interface PermissionAddedEvent extends PermissionEvent {
-  type: 'PERMISSION_ADDED';
+  type: PermissionEventTypes.PERMISSION_ADDED;
   roleId: string;
   permission: Permission;
 }
@@ -54,7 +68,7 @@ export interface PermissionAddedEvent extends PermissionEvent {
  * Event emitted when a permission is removed from a role
  */
 export interface PermissionRemovedEvent extends PermissionEvent {
-  type: 'PERMISSION_REMOVED';
+  type: PermissionEventTypes.PERMISSION_REMOVED;
   roleId: string;
   permission: Permission;
 }
@@ -63,7 +77,7 @@ export interface PermissionRemovedEvent extends PermissionEvent {
  * Event emitted when a role is assigned to a user
  */
 export interface RoleAssignedEvent extends PermissionEvent {
-  type: 'ROLE_ASSIGNED';
+  type: PermissionEventTypes.ROLE_ASSIGNED;
   userRole: UserRole;
 }
 
@@ -71,7 +85,7 @@ export interface RoleAssignedEvent extends PermissionEvent {
  * Event emitted when a role is removed from a user
  */
 export interface RoleRemovedEvent extends PermissionEvent {
-  type: 'ROLE_REMOVED';
+  type: PermissionEventTypes.ROLE_REMOVED;
   userId: string;
   roleId: string;
 }
@@ -80,14 +94,14 @@ export interface RoleRemovedEvent extends PermissionEvent {
  * Event emitted when role permissions are synced
  */
 export interface RolePermissionsSyncedEvent extends PermissionEvent {
-  type: 'ROLE_PERMISSIONS_SYNCED';
+  type: PermissionEventTypes.ROLE_PERMISSIONS_SYNCED;
   roles: RoleWithPermissions[];
 }
 
 /**
  * Union type of all permission events
  */
-export type PermissionEventTypes =
+export type PermissionEvent =
   | RoleCreatedEvent
   | RoleUpdatedEvent
   | RoleDeletedEvent
@@ -100,7 +114,7 @@ export type PermissionEventTypes =
 /**
  * Permission event handler type
  */
-export type PermissionEventHandler = (event: PermissionEventTypes) => void;
+export type PermissionEventHandler = (event: PermissionEvent) => void;
 
 /**
  * Permission event emitter interface
@@ -119,5 +133,5 @@ export interface PermissionEventEmitter {
    * 
    * @param event The event to emit
    */
-  emit(event: PermissionEventTypes): void;
+  emit(event: PermissionEvent): void;
 }

--- a/src/core/permission/interfaces.ts
+++ b/src/core/permission/interfaces.ts
@@ -15,7 +15,7 @@ import {
   RoleCreationPayload,
   RoleUpdatePayload
 } from './models';
-import { PermissionEventTypes, PermissionEventHandler } from './events';
+import { PermissionEventHandler } from './events';
 
 /**
  * Core permission service interface

--- a/src/services/permission/__tests__/mocks/mock-permission-service.ts
+++ b/src/services/permission/__tests__/mocks/mock-permission-service.ts
@@ -10,7 +10,11 @@ import {
   RoleCreationPayload,
   RoleUpdatePayload
 } from '../../../../core/permission/models';
-import { PermissionEventHandler, PermissionEventTypes } from '../../../../core/permission/events';
+import {
+  PermissionEvent,
+  PermissionEventHandler,
+  PermissionEventTypes,
+} from '../../../../core/permission/events';
 
 /**
  * Mock implementation of the PermissionService interface for testing

--- a/src/services/permission/default-permission.service.ts
+++ b/src/services/permission/default-permission.service.ts
@@ -20,6 +20,7 @@ import {
 import {
   PermissionEventTypes,
   PermissionEventHandler,
+  PermissionEvent,
 } from "@/core/permission/events";
 import type { PermissionDataProvider } from "@/core/permission/IPermissionDataProvider";
 import { translateError } from "@/lib/utils/error";
@@ -29,7 +30,7 @@ import { TypedEventEmitter } from "@/lib/utils/typed-event-emitter";
  * Default implementation of the PermissionService interface
  */
 export class DefaultPermissionService
-  extends TypedEventEmitter<PermissionEventTypes>
+  extends TypedEventEmitter<PermissionEvent>
   implements PermissionService
 {
   /**
@@ -46,7 +47,7 @@ export class DefaultPermissionService
    *
    * @param event - The event to emit
    */
-  private emitEvent(event: PermissionEventTypes): void {
+  private emitEvent(event: PermissionEvent): void {
     this.emit(event);
   }
 
@@ -160,7 +161,7 @@ export class DefaultPermissionService
 
       // Emit role created event
       this.emitEvent({
-        type: "ROLE_CREATED",
+        type: PermissionEventTypes.ROLE_CREATED,
         timestamp: new Date(),
         role,
       });
@@ -201,7 +202,7 @@ export class DefaultPermissionService
 
       // Emit role updated event
       this.emitEvent({
-        type: "ROLE_UPDATED",
+        type: PermissionEventTypes.ROLE_UPDATED,
         timestamp: new Date(),
         role,
         previousRole,
@@ -229,7 +230,7 @@ export class DefaultPermissionService
 
       // Emit role deleted event
       this.emitEvent({
-        type: "ROLE_DELETED",
+        type: PermissionEventTypes.ROLE_DELETED,
         timestamp: new Date(),
         roleId,
       });
@@ -294,7 +295,7 @@ export class DefaultPermissionService
 
       // Emit role assigned event
       this.emitEvent({
-        type: "ROLE_ASSIGNED",
+        type: PermissionEventTypes.ROLE_ASSIGNED,
         timestamp: new Date(),
         userRole,
       });
@@ -329,7 +330,7 @@ export class DefaultPermissionService
 
       // Emit role removed event
       this.emitEvent({
-        type: "ROLE_REMOVED",
+        type: PermissionEventTypes.ROLE_REMOVED,
         timestamp: new Date(),
         userId,
         roleId,
@@ -390,7 +391,7 @@ export class DefaultPermissionService
 
       // Emit permission added event
       this.emitEvent({
-        type: "PERMISSION_ADDED",
+        type: PermissionEventTypes.PERMISSION_ADDED,
         timestamp: new Date(),
         roleId,
         permission,
@@ -425,7 +426,7 @@ export class DefaultPermissionService
 
       // Emit permission removed event
       this.emitEvent({
-        type: "PERMISSION_REMOVED",
+        type: PermissionEventTypes.PERMISSION_REMOVED,
         timestamp: new Date(),
         roleId,
         permission,
@@ -530,7 +531,7 @@ export class DefaultPermissionService
 
       // Emit role permissions synced event
       this.emitEvent({
-        type: "ROLE_PERMISSIONS_SYNCED",
+        type: PermissionEventTypes.ROLE_PERMISSIONS_SYNCED,
         timestamp: new Date(),
         roles: updatedRoles,
       });

--- a/src/services/permission/index.ts
+++ b/src/services/permission/index.ts
@@ -35,3 +35,6 @@ export function createPermissionService(config: PermissionServiceConfig): Permis
 export default {
   createPermissionService
 };
+
+export type { PermissionEvent } from '@/core/permission/events';
+export { PermissionEventTypes } from '@/core/permission/events';


### PR DESCRIPTION
## Summary
- add `PermissionEventTypes` enum and use it in `PermissionEvent` interfaces
- rename union to `PermissionEvent`
- propagate enum usage to provider, service, and mocks
- re-export event types from service index

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Declaration or statement expected)*