### PR TITLE
Fix parsing errors in tests

### DIFF
--- a/app/api/webhooks/__tests__/route.test.ts
+++ b/app/api/webhooks/__tests__/route.test.ts
@@ -208,7 +208,6 @@ describe('Webhooks API', () => {
       expect(urlError).toBeDefined();
     });
   });
-}); 
   describe('DELETE /api/webhooks', () => {
     it('should delete a webhook', async () => {
       supabaseMock.delete = vi.fn().mockReturnThis();
@@ -227,4 +226,5 @@ describe('Webhooks API', () => {
       expect(body).toHaveProperty('success', true);
     });
   });
+
 });

--- a/e2e/auth/personal/account-deletion.test.ts
+++ b/e2e/auth/personal/account-deletion.test.ts
@@ -190,7 +190,6 @@ test.describe('2.5: Account Deletion', () => {
     await cancelButton.click();
     await expect(dialog).not.toBeVisible();
   }
-  });
 
   test('Account deletion requires confirmation', async () => {
     // Navigate to settings page


### PR DESCRIPTION
## Summary
- fix unmatched closing bracket in webhooks route tests
- fix premature closing of test suite in account deletion e2e test

## Testing
- `npx vitest run --coverage` *(fails: JS heap out of memory)*