### PR TITLE
Add centralized auth configuration utilities

### DIFF
--- a/docs/Product documentation/auth-config.md
+++ b/docs/Product documentation/auth-config.md
@@ -1,0 +1,43 @@
+# Auth Configuration Module
+
+This document explains how to work with the `authEnvironment` utilities used to
+configure authentication related features.
+
+## Overview
+
+`src/lib/auth/authEnvironment.ts` centralizes access to all authentication
+environment variables. It exposes helper methods that make it easy to create
+Supabase clients or validate that required variables are present.
+
+## Available Environment Variables
+
+| Variable | Description |
+| -------- | ----------- |
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL (required) |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Public anon key used in the browser (required) |
+| `SUPABASE_SERVICE_ROLE_KEY` | Service role key for server operations |
+| `SESSION_COOKIE_NAME` | Name of the cookie storing the access token |
+| `TOKEN_EXPIRY_DAYS` | Lifetime of refresh tokens in days |
+
+## Usage
+
+```typescript
+import {
+  authEnv,
+  validateAuthEnv,
+  getSupabaseClientConfig,
+  getSupabaseServerConfig
+} from '@/lib/auth/authEnvironment';
+
+if (!validateAuthEnv()) {
+  throw new Error('Invalid authentication configuration');
+}
+
+const clientOpts = getSupabaseClientConfig();
+const serverOpts = getSupabaseServerConfig();
+```
+
+`validateAuthEnv` should run during application startup to ensure the expected
+environment variables are defined. The helper methods can then be used wherever a
+Supabase client is created.
+

--- a/src/lib/auth/__tests__/auth-env.test.ts
+++ b/src/lib/auth/__tests__/auth-env.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, afterEach, describe, expect, test, vi } from 'vitest';
+
+// use dynamic import so env vars are read fresh
+
+describe('authEnvironment', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test('loads defaults and validates', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://test.supabase.co');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'anon');
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'service');
+
+    const mod = await import('../authEnvironment');
+    expect(mod.authEnv.sessionCookieName).toBe('user-management-session');
+    expect(mod.validateAuthEnv()).toBe(true);
+    expect(mod.isSupabaseConfigured()).toBe(true);
+    expect(mod.getSupabaseClientConfig()).toEqual({
+      url: 'https://test.supabase.co',
+      key: 'anon',
+    });
+  });
+
+  test('validation fails when required env vars are missing', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', '');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', '');
+
+    const mod = await import('../authEnvironment');
+    expect(mod.validateAuthEnv()).toBe(false);
+    expect(mod.isSupabaseConfigured()).toBe(false);
+  });
+});

--- a/src/lib/auth/authEnvironment.ts
+++ b/src/lib/auth/authEnvironment.ts
@@ -1,0 +1,68 @@
+/**
+ * Authentication environment configuration.
+ *
+ * Centralizes access to auth-related environment variables and provides
+ * helper functions for common configuration needs.
+ */
+
+export interface AuthEnvironment {
+  /** Supabase project URL */
+  supabaseUrl: string;
+  /** Public anonymous key used by the browser */
+  supabaseAnonKey: string;
+  /** Service role key for privileged server operations */
+  serviceRoleKey?: string;
+  /** Cookie name used to store the session access token */
+  sessionCookieName: string;
+  /** Lifetime of refresh tokens in days */
+  tokenExpiryDays: number;
+}
+
+function getEnv(name: string, fallback = ''): string {
+  return process.env[name] ?? fallback;
+}
+
+export const authEnv: AuthEnvironment = {
+  supabaseUrl: getEnv('NEXT_PUBLIC_SUPABASE_URL'),
+  supabaseAnonKey: getEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY'),
+  serviceRoleKey: getEnv('SUPABASE_SERVICE_ROLE_KEY'),
+  sessionCookieName: getEnv('SESSION_COOKIE_NAME', 'user-management-session'),
+  tokenExpiryDays: parseInt(getEnv('TOKEN_EXPIRY_DAYS', '7'), 10),
+};
+
+/** Check if Supabase credentials are present */
+export function isSupabaseConfigured(env: AuthEnvironment = authEnv): boolean {
+  return Boolean(env.supabaseUrl && env.supabaseAnonKey);
+}
+
+/** Validate required variables for server and client environments */
+export function validateAuthEnv(env: AuthEnvironment = authEnv): boolean {
+  const missing: string[] = [];
+  if (!env.supabaseUrl) missing.push('NEXT_PUBLIC_SUPABASE_URL');
+  if (!env.supabaseAnonKey) missing.push('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  if (typeof window === 'undefined' && !env.serviceRoleKey) {
+    missing.push('SUPABASE_SERVICE_ROLE_KEY');
+  }
+
+  if (missing.length > 0) {
+    console.error(`[authEnvironment] Missing environment variables: ${missing.join(', ')}`);
+    return false;
+  }
+  return true;
+}
+
+/** Options for creating a browser Supabase client */
+export function getSupabaseClientConfig(env: AuthEnvironment = authEnv) {
+  return {
+    url: env.supabaseUrl,
+    key: env.supabaseAnonKey,
+  };
+}
+
+/** Options for creating a server Supabase client */
+export function getSupabaseServerConfig(env: AuthEnvironment = authEnv) {
+  return {
+    url: env.supabaseUrl,
+    key: env.serviceRoleKey ?? env.supabaseAnonKey,
+  };
+}


### PR DESCRIPTION
## Summary
- add `authEnvironment` for consistent auth configuration
- provide helper functions for Supabase client config and env validation
- document usage in `auth-config.md`
- test auth configuration helpers

## Testing
- `npx vitest run src/lib/auth/__tests__/auth-env.test.ts --coverage` *(fails: source map errors)*