### PR TITLE
Refactor auth routes to use unified auth service

### DIFF
--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,6 +1,5 @@
 import { type NextRequest } from 'next/server';
 import { z } from 'zod';
-import { checkRateLimit } from '@/middleware/rate-limit';
 import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
 import { withSecurity } from '@/middleware/with-security';
 import { logUserAction } from '@/lib/audit/auditLogger';
@@ -62,17 +61,7 @@ async function handleRegistration(req: NextRequest, validatedData: z.infer<typeo
   const userAgent = req.headers.get('user-agent') || 'unknown';
   const regData = validatedData;
   
-  // 1. Rate Limiting
-  const isRateLimited = await checkRateLimit(req);
-  if (isRateLimited) {
-    throw new ApiError(
-      ERROR_CODES.INVALID_REQUEST,
-      'Too many requests',
-      429
-    );
-  }
-  
-  // 2. Get AuthService and prepare registration payload
+  // 1. Get AuthService and prepare registration payload
   const authService = getApiAuthService();
   
   // Prepare registration payload for the AuthService

--- a/docs/Product documentation/API.md
+++ b/docs/Product documentation/API.md
@@ -7,15 +7,34 @@ Register a new user.
 
 ```typescript
 interface RegisterRequest {
+  userType: 'private' | 'corporate';
   email: string;
   password: string;
-  name?: string;
-  userType?: 'private' | 'corporate';
+  firstName?: string;
+  lastName?: string;
+  companyName?: string;
+  companyWebsite?: string;
+  department?: string;
+  industry?: string;
+  companySize?:
+    | '1-10'
+    | '11-50'
+    | '51-200'
+    | '201-500'
+    | '501-1000'
+    | '1000+'
+    | 'Other/Not Specified';
+  position?: string;
+  acceptTerms: boolean;
 }
 
 interface RegisterResponse {
+  message: string;
   user: User;
-  session: Session;
+  companyAssociation?: {
+    success: boolean;
+    companyName?: string;
+  } | null;
 }
 ```
 
@@ -27,16 +46,27 @@ interface LoginRequest {
   email: string;
   password: string;
   twoFactorCode?: string;
+  rememberMe?: boolean;
 }
 
 interface LoginResponse {
   user: User;
-  session: Session;
+  token: string;
+  requiresMfa: boolean;
+  expiresAt?: string;
 }
 ```
 
 ### POST /api/auth/logout
 End the current session.
+
+An optional `callbackUrl` query parameter can be provided to redirect the user after logout.
+
+```typescript
+interface LogoutResponse {
+  message: string;
+}
+```
 
 ### POST /api/auth/reset-password
 Request a password reset.


### PR DESCRIPTION
## Summary
- update login route to wrap with security and auth rate limit
- update logout route to support redirect callback and clear cookies
- remove old rate-limit code from register and login routes
- document updated request/response models in API docs

## Testing
- `npx vitest run --coverage` *(fails: JavaScript heap out of memory)*