### PR TITLE
Add API services for user, permission and session

### DIFF
--- a/docs/Project documentation/GAP_ANALYSIS.md
+++ b/docs/Project documentation/GAP_ANALYSIS.md
@@ -27,7 +27,7 @@ This document summarises the remaining feature gaps in the User Management modul
 - Documentation guides such as the architecture overview and integration guide remain to be written.
 
 ## Client/Server Separation Gaps
-- API-based service implementations for user, permission, and other domains are missing. Currently, only the team domain has an API-based service (`ApiTeamService`).
+- API-based service implementations for user, permission, and session domains were missing. These have now been provided (`ApiUserService`, `ApiPermissionService`, `ApiSessionService`) alongside the existing `ApiTeamService`.
 - Prisma-based services/adapters must never be imported or executed on the client. All client-side code must use API-based services to comply with the layered, pluggable architecture.
 - API endpoints for these domains must be implemented and tested to support the client services.
 

--- a/src/services/permission/__tests__/api/api-permission.service.test.ts
+++ b/src/services/permission/__tests__/api/api-permission.service.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ApiPermissionService } from '../../api-permission.service';
+
+describe('ApiPermissionService', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('getAllPermissions fetches list', async () => {
+    (global.fetch as any) = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { permissions: ['READ'] } })
+    });
+    const svc = new ApiPermissionService();
+    const res = await svc.getAllPermissions();
+    expect(global.fetch).toHaveBeenCalledWith('/api/permissions', expect.any(Object));
+    expect(res).toEqual(['READ']);
+  });
+});

--- a/src/services/permission/api-permission.service.ts
+++ b/src/services/permission/api-permission.service.ts
@@ -1,0 +1,154 @@
+import { PermissionService } from '@/core/permission/interfaces';
+import {
+  Permission,
+  Role,
+  RoleWithPermissions,
+  UserRole,
+  PermissionAssignment,
+  RoleCreationPayload,
+  RoleUpdatePayload
+} from '@/core/permission/models';
+import { PermissionEventHandler, PermissionEventTypes, PermissionEvent } from '@/core/permission/events';
+
+/**
+ * API-based implementation of {@link PermissionService} for client usage.
+ */
+export class ApiPermissionService implements PermissionService {
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  async hasPermission(userId: string, permission: Permission): Promise<boolean> {
+    const url = `/api/permissions/check?permission=${permission}`;
+    const res = await fetch(url, { credentials: 'include' });
+    if (!res.ok) return false;
+    const data = await res.json();
+    return !!(data.data && data.data.hasPermission);
+  }
+
+  async hasRole(_userId: string, role: Role): Promise<boolean> {
+    const url = `/api/permissions/check?permission=${role}`;
+    const res = await fetch(url, { credentials: 'include' });
+    if (!res.ok) return false;
+    const data = await res.json();
+    return !!(data.data && data.data.hasPermission);
+  }
+
+  async getAllRoles(): Promise<RoleWithPermissions[]> {
+    const res = await fetch('/api/team/roles', { credentials: 'include' });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return data.data.roles;
+  }
+
+  async getRoleById(roleId: string): Promise<RoleWithPermissions | null> {
+    const res = await fetch(`/api/team/roles/${roleId}`, { credentials: 'include' });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.data.role;
+  }
+
+  async createRole(roleData: RoleCreationPayload): Promise<RoleWithPermissions> {
+    const res = await fetch('/api/team/roles', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(roleData)
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'create failed');
+    return data.data.role ?? data.data;
+  }
+
+  async updateRole(roleId: string, roleData: RoleUpdatePayload): Promise<RoleWithPermissions> {
+    const res = await fetch(`/api/team/roles/${roleId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(roleData)
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'update failed');
+    return data.data.role ?? data.data;
+  }
+
+  async deleteRole(roleId: string): Promise<boolean> {
+    const res = await fetch(`/api/team/roles/${roleId}`, { method: 'DELETE', credentials: 'include' });
+    if (!res.ok) return false;
+    return true;
+  }
+
+  async getUserRoles(userId: string): Promise<UserRole[]> {
+    const res = await fetch(`/api/user/${userId}/roles`, { credentials: 'include' });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return data.data.roles;
+  }
+
+  async assignRoleToUser(userId: string, roleId: string, assignedBy: string, expiresAt?: Date): Promise<UserRole> {
+    const res = await fetch('/api/user/roles', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ userId, roleId, assignedBy, expiresAt })
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'assign failed');
+    return data.data.role ?? data.data;
+  }
+
+  async removeRoleFromUser(userId: string, roleId: string): Promise<boolean> {
+    const res = await fetch(`/api/user/${userId}/roles/${roleId}`, { method: 'DELETE', credentials: 'include' });
+    if (!res.ok) return false;
+    return true;
+  }
+
+  async roleHasPermission(roleId: string, permission: Permission): Promise<boolean> {
+    const role = await this.getRoleById(roleId);
+    return !!role && role.permissions.includes(permission);
+  }
+
+  async addPermissionToRole(roleId: string, permission: Permission): Promise<PermissionAssignment> {
+    const res = await fetch(`/api/team/roles/${roleId}/permissions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ permission })
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'add failed');
+    return data.data.permission ?? data.data;
+  }
+
+  async removePermissionFromRole(roleId: string, permission: Permission): Promise<boolean> {
+    const res = await fetch(`/api/team/roles/${roleId}/permissions/${permission}`, {
+      method: 'DELETE',
+      credentials: 'include'
+    });
+    return res.ok;
+  }
+
+  async getAllPermissions(): Promise<Permission[]> {
+    const res = await fetch('/api/permissions', { credentials: 'include' });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return data.data.permissions;
+  }
+
+  async getRolePermissions(roleId: string): Promise<Permission[]> {
+    const role = await this.getRoleById(roleId);
+    return role ? role.permissions : [];
+  }
+
+  async syncRolePermissions(): Promise<boolean> {
+    const res = await fetch('/api/permissions/sync', { method: 'POST', credentials: 'include' });
+    return res.ok;
+  }
+
+  onPermissionEvent(_handler: PermissionEventHandler): () => void {
+    // Client-side API service does not support realtime events
+    return () => {};
+  }
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+}
+
+export function getApiPermissionService(): PermissionService {
+  return new ApiPermissionService();
+}

