### PR TITLE
Fix eslint unused variable errors

### DIFF
--- a/app/api/admin/audit/route.ts
+++ b/app/api/admin/audit/route.ts
@@ -4,7 +4,6 @@ import { createSuccessResponse } from '@/lib/api/common';
 import { withErrorHandling } from '@/middleware/error-handling';
 import { withValidation } from '@/middleware/validation';
 import { getApiAdminService } from '@/services/admin/factory';
-import { createAuditLogRetrievalError } from '@/lib/api/admin/error-handler';
 import { createProtectedHandler } from '@/middleware/permissions';
 
 const querySchema = z.object({

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -4,7 +4,7 @@ import { createSuccessResponse } from '@/lib/api/common';
 import { withErrorHandling } from '@/middleware/error-handling';
 import { withValidation } from '@/middleware/validation';
 import { getApiAdminService } from '@/services/admin/factory';
-import { createUserNotFoundError, mapAdminServiceError } from '@/lib/api/admin/error-handler';
+
 import { createProtectedHandler } from '@/middleware/permissions';
 
 const querySchema = z.object({

--- a/app/api/auth/delete-account/__tests__/route.test.ts
+++ b/app/api/auth/delete-account/__tests__/route.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DELETE } from '../route';
 import { getApiAuthService } from '@/services/auth/factory';
-import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
-import { withSecurity } from '@/middleware/with-security';
 
 vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
 vi.mock('@/middleware/with-auth-rate-limit', () => ({

--- a/app/api/auth/disable-mfa/__tests__/route.test.ts
+++ b/app/api/auth/disable-mfa/__tests__/route.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../route';
 import { getApiAuthService } from '@/services/auth/factory';
-import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
-import { withSecurity } from '@/middleware/with-security';
 
 vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
 vi.mock('@/middleware/with-auth-rate-limit', () => ({

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -6,7 +6,6 @@ import { getApiAuthService } from '@/services/auth/factory';
 import { LoginPayload } from '@/core/auth/models';
 import {
   createSuccessResponse,
-  createErrorResponse,
   ApiError,
   ERROR_CODES
 } from '@/lib/api/common';

--- a/app/api/auth/mfa/disable/__tests__/route.test.ts
+++ b/app/api/auth/mfa/disable/__tests__/route.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../route';
 import { getApiAuthService } from '@/services/auth/factory';
-import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
-import { withSecurity } from '@/middleware/with-security';
 
 vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
 vi.mock('@/middleware/with-auth-rate-limit', () => ({

--- a/app/api/auth/mfa/enable/__tests__/route.test.ts
+++ b/app/api/auth/mfa/enable/__tests__/route.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../route';
 import { getApiAuthService } from '@/services/auth/factory';
-import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
-import { withSecurity } from '@/middleware/with-security';
 
 vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
 vi.mock('@/middleware/with-auth-rate-limit', () => ({

--- a/app/api/auth/mfa/enable/route.ts
+++ b/app/api/auth/mfa/enable/route.ts
@@ -4,7 +4,7 @@ import { withSecurity } from '@/middleware/with-security';
 import { getApiAuthService } from '@/services/auth/factory';
 import { createSuccessResponse, withErrorHandling, ApiError, ERROR_CODES } from '@/lib/api/common';
 
-async function handleEnableMfa(req: NextRequest) {
+async function handleEnableMfa(_req: NextRequest) {
   const authService = getApiAuthService();
   const result = await authService.setupMFA();
   if (!result.success) {

--- a/app/api/auth/refresh-token/__tests__/route.test.ts
+++ b/app/api/auth/refresh-token/__tests__/route.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../route';
 import { getApiAuthService } from '@/services/auth/factory';
-import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
-import { withSecurity } from '@/middleware/with-security';
 
 vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
 vi.mock('@/middleware/with-auth-rate-limit', () => ({

--- a/app/api/auth/setup-mfa/__tests__/route.test.ts
+++ b/app/api/auth/setup-mfa/__tests__/route.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../route';
 import { getApiAuthService } from '@/services/auth/factory';
-import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
-import { withSecurity } from '@/middleware/with-security';
 
 vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
 vi.mock('@/middleware/with-auth-rate-limit', () => ({

--- a/app/api/auth/verify-email/__tests__/route.test.ts
+++ b/app/api/auth/verify-email/__tests__/route.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../route';
 import { getApiAuthService } from '@/services/auth/factory';
-import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
-import { withSecurity } from '@/middleware/with-security';
 
 vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
 vi.mock('@/middleware/with-auth-rate-limit', () => ({

--- a/app/api/auth/verify-mfa/__tests__/route.test.ts
+++ b/app/api/auth/verify-mfa/__tests__/route.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../route';
 import { getApiAuthService } from '@/services/auth/factory';
-import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
-import { withSecurity } from '@/middleware/with-security';
 
 vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
 vi.mock('@/middleware/with-auth-rate-limit', () => ({

--- a/app/api/profile/avatar/route.ts
+++ b/app/api/profile/avatar/route.ts
@@ -4,19 +4,13 @@ import { decode } from 'base64-arraybuffer';
 
 import {
   createSuccessResponse,
-  createCreatedResponse,
   createNoContentResponse,
-  ApiError,
-  ERROR_CODES,
 } from '@/lib/api/common';
 import { withErrorHandling } from '@/middleware/error-handling';
 import { withValidation } from '@/middleware/validation';
 import { withRouteAuth } from '@/middleware/auth';
 
-import {
-  createUserUpdateFailedError,
-  mapUserServiceError,
-} from '@/lib/api/user/error-handler';
+import { createUserUpdateFailedError } from '@/lib/api/user/error-handler';
 
 import { getApiUserService } from '@/services/user/factory';
 
@@ -31,11 +25,9 @@ const AvatarUploadSchema = z.object({
   message: "Either 'avatar' or 'avatarId' is required"
 });
 
-type AvatarUploadRequest = z.infer<typeof AvatarUploadSchema>;
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB limit
 const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
-const STORAGE_BUCKET = 'avatars';
 
 // Predefined avatars - These would typically be stored in a database or config file
 // For now, we're hardcoding them here
@@ -135,7 +127,7 @@ export async function POST(request: NextRequest) {
 
 export async function DELETE(request: NextRequest) {
   return withErrorHandling(
-    (req) => withRouteAuth((r, userId) => handleDeleteAvatar(userId), r),
+    (req) => withRouteAuth((r, userId) => handleDeleteAvatar(userId), req),
     request
   );
 }

--- a/app/api/subscriptions/plans/route.ts
+++ b/app/api/subscriptions/plans/route.ts
@@ -1,10 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { getApiSubscriptionService } from '@/services/subscription/factory';
 
 /**
  * Public endpoint to list available subscription plans.
  */
-export async function GET(_req: NextRequest) {
+export async function GET() {
   const service = getApiSubscriptionService();
   const plans = await service.getPlans();
   return NextResponse.json(plans);

--- a/app/api/user/profile/route.ts
+++ b/app/api/user/profile/route.ts
@@ -9,8 +9,7 @@ import { getApiUserService } from '@/services/user/factory';
 import { profileSchema } from '@/types/database';
 import {
   createUserNotFoundError,
-  createUserUpdateFailedError,
-  mapUserServiceError
+  createUserUpdateFailedError
 } from '@/lib/api/user/error-handler';
 
 const UpdateSchema = profileSchema

--- a/app/api/webhooks/stripe/__tests__/route.test.ts
+++ b/app/api/webhooks/stripe/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../route';
 
 vi.mock('@/lib/payments/stripe', () => ({
@@ -15,8 +15,8 @@ vi.mock('@/adapters/subscription/factory', () => ({
   }))
 }));
 
-const { stripe } = require('@/lib/payments/stripe');
-const { createSupabaseSubscriptionProvider } = require('@/adapters/subscription/factory');
+import { stripe } from '@/lib/payments/stripe';
+import { createSupabaseSubscriptionProvider } from '@/adapters/subscription/factory';
 
 function createRequest(body: any, signature = 'sig') {
   return new Request('http://localhost', {

--- a/docs/Testing documentation/MockComponent.example.test.tsx
+++ b/docs/Testing documentation/MockComponent.example.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { useAuthStore } from '@/lib/stores/auth.store';
 import { userEvent } from '@testing-library/user-event';
 

--- a/e2e/accessibility/a11y-features.e2e.test.ts
+++ b/e2e/accessibility/a11y-features.e2e.test.ts
@@ -12,12 +12,10 @@ This file tests the accessibility features:
 */
 
 import { test, expect } from '@playwright/test';
-import { loginAs } from '../utils/auth-helpers';
 
 // Constants for URLs and test data
 const HOME_URL = '/';
 const LOGIN_URL = '/auth/login';
-const REGISTRATION_URL = '/auth/register';
 
 test.describe('Accessibility Features', () => {
   test.beforeEach(async ({ page }) => {
@@ -222,10 +220,7 @@ test.describe('Accessibility Features', () => {
         return active ? active.textContent?.trim().toLowerCase() : '';
       });
       
-      const elementRole = await page.evaluate(() => {
-        const active = document.activeElement;
-        return active ? active.getAttribute('role') : null;
-      });
+
       
       // Check if we've reached a login or register link/button
       if (

--- a/e2e/adapters/adapter-registry.e2e.test.ts
+++ b/e2e/adapters/adapter-registry.e2e.test.ts
@@ -25,7 +25,7 @@ describe('Adapter Registry - E2E', () => {
     const defaultAdapters = ['supabase'];
     AdapterRegistry.listAvailableAdapters().forEach(adapter => {
       if (!defaultAdapters.includes(adapter)) {
-        // @ts-ignore - Accessing private property for testing
+        // @ts-expect-error - Accessing private property for testing
         delete AdapterRegistry.factories[adapter];
       }
     });

--- a/e2e/admin/login-debug.e2e.test.ts
+++ b/e2e/admin/login-debug.e2e.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import * as dotenv from 'dotenv';
 
 // Load environment variables

--- a/e2e/auth/mfa/backup-codes.e2e.test.ts
+++ b/e2e/auth/mfa/backup-codes.e2e.test.ts
@@ -5,19 +5,6 @@ import { loginAs } from '../../utils/auth';
 const USER_EMAIL = process.env.E2E_USER_EMAIL || 'user@example.com';
 const USER_PASSWORD = process.env.E2E_USER_PASSWORD || 'password123';
 
-// Example backup codes for reference/testing
-const SAMPLE_BACKUP_CODES = [
-  'ABCD-1234',
-  'EFGH-5678',
-  'IJKL-9012',
-  'MNOP-3456',
-  'QRST-7890',
-  'UVWX-2345',
-  'YZAB-6789',
-  'CDEF-0123',
-  'GHIJ-4567',
-  'KLMN-8901',
-];
 
 /**
  * Helper function to navigate to security settings with fallbacks

--- a/e2e/auth/mfa/totp-verification.e2e.test.ts
+++ b/e2e/auth/mfa/totp-verification.e2e.test.ts
@@ -39,7 +39,7 @@ async function navigateToLogin(page: Page): Promise<boolean> {
 }
 
 test.describe('4.4 MFA Verify (TOTP) During Login', () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async () => {
     // Nothing needed in beforeEach - each test handles its own login
   });
   
@@ -327,25 +327,19 @@ test.describe('4.4 MFA Verify (TOTP) During Login', () => {
     await initialLoginPage.fill('#password, input[name="password"]', USER_PASSWORD);
     
     // Check the "Remember Me" checkbox (best practice #13 for custom components)
-    const rememberMeLabel = initialLoginPage.getByText('Remember me', { exact: false });
-    
-    // Try multiple approaches to check the box
-    let rememberMeChecked = false;
+  const rememberMeLabel = initialLoginPage.getByText('Remember me', { exact: false });
     
     try {
       // First attempt: Click the label
       await rememberMeLabel.click({ timeout: 5000 });
-      rememberMeChecked = true;
     } catch (e) {
       try {
         // Second attempt: Force click
         await rememberMeLabel.click({ force: true, timeout: 5000 });
-        rememberMeChecked = true;
       } catch (e2) {
         try {
           // Third attempt: Find by data-testid
           await initialLoginPage.locator('[data-testid="remember-me-checkbox"]').click({ timeout: 5000 });
-          rememberMeChecked = true;
         } catch (e3) {
           console.log('All attempts to check "Remember Me" checkbox failed, using JavaScript');
           
@@ -367,7 +361,7 @@ test.describe('4.4 MFA Verify (TOTP) During Login', () => {
             }
             return false;
           });
-          rememberMeChecked = true; // Assume JS approach worked
+          // Assume JS approach worked
         }
       }
     }

--- a/e2e/auth/personal/check-delete-button.test.ts
+++ b/e2e/auth/personal/check-delete-button.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, Page } from '@playwright/test';
 import { loginAs } from '../../utils/auth';
 
 // Test data

--- a/e2e/auth/personal/logout.e2e.test.ts
+++ b/e2e/auth/personal/logout.e2e.test.ts
@@ -1,5 +1,4 @@
 import { test, expect, Page } from '@playwright/test';
-import { loginAs } from '../../utils/auth';
 
 // --- Constants and Test Data --- //
 const USER_EMAIL = process.env.E2E_USER_EMAIL || 'user@example.com';

--- a/e2e/auth/sso/business-sso-user-login.e2e.test.ts
+++ b/e2e/auth/sso/business-sso-user-login.e2e.test.ts
@@ -6,7 +6,6 @@ import { test, expect } from '@playwright/test';
 
 test.describe('E2E: Business SSO User Login', () => {
   // TODO: VERIFY CONFIG: Adjust URLs/patterns as needed
-  const LOGIN_URL = '/auth/login'; // General login page
   const ORG_LOGIN_URL_PATTERN = (orgId: string) => `/login/${orgId}`; // Example pattern
   const DASHBOARD_URL = '/dashboard/overview';
   const MOCK_SAML_IDP_URL_PATTERN = /^https:\/\/mock-saml-idp\.com\/login.*/;
@@ -17,9 +16,8 @@ test.describe('E2E: Business SSO User Login', () => {
   // Placeholder orgId for tests
   const TEST_ORG_ID_SAML = 'test-org-saml';
   const TEST_ORG_ID_OIDC = 'test-org-oidc';
-  const TEST_USER_EMAIL = 'sso-user@example.com';
 
-  test.beforeEach(async ({ page, context }) => {
+  test.beforeEach(async ({ context }) => {
     // --- START Org/User Setup ---
     // TODO: SETUP: Replace placeholders with actual setup calls.
     // Ensure orgs exist with respective SSO types configured.


### PR DESCRIPTION
## Summary
- clean up unused imports and parameters in API route handlers
- remove unused imports from API route tests
- fix eslint issues in docs and e2e tests

## Testing
- `npm run test:coverage` *(fails: JavaScript heap out of memory)*