### PR TITLE
Fix import paths and client metadata

### DIFF
--- a/app/admin/gdpr/page.tsx
+++ b/app/admin/gdpr/page.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Metadata } from 'next';
 import { DataExportRequest } from '@/ui/styled/gdpr/DataExportRequest';
 import { DataDeletionRequest } from '@/ui/styled/gdpr/DataDeletionRequest';

--- a/app/admin/permissions/page.tsx
+++ b/app/admin/permissions/page.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Metadata } from 'next';
 import { Skeleton } from '@/ui/primitives/skeleton';
 import { Alert, AlertDescription } from '@/ui/primitives/alert';

--- a/app/admin/roles/page.tsx
+++ b/app/admin/roles/page.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Metadata } from 'next';
 import { Skeleton } from '@/ui/primitives/skeleton';
 import { Alert, AlertDescription } from '@/ui/primitives/alert';

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { PasswordResetForm } from '@/src/ui/styled/auth/PasswordResetForm';
+import { PasswordResetForm } from '@/ui/styled/auth/PasswordResetForm';
 import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';

--- a/app/auth/update-password/page.tsx
+++ b/app/auth/update-password/page.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';
 
 // Import from our new architecture
-import { usePasswordReset } from '@/hooks/auth/use-password-reset';
+import { usePasswordReset } from '@/hooks/auth/usePasswordReset';
 import { Button } from '@/ui/primitives/button';
 import { Input } from '@/ui/primitives/input';
 import { Label } from '@/ui/primitives/label';


### PR DESCRIPTION
## Summary
- remove `use client` directive so pages can export metadata
- fix bad absolute imports

## Testing
- `npm run lint` *(fails: several lint errors in unrelated files)*
- `npm run build` *(failed: network access needed)*
- `npm run test:coverage` *(failed: ran out of memory)*