### PR TITLE
Refactor auth utilities for Supabase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,7 @@
         "lucide-react": "^0.510.0",
         "msw": "^2.8.2",
         "node-mocks-http": "^1.17.2",
+        "playwright": "^1.52.0",
         "postcss": "^8.4.35",
         "prisma": "^6.6.0",
         "sonner": "^2.0.3",
@@ -106,7 +107,7 @@
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.2.2",
         "vite-tsconfig-paths": "^5.1.4",
-        "vitest": "3.1.3"
+        "vitest": "^3.1.3"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "lucide-react": "^0.510.0",
     "msw": "^2.8.2",
     "node-mocks-http": "^1.17.2",
+    "playwright": "^1.52.0",
     "postcss": "^8.4.35",
     "prisma": "^6.6.0",
     "sonner": "^2.0.3",
@@ -113,6 +114,6 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.2.2",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "3.1.3"
+    "vitest": "^3.1.3"
   }
 }

--- a/src/lib/auth/utils.ts
+++ b/src/lib/auth/utils.ts
@@ -1,7 +1,5 @@
 import { NextRequest } from 'next/server';
-import { getServerSession } from 'next-auth';
 import { supabase } from '@/lib/database/supabase';
-import { authOptions } from '@/lib/auth';
 
 /**
  * Get the current user from a request
@@ -10,19 +8,22 @@ import { authOptions } from '@/lib/auth';
  */
 export async function getUserFromRequest(req: NextRequest) {
   try {
-    // First try to get the user from the session
-    const session = await getServerSession(authOptions);
-    if (session?.user) {
-      return session.user;
+    // Retrieve the Supabase auth token from the Authorization header
+    // or fall back to the sb-access-token cookie
+    let token = '';
+    const authHeader = req.headers.get('Authorization') || '';
+    if (authHeader.startsWith('Bearer ')) {
+      token = authHeader.substring(7);
+    } else if (authHeader) {
+      token = authHeader;
+    } else {
+      token = req.cookies.get('sb-access-token')?.value || '';
     }
 
-    // If no session, try to get the user from the Authorization header
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader?.startsWith('Bearer ')) {
+    if (!token) {
       return null;
     }
 
-    const token = authHeader.substring(7);
     const { data, error } = await supabase.auth.getUser(token);
     
     if (error || !data.user) {


### PR DESCRIPTION
## Summary
- update auth utils to rely on Supabase
- add cookie fallback when extracting auth token

## Testing
- `npm run lint`
- `npx vitest run --coverage` *(fails: Unable to find a label with the text of: /full name/i and other errors)*