### PR TITLE
Fix auth store tests

### DIFF
--- a/docs/Testing documentation/TESTING_ISSUES-UnitTests.md
+++ b/docs/Testing documentation/TESTING_ISSUES-UnitTests.md
@@ -343,8 +343,27 @@
 - **Best Practice:**
     - Always use top-level vi.mock for context hooks used outside of React components, and place the mock before importing the code under test.
     - Avoid using require/spyOn for this use case, as it is less reliable with ESM and hoisting.
-- **Example:**
+  - **Example:**
     - See `src/lib/stores/__tests__/subscription.store.test.ts` for a working example.
+
+### H. Adapter Mock Defaults for Service Tests
+- **Issue:** Service tests that rely on adapters returning `User | null` (e.g.,
+  `IAuthDataProvider.getCurrentUser`) may fail when the mocked adapter returns
+  `undefined` instead of `null`.
+- **Solution:** When creating adapter mocks, explicitly set return values to
+  `Promise.resolve(null)` where the real implementation would return `null`.
+  This keeps assertions consistent and prevents `undefined` from causing
+  unexpected failures.
+- **Example:**
+  ```typescript
+  // Service adapter mock
+  function createAdapter() {
+    return {
+      getCurrentUser: vi.fn().mockResolvedValue(null),
+      // ...other methods
+    } as IAuthDataProvider;
+  }
+  ```
 
 ---
 

--- a/src/services/auth/__tests__/auth.store.test.ts
+++ b/src/services/auth/__tests__/auth.store.test.ts
@@ -11,7 +11,12 @@ function createAdapter(
     login: vi.fn(),
     register: vi.fn(),
     logout: vi.fn(),
-    getCurrentUser: vi.fn(),
+    // getCurrentUser should resolve to null by default to mimic
+    // the typical behavior of real providers when no user is
+    // authenticated. This prevents tests from receiving
+    // `undefined` which would cause assertions expecting `null`
+    // to fail.
+    getCurrentUser: vi.fn().mockResolvedValue(null),
     resetPassword: vi.fn(),
     updatePassword: vi.fn(),
     sendVerificationEmail: vi.fn(),


### PR DESCRIPTION
## Summary
- fix adapter mocks in `auth.store.test.ts`
- document adapter mock defaults for service tests in TESTING_ISSUES

## Testing
- `npx vitest run src/services/auth/__tests__/auth.store.test.ts --coverage`