### PR TITLE
Fix lint errors from generated folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -13,3 +13,6 @@ src/tests/integration/**/*.Skeleton.integration.test.tsx
 # Other test utilities
 src/tests/mocks/**/*
 src/tests/utils/**/* 
+# Generated files
+generated
+prisma/migrations/**


### PR DESCRIPTION
## Summary
- ignore generated Prisma runtime and migrations for ESLint

## Testing
- `npx eslint . --quiet`
- `npm run test:coverage` *(fails: FATAL ERROR JavaScript heap out of memory)*