--- a/src/services/permission/index.ts
+++ b/src/services/permission/index.ts
@@ -7,6 +7,7 @@
 
 import { PermissionService } from '@/core/permission/interfaces';
 import { DefaultPermissionService } from './default-permission.service';
+export { ApiPermissionService, getApiPermissionService } from './api-permission.service';
 import type { PermissionDataProvider } from '@/core/permission/IPermissionDataProvider';
 
 /**

--- a/src/services/session/__tests__/api-session.service.test.ts
+++ b/src/services/session/__tests__/api-session.service.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ApiSessionService } from '../api-session.service';
+
+describe('ApiSessionService', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('listUserSessions fetches sessions', async () => {
+    (global.fetch as any) = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ sessions: [] })
+    });
+    const svc = new ApiSessionService();
+    const res = await svc.listUserSessions('u1');
+    expect(global.fetch).toHaveBeenCalledWith('/api/session', expect.any(Object));
+    expect(res).toEqual([]);
+  });
+});

--- a/src/services/session/api-session.service.ts
+++ b/src/services/session/api-session.service.ts
@@ -1,0 +1,27 @@
+import { SessionService } from '@/core/session/interfaces';
+import type { SessionInfo } from '@/core/session/models';
+
+/**
+ * API-based implementation of {@link SessionService} for client use.
+ */
+export class ApiSessionService implements SessionService {
+  async listUserSessions(_userId: string): Promise<SessionInfo[]> {
+    const res = await fetch('/api/session', { credentials: 'include' });
+    if (!res.ok) throw new Error('Failed to fetch sessions');
+    const data = await res.json();
+    return data.sessions ?? data.data?.sessions ?? [];
+  }
+
+  async revokeUserSession(_userId: string, sessionId: string): Promise<{ success: boolean; error?: string }> {
+    const res = await fetch(`/api/session/${sessionId}`, { method: 'DELETE', credentials: 'include' });
+    if (!res.ok) {
+      const data = await res.json();
+      return { success: false, error: data.error };
+    }
+    return { success: true };
+  }
+}
+
+export function getApiSessionService(): SessionService {
+  return new ApiSessionService();
+}

--- a/src/services/session/index.ts
+++ b/src/services/session/index.ts
@@ -1,4 +1,5 @@
 import { DefaultSessionService } from './default-session.service';
+export { ApiSessionService, getApiSessionService } from './api-session.service';
 import type { SessionService } from '@/core/session/interfaces';
 import type { SessionDataProvider } from '@/core/session/ISessionDataProvider';
 

--- a/src/services/user/__tests__/api-user.service.test.ts
+++ b/src/services/user/__tests__/api-user.service.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ApiUserService } from '../api-user.service';
+
+describe('ApiUserService', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('getUserProfile fetches profile', async () => {
+    const service = new ApiUserService();
+    (global.fetch as any) = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { id: 'u1' } })
+    });
+    const res = await service.getUserProfile('u1');
+    expect(global.fetch).toHaveBeenCalledWith('/api/user/profile', expect.any(Object));
+    expect(res).toEqual({ id: 'u1' });
+  });
+
+  it('updateUserPreferences posts data', async () => {
+    const service = new ApiUserService();
+    (global.fetch as any) = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { theme: 'dark' } })
+    });
+    const res = await service.updateUserPreferences('u1', { theme: 'dark' } as any);
+    expect((global.fetch as any).mock.calls[0][0]).toBe('/api/user/settings');
+    expect(res).toEqual({ success: true, preferences: { theme: 'dark' } });
+  });
+});

