### PR TITLE
Switch auth utilities to Supabase

### DIFF
--- a/src/lib/auth/authConfig.ts
+++ b/src/lib/auth/authConfig.ts
@@ -1,13 +1,31 @@
-// Placeholder for actual auth configuration
-// In a real app, this would use NextAuth or similar
+import { cookies } from 'next/headers';
+import { createServerClient, type Session } from '@supabase/ssr';
 
-export async function auth() {
-  return {
-    user: {
-      id: 'mock-user-id',
-      name: 'Mock Admin',
-      email: 'admin@example.com',
-      role: 'ADMIN',
+/**
+ * Retrieve the current Supabase session on the server.
+ *
+ * The function uses the request cookies to create a Supabase client and
+ * returns the active session if one exists.
+ */
+export async function auth(): Promise<Session | null> {
+  const cookieStore = cookies();
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get: (name: string) => cookieStore.get(name)?.value,
+      },
     }
-  };
-} 
+  );
+
+  const { data, error } = await supabase.auth.getSession();
+
+  if (error) {
+    console.error('Error retrieving session:', error);
+    return null;
+  }
+
+  return data.session;
+}

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -1,78 +1,27 @@
-import { NextAuthOptions } from 'next-auth';
-import CredentialsProvider from 'next-auth/providers/credentials';
-import { prisma } from '@/lib/database/prisma';
-import { compare } from 'bcryptjs';
+import { cookies } from 'next/headers';
+import { createServerClient } from '@supabase/ssr';
 
-export const authOptions: NextAuthOptions = {
-  providers: [
-    CredentialsProvider({
-      name: 'credentials',
-      credentials: {
-        email: { label: 'Email', type: 'email' },
-        password: { label: 'Password', type: 'password' },
+// Export an empty object to satisfy existing imports while the codebase
+// migrates away from NextAuth. Supabase is now used for authentication.
+export const authOptions: any = {};
+
+/**
+ * Create a Supabase client configured with the current request cookies.
+ */
+export function getSupabaseServerClient() {
+  const cookieStore = cookies();
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get: (name: string) => cookieStore.get(name)?.value,
       },
-      async authorize(credentials) {
-        if (!credentials?.email || !credentials?.password) {
-          throw new Error('Invalid credentials');
-        }
+    }
+  );
+}
 
-        const user = await prisma.user.findUnique({
-          where: { email: credentials.email },
-          include: { teamMemberships: { select: { teamId: true, role: true } } }
-        });
-
-        if (!user || !user.password) {
-          throw new Error('Invalid credentials');
-        }
-
-        const isValid = await compare(credentials.password, user.password);
-
-        if (!isValid) {
-          throw new Error('Invalid credentials');
-        }
-
-        return {
-          id: user.id,
-          email: user.email,
-          name: user.name,
-          role: user.teamMemberships[0]?.role,
-          teamId: user.teamMemberships[0]?.teamId
-        };
-      },
-    }),
-  ],
-  session: {
-    strategy: 'jwt',
-  },
-  pages: {
-    signIn: '/auth/login',
-    error: '/auth/error',
-  },
-  callbacks: {
-    jwt: async ({ token, user }) => {
-      if (user) {
-        token.sub = user.id;
-        token.role = user.role;
-        token.teamId = user.teamId;
-      } else if (token.sub) {
-        const dbUser = await prisma.user.findUnique({
-            where: { id: token.sub },
-            include: { teamMemberships: { select: { teamId: true, role: true } } }
-        });
-        if (dbUser) {
-            token.role = dbUser.teamMemberships[0]?.role;
-            token.teamId = dbUser.teamMemberships[0]?.teamId;
-        }
-      }
-      return token;
-    },
-    session: async ({ session, token }) => {
-      if (token?.sub && session.user) {
-        session.user.id = token.sub;
-        session.user.role = token.role;
-        session.user.teamId = token.teamId;
-      }
-      return session;
-    },
-  },
-}; 
+export async function signOut() {
+  const supabase = getSupabaseServerClient();
+  await supabase.auth.signOut();
+}


### PR DESCRIPTION
## Summary
- replace old placeholder `authConfig` with real Supabase server client
- drop NextAuth setup in `lib/auth/index.ts` and export Supabase helpers
- rewrite `getUser` to load the user via Supabase
- implement Supabase-based session helper

## Testing
- `npm run lint`
- `npm run test` *(fails: many tests fail and the suite runs out of memory)*