### PR TITLE
Fix useAddresses hook tests

### DIFF
--- a/src/hooks/address/__tests__/useAddresses.test.tsx
+++ b/src/hooks/address/__tests__/useAddresses.test.tsx
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useAddresses } from '../useAddresses';
 import { UserManagementConfiguration } from '@/core/config';
 import type { AddressService } from '@/core/address/interfaces';
+import { TestWrapper } from '../../../tests/utils/test-wrapper';
+import { useAuth } from '@/hooks/auth/useAuth';
 
 const mockService: AddressService = {
   getAddresses: vi.fn(async () => []),
@@ -13,15 +15,23 @@ const mockService: AddressService = {
   setDefaultAddress: vi.fn(async () => {}),
 };
 
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <TestWrapper authenticated customServices={{ addressService: mockService }}>
+    {children}
+  </TestWrapper>
+);
+
 describe('useAddresses', () => {
   beforeEach(() => {
     UserManagementConfiguration.reset();
     UserManagementConfiguration.configureServiceProviders({ addressService: mockService });
     vi.clearAllMocks();
+    (useAuth as any).getState().user = { id: 'u1' };
+    (useAuth as any).getState().isAuthenticated = true;
   });
 
   it('fetches addresses on mount', async () => {
-    const { result } = renderHook(() => useAddresses());
+    const { result } = renderHook(() => useAddresses(), { wrapper });
     await act(async () => {
       await result.current.refresh();
     });
@@ -29,7 +39,7 @@ describe('useAddresses', () => {
   });
 
   it('adds address', async () => {
-    const { result } = renderHook(() => useAddresses());
+    const { result } = renderHook(() => useAddresses(), { wrapper });
     await act(async () => {
       await result.current.addAddress({ userId: 'u1', type: 'shipping', isDefault: false, fullName: 'John', street1: '123', city: 'A', state: 'B', postalCode: '1', country: 'US' });
     });


### PR DESCRIPTION
## Summary
- fix failing useAddresses tests by using TestWrapper
- mock auth store user state for address tests

## Testing
- `npx vitest run --coverage src/hooks/address/__tests__/useAddresses.test.tsx`