--- a/src/services/user/api-user.service.ts
+++ b/src/services/user/api-user.service.ts
@@ -1,0 +1,172 @@
+import { UserService } from '@/core/user/interfaces';
+import {
+  UserProfile,
+  ProfileUpdatePayload,
+  UserPreferences,
+  PreferencesUpdatePayload,
+  UserProfileResult,
+  UserSearchParams,
+  UserSearchResult,
+  ProfileVisibility
+} from '@/core/user/models';
+
+/**
+ * API-based implementation of {@link UserService} for client-side usage.
+ * All operations delegate to REST API endpoints under `/api`.
+ */
+export class ApiUserService implements UserService {
+  async getUserProfile(_userId: string): Promise<UserProfile | null> {
+    const res = await fetch('/api/user/profile', { credentials: 'include' });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.data ?? null;
+  }
+
+  async updateUserProfile(
+    _userId: string,
+    profileData: ProfileUpdatePayload
+  ): Promise<UserProfileResult> {
+    const res = await fetch('/api/user/profile', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(profileData)
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      return { success: false, error: data.error || 'update failed' };
+    }
+    return { success: true, profile: data.data };
+  }
+
+  async getUserPreferences(_userId: string): Promise<UserPreferences> {
+    const res = await fetch('/api/user/settings', { credentials: 'include' });
+    if (!res.ok) throw new Error('Failed to fetch preferences');
+    const data = await res.json();
+    return data.data;
+  }
+
+  async updateUserPreferences(
+    _userId: string,
+    preferences: PreferencesUpdatePayload
+  ): Promise<{ success: boolean; preferences?: UserPreferences; error?: string }> {
+    const res = await fetch('/api/user/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(preferences)
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      return { success: false, error: data.error || 'update failed' };
+    }
+    return { success: true, preferences: data.data };
+  }
+
+  async uploadProfilePicture(
+    _userId: string,
+    imageData: Blob
+  ): Promise<{ success: boolean; imageUrl?: string; error?: string }> {
+    const base64 = await imageData.arrayBuffer().then(buf =>
+      Buffer.from(buf).toString('base64')
+    );
+    const res = await fetch('/api/user/avatar', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ avatar: `data:${imageData.type};base64,${base64}` })
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      return { success: false, error: data.error || 'upload failed' };
+    }
+    return { success: true, imageUrl: data.data.avatarUrl };
+  }
+
+  async deleteProfilePicture(_userId: string): Promise<{ success: boolean; error?: string }> {
+    const res = await fetch('/api/user/avatar', {
+      method: 'DELETE',
+      credentials: 'include'
+    });
+    if (res.status === 204) return { success: true };
+    const data = await res.json();
+    return { success: res.ok, error: data.error };
+  }
+
+  async updateProfileVisibility(
+    _userId: string,
+    visibility: ProfileVisibility
+  ): Promise<{ success: boolean; visibility?: ProfileVisibility; error?: string }> {
+    const res = await fetch('/api/profile/privacy', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(visibility)
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      return { success: false, error: data.error || 'update failed' };
+    }
+    return { success: true, visibility: data }; // privacy route returns object directly
+  }
+
+  async searchUsers(params: UserSearchParams): Promise<UserSearchResult> {
+    const url = `/api/user/search?query=${encodeURIComponent(params.query ?? '')}`;
+    const res = await fetch(url, { credentials: 'include' });
+    if (!res.ok) throw new Error('search failed');
+    return res.json();
+  }
+
+  async deactivateUser(_userId: string, reason?: string): Promise<{ success: boolean; error?: string }> {
+    const res = await fetch('/api/retention/deactivate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ reason })
+    });
+    if (!res.ok) {
+      const data = await res.json();
+      return { success: false, error: data.error };
+    }
+    return { success: true };
+  }
+
+  async reactivateUser(_userId: string): Promise<{ success: boolean; error?: string }> {
+    const res = await fetch('/api/retention/reactivate', {
+      method: 'POST',
+      credentials: 'include'
+    });
+    if (!res.ok) {
+      const data = await res.json();
+      return { success: false, error: data.error };
+    }
+    return { success: true };
+  }
+
+  async convertUserType(
+    _userId: string,
+    newType: string,
+    additionalData?: Record<string, any>
+  ): Promise<UserProfileResult> {
+    const res = await fetch('/api/user/convert-type', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ newType, additionalData })
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      return { success: false, error: data.error || 'convert failed' };
+    }
+    return { success: true, profile: data.data };
+  }
+
+  onUserProfileChanged(): () => void {
+    // Client-side implementation could use SSE or websockets; not implemented
+    return () => {};
+  }
+}
+
+export function getApiUserService(): UserService {
+  return new ApiUserService();
+}

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -7,6 +7,7 @@
 
 import { UserService } from '@/core/user/interfaces';
 import { DefaultUserService } from './default-user.service';
+export { ApiUserService, getApiUserService } from './api-user.service';
 import type { UserDataProvider } from '@/core/user/IUserDataProvider';
 
 /**


### PR DESCRIPTION
## Summary
- add ApiUserService with fetch-based calls
- add ApiPermissionService and ApiSessionService
- export API services from index files
- add unit tests for new API services
- document completed API service implementations in GAP_ANALYSIS

## Testing
- `npx vitest run --coverage` *(fails: JavaScript heap out of memory)*