### PR TITLE
Refactor getUser to use auth service

### DIFF
--- a/src/lib/auth/__tests__/getUser.test.ts
+++ b/src/lib/auth/__tests__/getUser.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/services/auth/factory', () => ({
+  getApiAuthService: vi.fn(),
+}));
+
+const mockService = {
+  getCurrentUser: vi.fn(),
+};
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  vi.stubEnv('NODE_ENV', 'production');
+  vi.stubEnv('E2E_TEST', 'false');
+  const mod = await import('@/services/auth/factory');
+  (mod.getApiAuthService as any).mockReturnValue(mockService);
+  delete (globalThis as any).__UM_GET_USER_CACHE__;
+});
+
+describe('getUser', () => {
+  it('returns mock user in development', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const { getUser } = await import('../getUser');
+    const user = await getUser();
+    expect(user?.id).toBe('mock-user-id');
+  });
+
+  it('returns user from auth service and caches result', async () => {
+    const mockUser = { id: '1', email: 'a@test.com' } as any;
+    mockService.getCurrentUser.mockResolvedValue(mockUser);
+    const { getUser } = await import('../getUser');
+    const first = await getUser();
+    const second = await getUser();
+    expect(first).toEqual(mockUser);
+    expect(second).toEqual(mockUser);
+    expect(mockService.getCurrentUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles errors and returns null', async () => {
+    mockService.getCurrentUser.mockRejectedValue(new Error('fail'));
+    const { getUser } = await import('../getUser');
+    const user = await getUser();
+    expect(user).toBeNull();
+  });
+});

--- a/src/lib/auth/getUser.ts
+++ b/src/lib/auth/getUser.ts
@@ -1,14 +1,56 @@
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
-import type { User } from '@supabase/supabase-js';
-import { auth } from '@/lib/auth/authConfig';
+import type { User } from '@/core/auth/models';
+import { getApiAuthService } from '@/services/auth/factory';
 
 /**
- * Retrieves the authenticated user from the session
- * 
- * @returns The authenticated user or null if not authenticated
+ * Cache entry used to memoize the last fetched user. The cache is stored on the
+ * global object to persist across module reloads in development. A very small
+ * TTL is used because serverless functions may live only for a single request.
  */
-export async function getUser() {
+interface UserCache {
+  user: User | null;
+  expires: number;
+}
+
+const GLOBAL_CACHE_KEY = '__UM_GET_USER_CACHE__';
+
+function getCache(): UserCache | null {
+  if (typeof globalThis === 'undefined') return null;
+  return (globalThis as any)[GLOBAL_CACHE_KEY] as UserCache | undefined || null;
+}
+
+function setCache(cache: UserCache): void {
+  if (typeof globalThis === 'undefined') return;
+  (globalThis as any)[GLOBAL_CACHE_KEY] = cache;
+}
+
+/**
+ * Retrieve the currently authenticated user using the configured AuthService.
+ *
+ * The function automatically returns a mock user in development and test
+ * environments. When running on the server it uses {@link getApiAuthService}
+ * to obtain the active user from Supabase. Results are cached for a short
+ * period to avoid repeated network calls within the same execution context.
+ *
+ * **Usage Examples**
+ * ```ts
+ * // In a server component
+ * const user = await getUser();
+ * if (user) {
+ *   // render user specific content
+ * }
+ *
+ * // In an API route
+ * export async function GET() {
+ *   const user = await getUser();
+ *   if (!user) return new Response('Unauthorized', { status: 401 });
+ *   return NextResponse.json(user);
+ * }
+ * ```
+ *
+ * @returns Resolves with the authenticated {@link User} or `null` when the
+ *          request is not authenticated.
+ */
+export async function getUser(): Promise<User | null> {
   // For E2E tests and development, return a mock user
   if (process.env.NODE_ENV === 'development' || process.env.E2E_TEST === 'true') {
     console.log('[DEV/TEST] Returning mock user');
@@ -24,44 +66,22 @@ export async function getUser() {
     };
   }
   
+  const now = Date.now();
+  const cached = getCache();
+  if (cached && cached.expires > now) {
+    return cached.user;
+  }
+
   try {
-    const session = await auth();
+    const authService = getApiAuthService();
+    const user = await authService.getCurrentUser();
 
-    if (!session?.user?.id) {
-      return null;
-    }
+    setCache({ user: user ?? null, expires: now + 5000 });
 
-    const cookieStore = cookies();
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      {
-        cookies: {
-          get: (name: string) => cookieStore.get(name)?.value,
-        },
-      }
-    );
-
-    const { data, error } = await supabase.auth.getUser();
-
-    if (error || !data.user) {
-      return null;
-    }
-
-    const user: User = data.user;
-
-    return {
-      id: user.id,
-      name: user.user_metadata?.name || null,
-      email: user.email,
-      role: user.role || 'user',
-      emailVerified: !!user.email_confirmed_at,
-      image: user.user_metadata?.avatar_url || null,
-      createdAt: new Date(user.created_at),
-      updatedAt: new Date(user.updated_at),
-    };
+    return user ?? null;
   } catch (error) {
     console.error('Error retrieving user:', error);
+    setCache({ user: null, expires: now + 5000 });
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- reimplement `getUser` using `getApiAuthService`
- add simple cache and detailed JSDoc docs
- add unit tests for `getUser`

## Testing
- `npm test --silent` *(fails: JavaScript heap out of memory)*