### PR TITLE
Fix compile errors in test and styled component

### DIFF
--- a/src/middleware/__tests__/permissions.test.ts
+++ b/src/middleware/__tests__/permissions.test.ts
@@ -1,4 +1,3 @@
-conflicted_code = """
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 import { withPermissionCheck } from '../permissions';
@@ -243,13 +242,7 @@ describe('withPermissionCheck', () => {
       const data = await response.json();
 
       expect(response.status).toBe(500);
-      expect(data.error).toBe('Internal server error');
+  expect(data.error).toBe('Internal server error');
     });
   });
 });
-"""
-
-with open('merged_permissions_test.ts', 'w') as f:
-    f.write(conflicted_code)
-
-print("merged_permissions_test.ts created successfully.")

--- a/src/ui/styled/webhooks/WebhookEvents.tsx
+++ b/src/ui/styled/webhooks/WebhookEvents.tsx
@@ -32,11 +32,7 @@ export function WebhookEvents({
   );
 
   return (
-    <HeadlessWebhookEvents 
-      events={events} 
-      available={available} 
-      onChange={onChange}
-    >
+    <HeadlessWebhookEvents events={events} onChange={onChange}>
       {children || renderDefault}
     </HeadlessWebhookEvents>
   );


### PR DESCRIPTION
## Summary
- remove leftover merge artifacts in `permissions.test.ts`
- drop invalid `available` prop from `WebhookEvents`

## Testing
- `npm run test` *(fails: Worker exited unexpectedly)*