### PR TITLE
Fix OAuth tests & add cleanup

### DIFF
--- a/app/api/auth/oauth/callback/__tests__/route.test.ts
+++ b/app/api/auth/oauth/callback/__tests__/route.test.ts
@@ -710,3 +710,7 @@ describe("POST /api/auth/oauth/callback", () => {
   // TODO: Add more tests:
   // - PKCE validation test (if applicable for any provider used in the route)
 });
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});


### PR DESCRIPTION
## Summary
- dynamically load OAuth route to ensure env vars are set in tests
- mock signInWithOAuth return value and assert generated state
- clean up mocks after tests

## Testing
- `npx vitest run app/api/auth/oauth/__tests__/route.test.ts`
- `npx vitest run app/api/auth/oauth/callback/__tests__/route.test.ts`
