### PR TITLE
Implement OAuth support in AuthService

### DIFF
--- a/src/core/auth/interfaces.ts
+++ b/src/core/auth/interfaces.ts
@@ -6,14 +6,15 @@
  * the contract that any implementation must fulfill.
  */
 
-import { 
-  AuthResult, 
-  LoginPayload, 
-  RegistrationPayload, 
+import {
+  AuthResult,
+  LoginPayload,
+  RegistrationPayload,
   User,
   MFASetupResponse,
   MFAVerifyResponse
 } from './models';
+import type { OAuthProvider, OAuthUserProfile, OAuthProviderConfig } from '@/types/oauth';
 
 /**
  * Core authentication service interface
@@ -126,6 +127,33 @@ export interface AuthService {
    * @returns Authentication result with success status or error
    */
   disableMFA(code: string): Promise<AuthResult>;
+
+  /**
+   * Configure an OAuth provider.
+   *
+   * @param config Provider configuration
+   */
+  configureOAuthProvider(config: OAuthProviderConfig): void;
+
+  /**
+   * Build an authorization URL for the given provider.
+   *
+   * @param provider OAuth provider identifier
+   * @param state Optional state parameter for CSRF protection
+   */
+  getOAuthAuthorizationUrl(provider: OAuthProvider, state?: string): string;
+
+  /**
+   * Exchange an authorization code for an OAuth profile.
+   *
+   * @param provider OAuth provider identifier
+   * @param code Authorization code returned by the provider
+   * @returns The provider user profile
+   */
+  exchangeOAuthCode(
+    provider: OAuthProvider,
+    code: string
+  ): Promise<OAuthUserProfile>;
   
   /**
    * Refresh the authentication token

--- a/src/services/auth/__tests__/oauth.service.test.ts
+++ b/src/services/auth/__tests__/oauth.service.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DefaultAuthService } from '../default-auth.service';
+import type { OAuthDataProvider } from '@/adapters/auth/providers/oauth-provider';
+import { OAuthProvider } from '@/types/oauth';
+
+function createProvider(): OAuthDataProvider {
+  return {
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    getCurrentUser: vi.fn(),
+    resetPassword: vi.fn(),
+    updatePassword: vi.fn(),
+    sendVerificationEmail: vi.fn(),
+    verifyEmail: vi.fn(),
+    deleteAccount: vi.fn(),
+    setupMFA: vi.fn(),
+    verifyMFA: vi.fn(),
+    disableMFA: vi.fn(),
+    refreshToken: vi.fn(),
+    onAuthStateChanged: vi.fn().mockReturnValue(() => {}),
+    handleSessionTimeout: vi.fn(),
+    configureProvider: vi.fn(),
+    getProviderConfig: vi.fn(),
+    getAuthorizationUrl: vi.fn().mockReturnValue('http://auth'),
+    exchangeCode: vi.fn().mockResolvedValue({ accessToken: 'tok' }),
+    fetchUserProfile: vi.fn().mockResolvedValue({
+      id: '1',
+      provider: OAuthProvider.GOOGLE,
+      accessToken: 'tok',
+    }),
+    setProviderMetadata: vi.fn(),
+    getProviderMetadata: vi.fn(),
+  } as unknown as OAuthDataProvider;
+}
+
+describe('DefaultAuthService OAuth support', () => {
+  it('builds authorization url via provider', () => {
+    const provider = createProvider();
+    const service = new DefaultAuthService(provider as any);
+    const url = service.getOAuthAuthorizationUrl(OAuthProvider.GOOGLE, 's1');
+    expect(provider.getAuthorizationUrl).toHaveBeenCalledWith(OAuthProvider.GOOGLE, 's1');
+    expect(url).toBe('http://auth');
+  });
+
+  it('exchanges code and fetches profile', async () => {
+    const provider = createProvider();
+    const service = new DefaultAuthService(provider as any);
+    const profile = await service.exchangeOAuthCode(OAuthProvider.GOOGLE, 'code');
+    expect(provider.exchangeCode).toHaveBeenCalledWith(OAuthProvider.GOOGLE, 'code');
+    expect(provider.fetchUserProfile).toHaveBeenCalledWith(OAuthProvider.GOOGLE, 'tok');
+    expect(provider.setProviderMetadata).toHaveBeenCalledWith(OAuthProvider.GOOGLE, { accessToken: 'tok' });
+    expect(profile).toEqual({ id: '1', provider: OAuthProvider.GOOGLE, accessToken: 'tok' });
+  });
+
+  it('throws error when exchange fails', async () => {
+    const provider = createProvider();
+    (provider.exchangeCode as any).mockRejectedValue(new Error('boom'));
+    const service = new DefaultAuthService(provider as any);
+    await expect(service.exchangeOAuthCode(OAuthProvider.GOOGLE, 'x')).rejects.toThrow('boom');
+  });
+});


### PR DESCRIPTION
## Summary
- extend `AuthService` with OAuth methods
- implement OAuth operations in `DefaultAuthService`
- add new unit tests for OAuth service flow

## Testing
- `npx vitest run --coverage src/services/auth/__tests__/auth.store.test.ts src/services/auth/__tests__/oauth.service.test.ts`
- `npx vitest run --coverage` *(fails: environment lacks network access)*