### PR TITLE
Refactor utils token handling

### DIFF
--- a/src/lib/auth/utils.ts
+++ b/src/lib/auth/utils.ts
@@ -1,7 +1,5 @@
 import { NextRequest } from 'next/server';
-import { getServerSession } from 'next-auth';
 import { supabase } from '@/lib/database/supabase';
-import { authOptions } from '@/lib/auth';
 
 /**
  * Get the current user from a request
@@ -10,19 +8,16 @@ import { authOptions } from '@/lib/auth';
  */
 export async function getUserFromRequest(req: NextRequest) {
   try {
-    // First try to get the user from the session
-    const session = await getServerSession(authOptions);
-    if (session?.user) {
-      return session.user;
-    }
+    // Retrieve the Supabase auth token from the Authorization header
+    const authHeader = req.headers.get('Authorization') || '';
+    const token = authHeader.startsWith('Bearer ')
+      ? authHeader.substring(7)
+      : authHeader;
 
-    // If no session, try to get the user from the Authorization header
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader?.startsWith('Bearer ')) {
+    if (!token) {
       return null;
     }
 
-    const token = authHeader.substring(7);
     const { data, error } = await supabase.auth.getUser(token);
     
     if (error || !data.user) {


### PR DESCRIPTION
## Summary
- remove NextAuth dependency from auth utils
- use Authorization header token with Supabase

## Testing
- `npx vitest run --coverage` *(fails: withErrorHandling is not a function)*