### PR TITLE
Fix eslint unused warnings

### DIFF
--- a/src/lib/stores/__tests__/preferences.store.test.ts
+++ b/src/lib/stores/__tests__/preferences.store.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act } from '@testing-library/react';
 import { usePreferencesStore } from '@/lib/stores/preferences.store';
-import { useAuth } from '@/hooks/auth/useAuth';
 import { useAuthStore } from '@/lib/stores/auth.store';
 import { api } from '../../api/axios';
 import type { UserPreferences } from '@/types/database';

--- a/src/lib/stores/auth.store.ts
+++ b/src/lib/stores/auth.store.ts
@@ -5,13 +5,11 @@
  */
 
 import { useAuth } from '@/hooks/auth/useAuth';
-import type { 
-  AuthState, 
-  LoginPayload, 
-  RegistrationPayload, 
-  User, 
+import type {
+  LoginPayload,
+  RegistrationPayload,
+  User,
   AuthResult,
-  RateLimitInfo,
   MFASetupResponse,
   MFAVerifyResponse
 } from '@/core/auth/models';

--- a/src/lib/stores/profile.store.ts
+++ b/src/lib/stores/profile.store.ts
@@ -1,9 +1,8 @@
 import { create } from 'zustand';
 import { api } from '@/lib/api/axios';
 import { supabase } from '../supabase';
-import { 
-    ProfileState, 
-    Profile,
+import {
+    ProfileState,
 } from '@/types/profile';
 import { fileToBase64 } from '@/lib/utils/file-upload';
 import { useAuth } from '@/lib/hooks/useAuth';

--- a/src/lib/stores/rbac.store.ts
+++ b/src/lib/stores/rbac.store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { api } from '@/lib/api/axios';
-import { RBACState, Role, Permission, RoleSchema, UserRoleSchema } from '../../types/rbac';
+import { RBACState, Role, Permission } from '../../types/rbac';
 import { useAuth } from '@/lib/hooks/useAuth';
 
 type RBACInternalState = Omit<RBACState, 'hasPermission' | 'hasRole'> & {

--- a/src/lib/stores/subscription.store.ts
+++ b/src/lib/stores/subscription.store.ts
@@ -1,10 +1,8 @@
 import { create } from 'zustand';
 import { api } from '@/lib/api/axios';
-import { 
-  SubscriptionState, 
-  SubscriptionTier, 
-  SubscriptionPlan,
-  UserSubscription
+import {
+  SubscriptionState,
+  SubscriptionTier
 } from '@/types/subscription';
 import { useUserManagement } from '../auth/UserManagementProvider';
 
@@ -136,7 +134,6 @@ const subscriptionStoreBase = create<SubscriptionInternalState>((set, get) => ({
 
   // Helper: Check if user has access to a specific feature
   hasFeature: (cfg: any, featureName: string) => {
-    const { userSubscription, plans } = get();
 
     // First check if there's a subscription config for the feature
     const featureConfig = cfg?.subscription?.features?.[featureName];

--- a/src/middleware/__tests__/csrf.test.ts
+++ b/src/middleware/__tests__/csrf.test.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { csrf, getCSRFToken, defaultTokenProvider, type CSRFTokenProvider } from '../csrf';
+import { csrf, getCSRFToken, type CSRFTokenProvider } from '../csrf';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 // Mock crypto module properly using importOriginal

--- a/src/middleware/__tests__/index.test.ts
+++ b/src/middleware/__tests__/index.test.ts
@@ -2,7 +2,6 @@ import { createMocks } from 'node-mocks-http';
 import { combineMiddleware, createApiMiddleware, withSecurity } from '@/middleware/index';
 import { rateLimit } from '@/middleware/rate-limit';
 import { securityHeaders } from '@/middleware/security-headers';
-import { auditLog } from '@/middleware/audit-log';
 import { cors } from '@/middleware/cors';
 import { csrf } from '@/middleware/csrf';
 import { vi, describe, it, expect, beforeEach } from 'vitest';

--- a/src/middleware/csrf.ts
+++ b/src/middleware/csrf.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { randomBytes } from 'crypto';
-import { ApiError, ERROR_CODES, createErrorResponse } from '@/lib/api/common';
+import { ApiError, ERROR_CODES } from '@/lib/api/common';
 
 /**
  * Configuration options for the {@link csrf} middleware.

--- a/src/pages/api/address/[...address].ts
+++ b/src/pages/api/address/[...address].ts
@@ -5,7 +5,6 @@ import { addressSchema } from '@/core/address/validation';
 import { z } from 'zod';
 
 const userSchema = z.object({ userId: z.string().uuid() });
-const idSchema = z.string();
 const createSchema = addressSchema.extend({ userId: z.string().uuid() });
 const updateSchema = addressSchema.partial().extend({ userId: z.string().uuid() });
 

--- a/src/pages/api/auth/[...auth].ts
+++ b/src/pages/api/auth/[...auth].ts
@@ -18,7 +18,7 @@ const LoginSchema = z.object({
  */
 const loginHandler = createApiHandler({
   methods: ['POST'],
-  async handler(req, res) {
+  async handler(req) {
     const parse = LoginSchema.safeParse(req.body);
     if (!parse.success) {
       throw new ApiError(400, 'Invalid credentials input', { details: parse.error.flatten() });

--- a/src/pages/api/users/[id].ts
+++ b/src/pages/api/users/[id].ts
@@ -15,7 +15,7 @@ const createUserSchema = z.object({
 const getUserHandler = createApiHandler({
   methods: ['GET'],
   requiresAuth: true,
-  async handler(req, res) {
+  async handler(req) {
     const { id } = req.query;
     
     // Validate user ID
@@ -32,7 +32,7 @@ const getUserHandler = createApiHandler({
     }
 
     // Omit sensitive data before sending response
-    const { password, ...safeUser } = user;
+    const { password: _password, ...safeUser } = user;
     return safeUser;
   },
 });
@@ -42,7 +42,7 @@ const updateUserHandler = createApiHandler({
   methods: ['PATCH'],
   requiresAuth: true,
   // schema: createUserSchema.partial(), // Uncomment and use with validation
-  async handler(req, res) {
+  async handler(req) {
     const { id } = req.query;
     const updateData = req.body;
 
@@ -63,7 +63,7 @@ const updateUserHandler = createApiHandler({
     const userService = getApiUserService();
     const updatedUser = await userService.updateUser(idValidation.data, dataValidation.data);
     
-    const { password, ...safeUser } = updatedUser;
+    const { password: _password, ...safeUser } = updatedUser;
     return safeUser;
   },
 });
@@ -73,7 +73,7 @@ const deleteUserHandler = createApiHandler({
   methods: ['DELETE'],
   requiresAuth: true,
   requiredRoles: ['admin'],
-  async handler(req, res) {
+  async handler(req) {
     const { id } = req.query;
     
     const validation = userIdSchema.safeParse(id);

--- a/src/scripts/fix-initialization.ts
+++ b/src/scripts/fix-initialization.ts
@@ -7,7 +7,6 @@
  */
 
 import { UserManagementConfiguration } from "@/core/config";
-import { createSupabaseClient } from "@/lib/database/supabase";
 import { api } from "@/lib/api/axios";
 
 // Import factory functions

--- a/src/services/address/__tests__/factory.test.ts
+++ b/src/services/address/__tests__/factory.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import type { UserManagementConfiguration as UMCType } from '@/core/config';
 
 let getApiAddressService: typeof import('../factory').getApiAddressService;
 let DefaultAddressService: typeof import('../default-address.service').DefaultAddressService;

--- a/src/services/auth/__tests__/business-sso.test.tsx
+++ b/src/services/auth/__tests__/business-sso.test.tsx
@@ -1,8 +1,4 @@
-/// <reference types="vitest" />
-// __tests__/auth/sso/business-sso.test.tsx
-
 import { vi } from 'vitest';
-import * as useOrganizationModule from '@/lib/hooks/useOrganization';
 
 declare global {
   // eslint-disable-next-line no-var

--- a/src/services/auth/__tests__/mocks/auth.store.mock.ts
+++ b/src/services/auth/__tests__/mocks/auth.store.mock.ts
@@ -186,10 +186,6 @@ export function createMockAuthStore(
   // Allow direct state mutation for tests
   store.__setState = (partial: Partial<AuthState>, replace = false) => store.setState(partial, replace);
 
-  // Create a function that returns the store
-  function useAuth() {
-    return store;
-  }
   // Attach Zustand-like static methods
   useAuthStore.getState = store.getState;
   useAuthStore.setState = store.setState;

--- a/src/services/auth/__tests__/mocks/mock-auth-service.ts
+++ b/src/services/auth/__tests__/mocks/mock-auth-service.ts
@@ -82,26 +82,26 @@ export class MockAuthService implements AuthService {
     return this.mockAuthState.isAuthenticated;
   });
 
-  resetPassword = vi.fn().mockImplementation(async (email: string): Promise<{ success: boolean; message?: string; error?: string }> => {
+  resetPassword = vi.fn().mockImplementation(async (_email: string): Promise<{ success: boolean; message?: string; error?: string }> => {
     return { success: true, message: 'Password reset email sent' };
   });
 
-  updatePassword = vi.fn().mockImplementation(async (oldPassword: string, newPassword: string): Promise<void> => {
+  updatePassword = vi.fn().mockImplementation(async (_oldPassword: string, _newPassword: string): Promise<void> => {
     // Implementation not needed for most tests
   });
 
-  sendVerificationEmail = vi.fn().mockImplementation(async (email: string): Promise<AuthResult> => {
+  sendVerificationEmail = vi.fn().mockImplementation(async (_email: string): Promise<AuthResult> => {
     return { success: true };
   });
 
-  verifyEmail = vi.fn().mockImplementation(async (token: string): Promise<void> => {
+  verifyEmail = vi.fn().mockImplementation(async (_token: string): Promise<void> => {
     if (this.mockUser) {
       this.mockUser.emailVerified = true;
       this.notifyListeners(this.mockUser);
     }
   });
 
-  deleteAccount = vi.fn().mockImplementation(async (password?: string): Promise<void> => {
+  deleteAccount = vi.fn().mockImplementation(async (_password?: string): Promise<void> => {
     this.mockUser = null;
     this.mockAuthState = {
       ...this.mockAuthState,
@@ -119,7 +119,7 @@ export class MockAuthService implements AuthService {
     };
   });
 
-  verifyMFA = vi.fn().mockImplementation(async (code: string): Promise<MFAVerifyResponse> => {
+  verifyMFA = vi.fn().mockImplementation(async (_code: string): Promise<MFAVerifyResponse> => {
     this.mockAuthState = {
       ...this.mockAuthState,
       mfaEnabled: true
@@ -127,7 +127,7 @@ export class MockAuthService implements AuthService {
     return { success: true, token: 'mock-mfa-token' };
   });
 
-  disableMFA = vi.fn().mockImplementation(async (code: string): Promise<AuthResult> => {
+  disableMFA = vi.fn().mockImplementation(async (_code: string): Promise<AuthResult> => {
     this.mockAuthState = {
       ...this.mockAuthState,
       mfaEnabled: false

--- a/src/services/auth/default-auth.service.ts
+++ b/src/services/auth/default-auth.service.ts
@@ -5,7 +5,7 @@
  * It provides the default implementation for authentication operations.
  */
 
-import { AuthService, AuthState } from "@/core/auth/interfaces";
+import { AuthService } from "@/core/auth/interfaces";
 import type { IAuthDataProvider } from "@/core/auth/IAuthDataProvider";
 import { 
   AuthResult, 
@@ -15,7 +15,7 @@ import {
   RegistrationPayload, 
   User 
 } from '@/core/auth/models';
-import { AuthEventHandler, AuthEventTypes } from '@/core/auth/events';
+import { AuthEventTypes } from '@/core/auth/events';
 import { translateError } from '@/lib/utils/error';
 import { TypedEventEmitter } from '@/lib/utils/typed-event-emitter';
 import type { SessionTracker } from './session-tracker';

--- a/src/services/permission/__tests__/mocks/mock-permission-service.ts
+++ b/src/services/permission/__tests__/mocks/mock-permission-service.ts
@@ -1,6 +1,6 @@
 // src/services/permission/__tests__/mocks/mock-permission-service.ts
 import { vi } from 'vitest';
-import { PermissionService, PermissionState } from '../../../../core/permission/interfaces';
+import { PermissionService } from '../../../../core/permission/interfaces';
 import { 
   Permission, 
   Role, 
@@ -11,7 +11,6 @@ import {
   RoleUpdatePayload
 } from '../../../../core/permission/models';
 import {
-  PermissionEvent,
   PermissionEventHandler,
   PermissionEventTypes,
 } from '../../../../core/permission/events';
@@ -140,7 +139,7 @@ export class MockPermissionService implements PermissionService {
       return false;
     }
     
-    const role = { ...this.mockRoles[roleId] };
+    const _role = { ...this.mockRoles[roleId] };
     delete this.mockRoles[roleId];
     delete this.mockRolePermissions[roleId];
     

--- a/src/services/permission/__tests__/mocks/rbac.store.mock.ts
+++ b/src/services/permission/__tests__/mocks/rbac.store.mock.ts
@@ -18,7 +18,7 @@ interface RBACStoreMockState {
 
 export function createRBACStoreMock(overrides = {}) {
   // Use Zustand to create a real store instance
-  const useRBACStore = create<RBACStoreMockState>((set, get) => ({
+  const useRBACStore = create<RBACStoreMockState>((set, _get) => ({
     roles: [],
     userRoles: [],
     isLoading: false,

--- a/src/services/permission/api-permission.service.ts
+++ b/src/services/permission/api-permission.service.ts
@@ -8,7 +8,7 @@ import {
   RoleCreationPayload,
   RoleUpdatePayload
 } from '@/core/permission/models';
-import { PermissionEventHandler, PermissionEventTypes, PermissionEvent } from '@/core/permission/events';
+import { PermissionEventHandler } from '@/core/permission/events';
 
 /**
  * API-based implementation of {@link PermissionService} for client usage.

--- a/src/services/permission/default-permission.service.ts
+++ b/src/services/permission/default-permission.service.ts
@@ -9,7 +9,6 @@ import { PermissionService } from "@/core/permission/interfaces";
 import {
   Permission,
   Role,
-  RoleEntity,
   RoleWithPermissions,
   UserRole,
   PermissionAssignment,

--- a/src/services/session/api-session.service.ts
+++ b/src/services/session/api-session.service.ts
@@ -6,6 +6,7 @@ import type { SessionInfo } from '@/core/session/models';
  */
 export class ApiSessionService implements SessionService {
   async listUserSessions(_userId: string): Promise<SessionInfo[]> {
+    void _userId;
     const res = await fetch('/api/session', { credentials: 'include' });
     if (!res.ok) throw new Error('Failed to fetch sessions');
     const data = await res.json();
@@ -13,6 +14,7 @@ export class ApiSessionService implements SessionService {
   }
 
   async revokeUserSession(_userId: string, sessionId: string): Promise<{ success: boolean; error?: string }> {
+    void _userId;
     const res = await fetch(`/api/session/${sessionId}`, { method: 'DELETE', credentials: 'include' });
     if (!res.ok) {
       const data = await res.json();

--- a/src/services/team/__tests__/mocks/mock-team-service.ts
+++ b/src/services/team/__tests__/mocks/mock-team-service.ts
@@ -1,6 +1,6 @@
 // src/services/team/__tests__/mocks/mock-team-service.ts
 import { vi } from 'vitest';
-import { TeamService, TeamState } from '../../../../core/team/interfaces';
+import { TeamService } from '../../../../core/team/interfaces';
 import { 
   Team, 
   TeamMember, 

--- a/src/services/team/default-team.service.ts
+++ b/src/services/team/default-team.service.ts
@@ -20,9 +20,7 @@ import {
   TeamMemberResult,
   TeamInvitationResult,
   TeamSearchParams,
-  TeamSearchResult,
-  InvitationStatus,
-  TeamVisibility
+  TeamSearchResult
 } from '@/core/team/models';
 import { TeamEventType } from '@/core/team/events';
 import type { TeamDataProvider } from '@/core/team/ITeamDataProvider';

--- a/src/services/two-factor/factory.ts
+++ b/src/services/two-factor/factory.ts
@@ -20,7 +20,6 @@ let twoFactorServiceInstance: TwoFactorService | null = null;
  */
 export function getApiTwoFactorService(): TwoFactorService {
   if (!twoFactorServiceInstance) {
-    const twoFactorDataProvider = AdapterRegistry.getInstance().getAdapter<ITwoFactorDataProvider>('twoFactor');
     twoFactorServiceInstance = UserManagementConfiguration.getServiceProvider('twoFactorService') as TwoFactorService;
     if (!twoFactorServiceInstance) {
       throw new Error('Two-factor service not registered in UserManagementConfiguration');

--- a/src/services/user/__tests__/mocks/companyProfileStore.mock.ts
+++ b/src/services/user/__tests__/mocks/companyProfileStore.mock.ts
@@ -1,4 +1,3 @@
-import { CompanyProfile, CompanyAddress, AddressType } from '@/types/company';
 
 interface CompanyProfileStoreMockState {
   profile: any;

--- a/src/services/user/__tests__/mocks/mock-user-service.ts
+++ b/src/services/user/__tests__/mocks/mock-user-service.ts
@@ -1,6 +1,6 @@
 // src/services/user/__tests__/mocks/mock-user-service.ts
 import { vi } from 'vitest';
-import { UserService, UserState } from '../../../../core/user/interfaces';
+import { UserService } from '../../../../core/user/interfaces';
 import { 
   UserProfile, 
   ProfileUpdatePayload, 
@@ -126,7 +126,7 @@ export class MockUserService implements UserService {
     };
   });
 
-  uploadProfilePicture = vi.fn().mockImplementation(async (userId: string, imageData: Blob): Promise<{ success: boolean; imageUrl?: string; error?: string }> => {
+  uploadProfilePicture = vi.fn().mockImplementation(async (userId: string, _imageData: Blob): Promise<{ success: boolean; imageUrl?: string; error?: string }> => {
     if (!this.mockProfiles[userId]) {
       return { success: false, error: 'User not found' };
     }
@@ -241,7 +241,7 @@ export class MockUserService implements UserService {
     };
   });
 
-  deactivateUser = vi.fn().mockImplementation(async (userId: string, reason?: string): Promise<{ success: boolean; error?: string }> => {
+  deactivateUser = vi.fn().mockImplementation(async (userId: string, _reason?: string): Promise<{ success: boolean; error?: string }> => {
     if (!this.mockProfiles[userId]) {
       return { success: false, error: 'User not found' };
     }

--- a/src/services/user/api-user.service.ts
+++ b/src/services/user/api-user.service.ts
@@ -16,6 +16,7 @@ import {
  */
 export class ApiUserService implements UserService {
   async getUserProfile(_userId: string): Promise<UserProfile | null> {
+    void _userId;
     const res = await fetch('/api/user/profile', { credentials: 'include' });
     if (!res.ok) return null;
     const data = await res.json();
@@ -26,6 +27,7 @@ export class ApiUserService implements UserService {
     _userId: string,
     profileData: ProfileUpdatePayload
   ): Promise<UserProfileResult> {
+    void _userId;
     const res = await fetch('/api/user/profile', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
@@ -40,6 +42,7 @@ export class ApiUserService implements UserService {
   }
 
   async getUserPreferences(_userId: string): Promise<UserPreferences> {
+    void _userId;
     const res = await fetch('/api/user/settings', { credentials: 'include' });
     if (!res.ok) throw new Error('Failed to fetch preferences');
     const data = await res.json();
@@ -50,6 +53,7 @@ export class ApiUserService implements UserService {
     _userId: string,
     preferences: PreferencesUpdatePayload
   ): Promise<{ success: boolean; preferences?: UserPreferences; error?: string }> {
+    void _userId;
     const res = await fetch('/api/user/settings', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
@@ -67,6 +71,7 @@ export class ApiUserService implements UserService {
     _userId: string,
     imageData: Blob
   ): Promise<{ success: boolean; imageUrl?: string; error?: string }> {
+    void _userId;
     const base64 = await imageData.arrayBuffer().then(buf =>
       Buffer.from(buf).toString('base64')
     );
@@ -84,6 +89,7 @@ export class ApiUserService implements UserService {
   }
 
   async deleteProfilePicture(_userId: string): Promise<{ success: boolean; error?: string }> {
+    void _userId;
     const res = await fetch('/api/user/avatar', {
       method: 'DELETE',
       credentials: 'include'
@@ -97,6 +103,7 @@ export class ApiUserService implements UserService {
     _userId: string,
     visibility: ProfileVisibility
   ): Promise<{ success: boolean; visibility?: ProfileVisibility; error?: string }> {
+    void _userId;
     const res = await fetch('/api/profile/privacy', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
@@ -118,6 +125,7 @@ export class ApiUserService implements UserService {
   }
 
   async deactivateUser(_userId: string, reason?: string): Promise<{ success: boolean; error?: string }> {
+    void _userId;
     const res = await fetch('/api/retention/deactivate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -132,6 +140,7 @@ export class ApiUserService implements UserService {
   }
 
   async reactivateUser(_userId: string): Promise<{ success: boolean; error?: string }> {
+    void _userId;
     const res = await fetch('/api/retention/reactivate', {
       method: 'POST',
       credentials: 'include'
@@ -148,6 +157,7 @@ export class ApiUserService implements UserService {
     newType: string,
     additionalData?: Record<string, any>
   ): Promise<UserProfileResult> {
+    void _userId;
     const res = await fetch('/api/user/convert-type', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/src/services/user/default-user.service.ts
+++ b/src/services/user/default-user.service.ts
@@ -20,7 +20,6 @@ import {
   ProfileVisibility
 } from '@/core/user/models';
 import { UserEventType } from '@/core/user/events';
-import { translateError } from '@/lib/utils/error';
 import { TypedEventEmitter } from '@/lib/utils/typed-event-emitter';
 
 /**

--- a/src/services/webhooks/WebhookService.ts
+++ b/src/services/webhooks/WebhookService.ts
@@ -74,6 +74,6 @@ export class WebhookService implements IWebhookService {
 
     const results = await this.sender.sendWebhookEvent(eventType, payload, userId);
     // Strip success field before returning
-    return results.map(({ success, ...delivery }) => delivery);
+    return results.map(({ success: _success, ...delivery }) => delivery);
   }
 }

--- a/src/tests/integration/account-settings-flow.test.tsx
+++ b/src/tests/integration/account-settings-flow.test.tsx
@@ -1,8 +1,5 @@
 // __tests__/integration/account-settings-flow.test.js
 
-import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 // import { AccountSettings } from '../../components/account/AccountSettings'; // TODO: Update path if file exists
 import { vi } from 'vitest';
 // import { supabase } from '../../lib/supabase'; // TODO: Update path if file exists
@@ -11,19 +8,9 @@ import { vi } from 'vitest';
 vi.mock('@/lib/supabase');
 
 describe('Account Settings Flow', () => {
-  let user;
-
-  // Create mock authenticated user
-  const mockUser = {
-    id: 'user-123',
-    email: 'user@example.com',
-    role: 'authenticated',
-    app_metadata: { role: 'user' }
-  };
 
   beforeEach(() => {
     vi.clearAllMocks();
-    user = userEvent.setup();
     
     // Mock user authentication
     // supabase.auth.getUser.mockResolvedValue({

--- a/src/tests/integration/account-switching-flow.test.tsx
+++ b/src/tests/integration/account-switching-flow.test.tsx
@@ -1,7 +1,7 @@
 // __tests__/integration/account-switching-flow.test.tsx
 import { vi, beforeEach, describe, expect, test, afterEach } from 'vitest';
 import '@/tests/i18nTestSetup';
-import { supabase, setTableMockData } from '@/tests/mocks/supabase';
+import { setTableMockData } from '@/tests/mocks/supabase';
 
 // IMPORTANT: vi.mock must be at the top, BEFORE any variable declarations
 vi.mock('@/lib/database/supabase', async () => await import('../../tests/mocks/supabase'));

--- a/src/tests/integration/api-error-messages.test.tsx
+++ b/src/tests/integration/api-error-messages.test.tsx
@@ -6,7 +6,7 @@ import { supabase } from '@/lib/database/supabase';
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { LoginForm } from '\.\.\/\.\.\/src\/components/auth/LoginForm';
+import { LoginForm } from '../../src/components/auth/LoginForm';
 
 describe('API Error Messages', () => {
   let user;

--- a/src/tests/integration/collaboration-flow.test.tsx
+++ b/src/tests/integration/collaboration-flow.test.tsx
@@ -8,8 +8,8 @@ vi.mock('@/lib/database/supabase', () => {
   // Define all mocks inside the factory to avoid hoisting issues
   const selectSpy = vi.fn();
   const updateSpy = vi.fn();
-  const insertSpy = vi.fn();
-  const deleteSpy = vi.fn();
+  const _insertSpy = vi.fn();
+  const _deleteSpy = vi.fn();
   const eqSpy = vi.fn();
   const channelSpy = vi.fn();
   const onSpy = vi.fn();
@@ -20,8 +20,8 @@ vi.mock('@/lib/database/supabase', () => {
   (global as any).__supabaseSpies = {
     selectSpy,
     updateSpy,
-    insertSpy,
-    deleteSpy,
+    insertSpy: _insertSpy,
+    deleteSpy: _deleteSpy,
     eqSpy,
     channelSpy,
     onSpy,
@@ -37,8 +37,8 @@ vi.mock('@/lib/database/supabase', () => {
         update: updateSpy.mockImplementation(() => ({
           eq: eqSpy.mockImplementation(() => Promise.resolve({ data: { updated: true }, error: null }))
         })),
-        insert: insertSpy,
-        delete: deleteSpy.mockImplementation(() => ({
+        insert: _insertSpy,
+        delete: _deleteSpy.mockImplementation(() => ({
           eq: eqSpy.mockImplementation(() => Promise.resolve({ data: { deleted: true }, error: null }))
         })),
       })),
@@ -66,8 +66,8 @@ import { describe, test, expect, beforeEach } from 'vitest';
 const {
   selectSpy,
   updateSpy,
-  insertSpy,
-  deleteSpy,
+  insertSpy: _insertSpy,
+  deleteSpy: _deleteSpy,
   eqSpy,
   channelSpy,
   onSpy,

--- a/src/tests/integration/data-management-flow.test.tsx
+++ b/src/tests/integration/data-management-flow.test.tsx
@@ -13,18 +13,6 @@ const updateSpy = vi.fn();
 const deleteSpy = vi.fn();
 const eqSpy = vi.fn();
 
-// Create chain-returning mock objects for method chaining
-const updateWithEq = {
-  update: vi.fn().mockReturnValue({
-    eq: eqSpy
-  })
-};
-
-const deleteWithEq = {
-  delete: vi.fn().mockReturnValue({
-    eq: eqSpy
-  })
-};
 
 // Fix the mocking approach: make update and delete use their spies and return chainable eq
 vi.mock('@/lib/database/supabase', () => {

--- a/src/tests/integration/feedback-submission-flow.test.tsx
+++ b/src/tests/integration/feedback-submission-flow.test.tsx
@@ -118,7 +118,7 @@ describe('Feedback Submission Flow', () => {
       readyState: 0,
       error: null,
       // Add only necessary methods
-      readAsDataURL: vi.fn(function(this: any, blob: Blob) {
+      readAsDataURL: vi.fn(function(this: any, _blob: Blob) {
         setTimeout(() => {
           // Set result before calling onload
           this.result = 'data:image/png;base64,c2NyZWVuc2hvdCBkYXRh';

--- a/src/tests/integration/organization-security-policy.integration.test.tsx
+++ b/src/tests/integration/organization-security-policy.integration.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import '@/tests/i18nTestSetup';
 import { OrganizationSessionManager } from '@/ui/styled/company/OrganizationSessionManager';
 import { DEFAULT_SECURITY_POLICY } from '@/types/organizations';
 import { validatePasswordWithPolicy } from '@/lib/security/password-validation';
-import { supabase } from '@/lib/database/supabase';
 
 // Mock dependencies
 vi.mock('@/hooks/user/useOrganizationSession', () => ({

--- a/src/tests/integration/session-management.integration.test.tsx
+++ b/src/tests/integration/session-management.integration.test.tsx
@@ -2,7 +2,6 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SessionPolicyEnforcer } from '@/ui/styled/session/SessionPolicyEnforcer';
-import { useAuth } from '@/hooks/auth/useAuth';
 import { api } from '@/lib/api/axios';
 
 // Mock the API module

--- a/src/types/jest-types.ts
+++ b/src/types/jest-types.ts
@@ -1,5 +1,3 @@
-import { Mock } from 'jest-mock';
-
 // Type helper for Jest mock functions
 export type JestMockFunction<TReturn, TArgs extends any[]> = jest.Mock<TReturn, TArgs>;
 


### PR DESCRIPTION
## Summary
- remove unused imports and parameters across src
- clean up subscription store
- streamline tests and API handlers

## Testing
- `npx vitest run --coverage` *(fails: JavaScript heap out of memory)*