### PR TITLE
Fix parse error messages

### DIFF
--- a/app/api/webhooks/__tests__/route.test.ts
+++ b/app/api/webhooks/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { GET, POST } from '../route';
+import { GET, POST, DELETE } from '../route';
 
 // Mock the dependencies
 vi.mock('@/middleware/rate-limit', () => ({
@@ -221,10 +221,12 @@ describe('Webhooks API', () => {
       supabaseMock.insert = vi.fn();
 
       const req = createMockRequest('DELETE', { id: 'webhook1' });
-      const response = await (await import('../route')).DELETE(req);
+      const response = await DELETE(req);
       const body = await response.json();
       expect(response.status).toBe(200);
       expect(body).toHaveProperty('success', true);
     });
   });
 });
+
+export {};

--- a/e2e/auth/personal/account-deletion.test.ts
+++ b/e2e/auth/personal/account-deletion.test.ts
@@ -295,3 +295,5 @@ test.describe('2.5: Account Deletion', () => {
     // ... (rest of the code remains the same)
   });
 });
+
+export {};


### PR DESCRIPTION
## Summary
- import DELETE handler instead of dynamic import
- add module export statements in tests

## Testing
- `npx tsc --noEmit` *(fails: Declaration or statement expected)*
- `npm run test:coverage` *(fails due to memory issues)*