### PR TITLE
Improve auth service factory with env config and caching

### DIFF
--- a/src/services/auth/__tests__/factory.test.ts
+++ b/src/services/auth/__tests__/factory.test.ts
@@ -1,21 +1,43 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { AdapterRegistry } from '@/adapters/registry';
-import { getApiAuthService } from '../factory';
 import { DefaultAuthService } from '../default-auth.service';
+import { getApiAuthService } from '../factory';
 
 describe('getApiAuthService', () => {
   beforeEach(() => {
     vi.resetModules();
     (AdapterRegistry as any).instance = null;
+    delete (globalThis as any).__UM_AUTH_SERVICE__;
   });
 
-  it('returns new service instance using adapter from registry', () => {
+  it('creates service with adapter and caches instance', () => {
     const adapter = {} as any;
     AdapterRegistry.getInstance().registerAdapter('auth', adapter);
-    const service1 = getApiAuthService();
+    const service1 = getApiAuthService({ reset: true });
     const service2 = getApiAuthService();
     expect(service1).toBeInstanceOf(DefaultAuthService);
-    expect(service2).toBeInstanceOf(DefaultAuthService);
-    expect(service1).not.toBe(service2);
+    expect(service1).toBe(service2);
+  });
+
+  it('throws when no provider is configured', () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', '');
+    vi.stubEnv('VITE_SUPABASE_URL', '');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', '');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', '');
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', '');
+
+    expect(() => getApiAuthService({ reset: true })).toThrow();
+
+    vi.unstubAllEnvs();
+  });
+
+  it('allows resetting the cached instance', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('auth', adapter);
+    const first = getApiAuthService({ reset: true });
+    const second = getApiAuthService();
+    const third = getApiAuthService({ reset: true });
+    expect(first).toBe(second);
+    expect(third).not.toBe(first);
   });
 });

--- a/src/services/auth/factory.ts
+++ b/src/services/auth/factory.ts
@@ -11,17 +11,87 @@ import { DefaultAuthService } from './default-auth.service';
 import type { AuthStorage } from './auth-storage';
 import { BrowserAuthStorage } from './auth-storage';
 import { AdapterRegistry } from '@/adapters/registry';
+import { createSupabaseAuthProvider } from '@/adapters/auth/factory';
 
 /**
- * Get a configured auth service instance for API routes
- *
- * @returns New AuthService instance
+ * Options for {@link getApiAuthService}
  */
-export function getApiAuthService(
-  storage: AuthStorage = new BrowserAuthStorage()
-): AuthService {
-  const authDataProvider =
-    AdapterRegistry.getInstance().getAdapter<AuthDataProvider>('auth');
+export interface ApiAuthServiceOptions {
+  /**
+   * Optional AuthDataProvider instance to use instead of auto creation.
+   */
+  provider?: AuthDataProvider;
+  /**
+   * Custom storage implementation (defaults to BrowserAuthStorage).
+   */
+  storage?: AuthStorage;
+  /**
+   * When true, forces creation of a new service instance. Useful in tests.
+   */
+  reset?: boolean;
+}
 
-  return new DefaultAuthService(authDataProvider, storage);
+// Key used for caching the service instance on the global object
+const GLOBAL_CACHE_KEY = '__UM_AUTH_SERVICE__';
+
+let cachedService: AuthService | null = null;
+
+/**
+ * Resolve the {@link AuthDataProvider} from environment variables or the
+ * {@link AdapterRegistry}. Falls back to registry when no environment
+ * configuration is provided.
+ */
+function resolveProvider(): AuthDataProvider {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const serviceKey =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+    process.env.VITE_SUPABASE_ANON_KEY;
+
+  if (supabaseUrl && serviceKey) {
+    return createSupabaseAuthProvider(supabaseUrl, serviceKey);
+  }
+
+  try {
+    return AdapterRegistry.getInstance().getAdapter<AuthDataProvider>('auth');
+  } catch (error) {
+    throw new Error(
+      'Auth provider not configured. Set NEXT_PUBLIC_SUPABASE_URL and authentication keys or register an auth adapter.'
+    );
+  }
+}
+
+/**
+ * Get a configured auth service instance for API routes.
+ *
+ * The service is cached for subsequent calls. Environment variables are used
+ * to configure the default Supabase implementation when no provider is
+ * registered. A custom provider or storage can be supplied for testing.
+ */
+export function getApiAuthService(options: ApiAuthServiceOptions = {}): AuthService {
+  if (options.reset) {
+    cachedService = null;
+    if (typeof globalThis !== 'undefined') {
+      delete (globalThis as any)[GLOBAL_CACHE_KEY];
+    }
+  }
+
+  if (!cachedService) {
+    if (typeof globalThis !== 'undefined') {
+      cachedService = (globalThis as any)[GLOBAL_CACHE_KEY] as AuthService | null;
+    }
+  }
+
+  if (!cachedService) {
+    const provider = options.provider ?? resolveProvider();
+    const storage = options.storage ?? new BrowserAuthStorage();
+    cachedService = new DefaultAuthService(provider, storage);
+
+    // Store on the global object for thread safety in server environments
+    if (typeof globalThis !== 'undefined') {
+      (globalThis as any)[GLOBAL_CACHE_KEY] = cachedService;
+    }
+  }
+
+  return cachedService;
 }


### PR DESCRIPTION
## Summary
- add singleton factory for `getApiAuthService`
- support environment variables and DI options
- add tests for new behaviour

## Testing
- `npx vitest run --coverage` *(fails: JavaScript heap out of memory)*