### PR TITLE
Fix ESLint no-empty and globalThis errors

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,4 +12,8 @@ src/tests/integration/**/*.Skeleton.integration.test.tsx
 
 # Other test utilities
 src/tests/mocks/**/*
-src/tests/utils/**/* 
+src/tests/utils/**/*
+
+# Generated code
+generated/
+generated/**

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,10 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
   "root": true,
+  "env": {
+    "es2020": true,
+    "node": true
+  },
   "rules": {
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/no-explicit-any": "warn",


### PR DESCRIPTION
## Summary
- stop ESLint from scanning generated code
- define Node and ES2020 env for ESLint so globalThis is defined

## Testing
- `npm run lint`
- `npm run test:coverage` *(fails: useAuthService must be used within an AuthProvider)*