### PR TITLE
Fix session tracker test with infinite loop

### DIFF
--- a/src/services/auth/__tests__/session-tracker.test.ts
+++ b/src/services/auth/__tests__/session-tracker.test.ts
@@ -22,7 +22,10 @@ describe('DefaultSessionTracker', () => {
   it('refreshes token from storage', async () => {
     (localStorage.getItem as any).mockReturnValue('tok');
     new DefaultSessionTracker({ refreshToken: refresh, onSessionTimeout: onTimeout });
-    await vi.runAllTimersAsync();
+    // Only flush pending microtasks to avoid running the interval in
+    // `initializeSessionCheck`, which would cause an infinite loop with
+    // `runAllTimersAsync`.
+    await vi.runAllTicks();
     expect(refresh).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- fix `DefaultSessionTracker` test infinite timer loop by only flushing microtasks

## Testing
- `npx vitest run src/services/auth/__tests__/session-tracker.test.ts`
- `npx vitest run src/services/user/__tests__/*.ts src/services/auth/__tests__/*.ts`