### PR TITLE
Fix eslint warnings in multiple files

### DIFF
--- a/e2e/subscription-and-licensing/License/license-management.test.ts
+++ b/e2e/subscription-and-licensing/License/license-management.test.ts
@@ -6,11 +6,9 @@ import { test, expect } from '@playwright/test';
 const USER_EMAIL = process.env.E2E_USER_EMAIL || 'user@example.com';
 const USER_PASSWORD = process.env.E2E_USER_PASSWORD || 'password123';
 const LICENSE_URL = '/license';
-const ACTIVATE_LICENSE_URL = '/license/activate';
-const TEST_LICENSE_KEY = 'TEST-LICENSE-KEY-1234-5678-90AB-CDEF';
 
 // --- Helper Functions --- //
-async function fillLoginForm(page, browserName) {
+async function fillLoginForm(page) {
   // Use a reliable, browser-independent login approach as mentioned in TESTING ISSUES-E2E.md
   try {
     // Method 1: Standard input filling
@@ -106,7 +104,7 @@ async function injectLicenseUIIfNeeded(page) {
 
 // --- Test Suite --- //
 test.describe('License Management Flow', () => {
-  test.beforeEach(async ({ page, browserName }) => {
+  test.beforeEach(async ({ page }) => {
     // Navigate to the login page with fallback strategy
     try {
       await page.goto('/auth/login', { timeout: 10000 });
@@ -119,7 +117,7 @@ test.describe('License Management Flow', () => {
     await page.waitForSelector('form', { timeout: 10000 });
     
     // Login with test credentials using our enhanced login helper
-    await fillLoginForm(page, browserName);
+    await fillLoginForm(page);
     
     // Wait for login to complete using multiple indicators
     try {
@@ -148,7 +146,7 @@ test.describe('License Management Flow', () => {
       }
     }
   });
-  test('User can view license information', async ({ page, browserName }) => {
+  test('User can view license information', async ({ page }) => {
     // Navigate to license page with fallback
     try {
       await page.goto(LICENSE_URL, { timeout: 10000 });

--- a/e2e/subscription-and-licensing/License/team-seat-licensing.test.ts
+++ b/e2e/subscription-and-licensing/License/team-seat-licensing.test.ts
@@ -255,7 +255,6 @@ async function injectTeamManagementUIIfNeeded(page: any) {
           });
           
           document.getElementById('confirm-remove')?.addEventListener('click', (e) => {
-            const userId = (e.currentTarget as HTMLElement).getAttribute('data-user-id');
             document.getElementById('remove-confirm-modal')?.remove();
             
             // Remove the team member from the UI

--- a/e2e/subscription-and-licensing/Payment/paymentmethods.test.ts
+++ b/e2e/subscription-and-licensing/Payment/paymentmethods.test.ts
@@ -8,7 +8,7 @@ const USER_PASSWORD = process.env.E2E_USER_PASSWORD || 'password123';
 const PAYMENT_METHODS_URL = '/payment/methods';
 
 // --- Helper Functions --- //
-async function fillLoginForm(page, browserName) {
+async function fillLoginForm(page) {
   // Use a reliable, browser-independent login approach as mentioned in TESTING ISSUES-E2E.md
   try {
     // Method 1: Standard input filling
@@ -64,7 +64,7 @@ test.describe('Payment Methods Management', () => {
     await page.waitForSelector('form', { timeout: 10000 });
     
     // Login with test credentials using our enhanced login helper
-    await fillLoginForm(page, browserName);
+    await fillLoginForm(page);
     
     // Wait for login to complete using multiple indicators
     try {

--- a/e2e/subscription-and-licensing/Subscription/feature-gating.test.ts
+++ b/e2e/subscription-and-licensing/Subscription/feature-gating.test.ts
@@ -7,7 +7,7 @@ const PREMIUM_USER_EMAIL = process.env.E2E_PREMIUM_USER_EMAIL || 'premium@exampl
 const PREMIUM_USER_PASSWORD = process.env.E2E_PREMIUM_USER_PASSWORD || 'premiumpass123';
 
 // --- Helper Functions --- //
-async function fillLoginForm(page, email, password, browserName) {
+async function fillLoginForm(page, email, password) {
   // Use a reliable, browser-independent login approach as mentioned in TESTING ISSUES-E2E.md
   try {
     // Method 1: Standard input filling 
@@ -186,7 +186,7 @@ test.describe('Feature Gating for Subscription Tiers', () => {
     await page.waitForSelector('form', { timeout: 10000 });
     
     // Login with free user credentials
-    await fillLoginForm(page, USER_EMAIL, USER_PASSWORD, browserName);
+    await fillLoginForm(page, USER_EMAIL, USER_PASSWORD);
     
     // Navigate to dashboard or home page where premium features might be available
     try {
@@ -277,7 +277,7 @@ test.describe('Feature Gating for Subscription Tiers', () => {
     await page.waitForSelector('form', { timeout: 10000 });
     
     // Login with premium user credentials
-    await fillLoginForm(page, PREMIUM_USER_EMAIL, PREMIUM_USER_PASSWORD, browserName);
+    await fillLoginForm(page, PREMIUM_USER_EMAIL, PREMIUM_USER_PASSWORD);
     
     // Navigate to dashboard or home page where premium features are available
     try {
@@ -342,7 +342,7 @@ test.describe('Feature Gating for Subscription Tiers', () => {
     await page.waitForSelector('form', { timeout: 10000 });
     
     // Login with free user credentials
-    await fillLoginForm(page, USER_EMAIL, USER_PASSWORD, browserName);
+    await fillLoginForm(page, USER_EMAIL, USER_PASSWORD);
     
     // Inject premium feature buttons with disabled state if they don't exist
     await page.evaluate(() => {
@@ -430,7 +430,7 @@ test.describe('Feature Gating for Subscription Tiers', () => {
     await page.waitForSelector('form', { timeout: 10000 });
     
     // Login with free user credentials
-    await fillLoginForm(page, USER_EMAIL, USER_PASSWORD, browserName);
+    await fillLoginForm(page, USER_EMAIL, USER_PASSWORD);
     
     // Inject usage limit test UI if it doesn't exist
     await page.evaluate(() => {

--- a/e2e/subscription-and-licensing/Subscription/subsription.test.ts
+++ b/e2e/subscription-and-licensing/Subscription/subsription.test.ts
@@ -5,7 +5,6 @@ const USER_EMAIL = process.env.E2E_USER_EMAIL || 'user@example.com';
 const USER_PASSWORD = process.env.E2E_USER_PASSWORD || 'password123';
 const SUBSCRIPTION_URL = '/subscription';
 const PLANS_URL = '/subscription/plans';
-const PORTAL_URL = '/subscription/manage';
 
 // --- Test Suite --- //
 test.describe('Subscription Management Flows', () => {

--- a/e2e/subscription-and-licensing/Subscription/subsriptionflow.test.ts
+++ b/e2e/subscription-and-licensing/Subscription/subsriptionflow.test.ts
@@ -9,7 +9,7 @@ const SUBSCRIPTION_URL = '/subscription';
 const PLANS_URL = '/subscription/plans';
 
 // --- Helper Functions --- //
-async function fillLoginForm(page, browserName) {
+async function fillLoginForm(page) {
   // Use a reliable, browser-independent login approach as mentioned in TESTING ISSUES-E2E.md
   try {
     // Method 1: Standard input filling 
@@ -65,7 +65,7 @@ test.describe('Subscription Management Flow', () => {
     await page.waitForSelector('form', { timeout: 10000 });
     
     // Login with test credentials using our enhanced login helper
-    await fillLoginForm(page, browserName);
+    await fillLoginForm(page);
     
     // Wait for login to complete using multiple indicators (Issue #14)
     try {

--- a/e2e/subscription-and-licensing/payment-checkout-flow.e2e.test.ts
+++ b/e2e/subscription-and-licensing/payment-checkout-flow.e2e.test.ts
@@ -294,7 +294,7 @@ test.describe('Payment Checkout Flow', () => {
     }
   });
 
-  test('User can view subscription details after purchase', async ({ page, browserName }) => {
+  test('User can view subscription details after purchase', async ({ page }) => {
     // First, mock a subscription or ensure one exists for the test user
     // For this test, we'll assume the user already has an active subscription
 
@@ -390,7 +390,7 @@ test.describe('Payment Checkout Flow', () => {
 });
 
 test.describe('Checkout Edge Cases', () => {
-  test('Handle checkout cancellation gracefully', async ({ page, browserName }) => {
+  test('Handle checkout cancellation gracefully', async ({ page }) => {
     // Log in first
     await loginAs(page, TEST_USER, TEST_PASSWORD);
 
@@ -409,7 +409,7 @@ test.describe('Checkout Edge Cases', () => {
     await expect(returnLink).toBeVisible();
   });
 
-  test('Handle successful checkout return', async ({ page, browserName }) => {
+  test('Handle successful checkout return', async ({ page }) => {
     // Log in first
     await loginAs(page, TEST_USER, TEST_PASSWORD);
 
@@ -428,7 +428,7 @@ test.describe('Checkout Edge Cases', () => {
     await expect(viewSubscriptionLink).toBeVisible();
   });
 
-  test('Handle provider outage gracefully', async ({ page, browserName }) => {
+  test('Handle provider outage gracefully', async ({ page }) => {
     // Log in first
     await loginAs(page, TEST_USER, TEST_PASSWORD);
 

--- a/e2e/team-invite-flow.e2e.test.ts
+++ b/e2e/team-invite-flow.e2e.test.ts
@@ -11,7 +11,7 @@ const INVITEE_EMAIL = `test-invite-${Date.now()}@example.com`;
 const INVITEE_PASSWORD = 'Password123!';
 
 // Helper function for reliable login across browsers
-async function fillLoginForm(page: Page, email: string, password: string, browserName: string): Promise<void> {
+async function fillLoginForm(page: Page, email: string, password: string): Promise<void> {
   try {
     // Method 1: Standard input filling 
     await page.locator('#email').fill(email);
@@ -158,7 +158,7 @@ test.describe('Team Invite Flow', () => {
       throw new Error('Login form not found');
     }
     
-    await fillLoginForm(page, ADMIN_EMAIL, ADMIN_PASSWORD, browserName);
+    await fillLoginForm(page, ADMIN_EMAIL, ADMIN_PASSWORD);
     console.log('Admin login successful');
     
     // Step 2: Navigate to team management page
@@ -384,7 +384,7 @@ test.describe('Team Invite Flow', () => {
     } else {
       console.log('On login page, logging in with invite email');
       // We're on a login page, fill it out
-      await fillLoginForm(page, INVITEE_EMAIL, INVITEE_PASSWORD, browserName);
+      await fillLoginForm(page, INVITEE_EMAIL, INVITEE_PASSWORD);
     }
     
     // Step 6: Verify the invited user is now part of the team
@@ -465,7 +465,7 @@ test.describe('Team Invite Flow', () => {
     console.log('=== Testing admin view of pending invites ===');
     // Log in as admin
     await navigateWithFallback(page, '/auth/login');
-    await fillLoginForm(page, ADMIN_EMAIL, ADMIN_PASSWORD, browserName);
+    await fillLoginForm(page, ADMIN_EMAIL, ADMIN_PASSWORD);
     
     // Navigate to team management
     await navigateWithFallback(page, '/team');

--- a/migrate-to-vitest.js
+++ b/migrate-to-vitest.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');

--- a/scripts/migrate-auth-imports.js
+++ b/scripts/migrate-auth-imports.js
@@ -13,6 +13,7 @@
  * --path=<directory>: Only process files in the specified directory
  */
 
+/* eslint-disable @typescript-eslint/no-var-requires */
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');

--- a/scripts/migrate-imports.js
+++ b/scripts/migrate-imports.js
@@ -14,6 +14,7 @@
  * --path=<directory>: Only process files in the specified directory
  */
 
+/* eslint-disable @typescript-eslint/no-var-requires */
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
@@ -123,10 +124,6 @@ const exactPathMappings = {
   '@/utils/permission': '@/services/permission/permission-utils',
 };
 
-// Function to convert PascalCase to kebab-case
-function pascalToKebabCase(str) {
-  return str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
-}
 
 // Generate additional mappings for common patterns
 const pathMappings = [];
@@ -141,7 +138,7 @@ Object.entries(exactPathMappings).forEach(([oldPath, newPath]) => {
 
 // Add kebab-case converter for new architecture paths
 pathMappings.push({
-  pattern: /from ['"](\@\/(?:ui|hooks|services|adapters|core)\/[a-zA-Z0-9-/]+)\/([A-Z][a-zA-Z0-9]*)['"]/,
+  pattern: /from ['"](@\/(?:ui|hooks|services|adapters|core)\/[a-zA-Z0-9-/]+)\/([A-Z][a-zA-Z0-9]*)['"]/,
   replacement: (match, p1, p2) => {
     // Convert PascalCase to kebab-case
     const kebabCase = p2.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
@@ -153,7 +150,6 @@ pathMappings.push({
 function processFile(filePath) {
   try {
     let content = fs.readFileSync(filePath, 'utf8');
-    let originalContent = content;
     let hasChanges = false;
     
     // Apply each mapping

--- a/src/adapters/__tests__/registry.test.ts
+++ b/src/adapters/__tests__/registry.test.ts
@@ -1,6 +1,6 @@
 
 
-import { AdapterRegistry, AdapterFactory, AdapterFactoryOptions } from '../registry';
+import { AdapterRegistry, AdapterFactory } from '../registry';
 import { SupabaseAdapterFactory, createSupabaseAdapterFactory } from '../supabase-factory';
 import { AuthDataProvider, UserDataProvider, TeamDataProvider, PermissionDataProvider } from '../interfaces';
 

--- a/src/adapters/auth/supabase-auth-provider.ts
+++ b/src/adapters/auth/supabase-auth-provider.ts
@@ -352,9 +352,9 @@ export class SupabaseAuthProvider implements IAuthDataProvider {
    * @param code MFA code from authenticator app for verification
    * @returns Authentication result with success status or error
    */
-  async disableMFA(code: string): Promise<AuthResult> {
+  async disableMFA(_code: string): Promise<AuthResult> {
     try {
-      const { data, error } = await this.supabase.auth.mfa.unenroll({
+      const { error } = await this.supabase.auth.mfa.unenroll({
         factorId: 'totp'
       });
       

--- a/src/adapters/organization/default-organization-adapter.ts
+++ b/src/adapters/organization/default-organization-adapter.ts
@@ -8,28 +8,28 @@ import type {
 
 export class DefaultOrganizationAdapter implements IOrganizationDataProvider {
   async createOrganization(
-    ownerId: string,
-    data: OrganizationCreatePayload
+    _ownerId: string,
+    _data: OrganizationCreatePayload
   ): Promise<OrganizationResult> {
     return { success: false, error: 'Not implemented' };
   }
 
-  async getOrganization(id: string): Promise<Organization | null> {
+  async getOrganization(_id: string): Promise<Organization | null> {
     return null;
   }
 
-  async getUserOrganizations(userId: string): Promise<Organization[]> {
+  async getUserOrganizations(_userId: string): Promise<Organization[]> {
     return [];
   }
 
   async updateOrganization(
-    id: string,
-    data: OrganizationUpdatePayload
+    _id: string,
+    _data: OrganizationUpdatePayload
   ): Promise<OrganizationResult> {
     return { success: false, error: 'Not implemented' };
   }
 
-  async deleteOrganization(id: string): Promise<{ success: boolean; error?: string }> {
+  async deleteOrganization(_id: string): Promise<{ success: boolean; error?: string }> {
     return { success: false, error: 'Not implemented' };
   }
 }

--- a/src/adapters/session/supabase-adapter.ts
+++ b/src/adapters/session/supabase-adapter.ts
@@ -42,6 +42,8 @@ export class SupabaseSessionProvider implements ISessionDataProvider {
     _userId: string,
     _payload: SessionCreatePayload
   ): Promise<SessionOperationResult> {
+    void _userId;
+    void _payload;
     return { success: false, error: 'createSession not supported' };
   }
 
@@ -55,6 +57,9 @@ export class SupabaseSessionProvider implements ISessionDataProvider {
     _sessionId: string,
     _update: SessionUpdatePayload
   ): Promise<SessionOperationResult> {
+    void _userId;
+    void _sessionId;
+    void _update;
     return { success: false, error: 'updateSession not supported' };
   }
 

--- a/src/adapters/team/supabase-team-provider.ts
+++ b/src/adapters/team/supabase-team-provider.ts
@@ -52,17 +52,17 @@ export class SupabaseTeamProvider implements ITeamDataProvider {
    * @param teamData Team creation data including name, description, etc.
    * @returns Result object with success status and created team or error
    */
-  async createTeam(ownerId: string, teamData: TeamCreatePayload): Promise<TeamResult> {
+  async createTeam(ownerId: string, teamDataInput: TeamCreatePayload): Promise<TeamResult> {
     try {
       // Insert the team record
       const { data: teamData, error: teamError } = await this.supabase
         .from('teams')
         .insert({
-          name: teamData.name,
-          description: teamData.description,
+          name: teamDataInput.name,
+          description: teamDataInput.description,
           owner_id: ownerId,
-          is_public: teamData.isPublic || false,
-          settings: teamData.settings || {},
+          is_public: teamDataInput.isPublic || false,
+          settings: teamDataInput.settings || {},
           created_at: new Date().toISOString(),
           updated_at: new Date().toISOString()
         })

--- a/src/adapters/webhooks/supabase/supabase-webhook.provider.ts
+++ b/src/adapters/webhooks/supabase/supabase-webhook.provider.ts
@@ -64,7 +64,7 @@ export class SupabaseWebhookProvider implements IWebhookDataProvider {
       req = req.limit(query.limit);
     }
 
-    const { data, error, count } = await req;
+    const { data, count } = await req;
     const items = data ? data.map(r => this.mapRecord(r)) : [];
     return {
       webhooks: items,

--- a/src/core/auth/__tests__/business-policies.test.tsx
+++ b/src/core/auth/__tests__/business-policies.test.tsx
@@ -323,7 +323,7 @@ describe('Business-specific Session Controls', () => {
     const mockIp = '192.168.1.100'; // Within allowed range
     
     // Mock IP verification RPC
-    supabase.rpc.mockImplementation((procedure: string, params: any) => {
+    supabase.rpc.mockImplementation((procedure: string, _params: any) => {
       if (procedure === 'check_ip_restrictions') {
         // Check if IP is within allowed ranges
         const allowed = mockOrganization.security_settings.allowed_ip_ranges.some(range => {
@@ -362,10 +362,9 @@ describe('Business-specific Session Controls', () => {
     
     // Now test with unauthorized IP
     vi.clearAllMocks();
-    const unauthorizedIp = '203.0.113.1'; // Outside allowed range
     
     // Update mock response for unauthorized IP
-    supabase.rpc.mockImplementation((procedure: string, params: any) => {
+    supabase.rpc.mockImplementation((procedure: string, _params: any) => {
       if (procedure === 'check_ip_restrictions') {
         return Promise.resolve({
           data: { allowed: false },

--- a/src/core/config/adapter-config.ts
+++ b/src/core/config/adapter-config.ts
@@ -45,6 +45,7 @@ export function createAdapterFactory(config: AdapterConfig): AdapterFactory {
   const { type, options } = config;
   
   // Import dynamically to avoid circular dependencies
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { AdapterRegistry } = require('@/adapters');
   
   if (!AdapterRegistry.isAdapterAvailable(type)) {

--- a/src/core/config/index.ts
+++ b/src/core/config/index.ts
@@ -12,8 +12,7 @@ import {
   UserManagementConfig, 
   FeatureFlags, 
   ServiceProviderRegistry,
-  DEFAULT_CONFIG,
-  DEFAULT_FEATURE_FLAGS
+  DEFAULT_CONFIG
 } from './interfaces';
 
 // The global configuration instance


### PR DESCRIPTION
## Summary
- remove unused params from E2E tests
- mark unused arguments in adapters with underscore or void
- disable eslint for Node scripts using require
- adjust adapter config dynamic require
- clean up unused imports and variables

## Testing
- `npx vitest run --coverage`