### PR TITLE
Add Supabase auth init helper

### DIFF
--- a/src/lib/auth/__tests__/initialize-supabase-auth.test.ts
+++ b/src/lib/auth/__tests__/initialize-supabase-auth.test.ts
@@ -1,0 +1,35 @@
+import { describe, beforeEach, test, expect, vi } from 'vitest';
+import { supabase, createClient, resetSupabaseMock } from '@/tests/mocks/supabase';
+
+// dynamic import to get fresh module per test
+
+describe('initializeSupabaseAuth', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetSupabaseMock();
+  });
+
+  test('initializes client and registers listener', async () => {
+    const { initializeSupabaseAuth } = await import('../initialize-supabase-auth');
+
+    const client = initializeSupabaseAuth({
+      url: 'https://test.supabase.co',
+      anonKey: 'anon',
+      serviceRoleKey: 'service',
+      cookieName: 'test-cookie',
+      persistSession: false,
+      autoRefreshToken: false,
+    });
+
+    expect(client).toBeTruthy();
+  });
+
+  test('throws when configuration invalid', async () => {
+    const { initializeSupabaseAuth } = await import('../initialize-supabase-auth');
+
+    expect(() =>
+      initializeSupabaseAuth({ url: '', anonKey: '' }),
+    ).toThrow();
+  });
+});
+

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -37,3 +37,4 @@ export async function signOut(): Promise<void> {
 }
 
 export * from './supabase-auth.config';
+export { initializeSupabaseAuth } from './initialize-supabase-auth';

--- a/src/lib/auth/initialize-supabase-auth.ts
+++ b/src/lib/auth/initialize-supabase-auth.ts
@@ -1,0 +1,54 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import {
+  supabaseAuthConfig,
+  validateSupabaseAuthConfig,
+  type SupabaseAuthConfig,
+} from './supabase-auth.config';
+
+let supabaseClient: SupabaseClient | null = null;
+
+/**
+ * Initialize the Supabase client for authentication.
+ *
+ * This uses configuration from {@link supabaseAuthConfig} unless overridden.
+ * The function will attach an auth state change listener and configure
+ * persistence options based on the provided configuration.
+ */
+export function initializeSupabaseAuth(
+  config: Partial<SupabaseAuthConfig> = {},
+): SupabaseClient {
+  if (supabaseClient) return supabaseClient;
+
+  const finalConfig: SupabaseAuthConfig = { ...supabaseAuthConfig, ...config };
+
+  if (!validateSupabaseAuthConfig(finalConfig)) {
+    throw new Error('Invalid Supabase auth configuration');
+  }
+
+  try {
+    console.log('[initializeSupabaseAuth] creating client');
+    supabaseClient = createClient(finalConfig.url, finalConfig.anonKey, {
+      auth: {
+        persistSession: finalConfig.persistSession,
+        autoRefreshToken: finalConfig.autoRefreshToken,
+        storageKey: finalConfig.cookieName,
+      },
+    });
+
+    supabaseClient.auth.onAuthStateChange((event, session) => {
+      console.log('[initializeSupabaseAuth] auth event', event);
+      if (session) {
+        console.log(
+          '[initializeSupabaseAuth] session expires at',
+          session.expires_at,
+        );
+      }
+    });
+
+    return supabaseClient;
+  } catch (error) {
+    console.error('[initializeSupabaseAuth] failed to init', error);
+    throw error;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `initializeSupabaseAuth` to centralize Supabase auth setup
- export initializer from auth index
- test initialization logic

## Testing
- `npx vitest run src/lib/auth/__tests__/initialize-supabase-auth.test.ts --coverage`
