### PR TITLE
Fix eslint noise from generated Prisma files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -13,3 +13,4 @@ src/tests/integration/**/*.Skeleton.integration.test.tsx
 # Other test utilities
 src/tests/mocks/**/*
 src/tests/utils/**/* 
+generated/**


### PR DESCRIPTION
## Summary
- ignore generated folder in eslint

## Testing
- `vitest run --coverage` *(fails: JavaScript heap out of memory)*
- `npm run lint`