### PR TITLE
Load environment variables for e2e tests

### DIFF
--- a/e2e/admin/audit-log.e2e.test.ts
+++ b/e2e/admin/audit-log.e2e.test.ts
@@ -1,9 +1,10 @@
 import { test, expect } from '@playwright/test';
 import * as dotenv from 'dotenv';
+import path from 'path';
 import { loginAs } from '../utils/auth';
 
-// Load environment variables from .env file
-dotenv.config();
+// Load environment variables from the root .env file
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 // Constants for test credentials - Prioritize environment variables that actually exist
 const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || 'admin@example.com';

--- a/e2e/admin/business-sso-status.e2e.test.ts
+++ b/e2e/admin/business-sso-status.e2e.test.ts
@@ -1,9 +1,10 @@
 import { test, expect, Page } from '@playwright/test';
 import * as dotenv from 'dotenv';
+import path from 'path';
 import { loginAs } from '../utils/auth';
 
-// Load environment variables
-dotenv.config();
+// Load environment variables from the root .env file
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 // Admin credentials from environment or defaults
 const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || 'admin@example.com';

--- a/e2e/admin/login-debug.e2e.test.ts
+++ b/e2e/admin/login-debug.e2e.test.ts
@@ -1,8 +1,9 @@
 import { test } from '@playwright/test';
 import * as dotenv from 'dotenv';
+import path from 'path';
 
-// Load environment variables
-dotenv.config();
+// Load environment variables from the root .env file
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 // Log environment details
 test.beforeAll(() => {

--- a/e2e/data-retention.e2e.test.ts
+++ b/e2e/data-retention.e2e.test.ts
@@ -1,9 +1,10 @@
 import { test, expect } from '@playwright/test';
 import * as dotenv from 'dotenv';
+import path from 'path';
 import { loginAs } from './utils/auth';
 
-// Load environment variables from .env file
-dotenv.config();
+// Load environment variables from the root .env file
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
 
 // Constants for test credentials
 const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || 'admin@example.com';

--- a/e2e/team-invite-flow.e2e.test.ts
+++ b/e2e/team-invite-flow.e2e.test.ts
@@ -1,8 +1,9 @@
 import { test, expect, Page } from '@playwright/test';
 import * as dotenv from 'dotenv';
+import path from 'path';
 
-// Load environment variables
-dotenv.config();
+// Load environment variables from the root .env file
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
 
 // Test users with fallback values
 const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || 'admin@example.com';

--- a/e2e/utils/global-setup.ts
+++ b/e2e/utils/global-setup.ts
@@ -1,10 +1,12 @@
 import { setupI18n } from './i18n-setup';
 import * as dotenv from 'dotenv';
+import path from 'path';
 import { ensureUserExists } from './user-setup';
 import { startMsw, stopMsw } from './msw-supabase';
 
-// Load environment variables
-dotenv.config();
+// Load environment variables from the root .env file so test and application
+// share the same values when running E2E
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 // Test credentials - should match the ones used in tests
 const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || 'admin@example.com';

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,9 @@
-import 'dotenv/config';
+import * as dotenv from 'dotenv';
+import path from 'path';
+
+// Explicitly load variables from the root .env file so e2e tests
+// always share the same configuration
+dotenv.config({ path: path.resolve(__dirname, '.env') });
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- load `.env` explicitly in Playwright configuration
- make global e2e setup import `.env`
- ensure individual e2e tests load `.env`

## Testing
- `npx vitest run --coverage` *(fails: JavaScript heap out of memory)*