### PR TITLE
Add password reset verification flow

### DIFF
--- a/app/api/auth/update-password/__tests__/route.test.ts
+++ b/app/api/auth/update-password/__tests__/route.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+import { getApiAuthService } from '@/services/auth/factory';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+import { ERROR_CODES } from '@/lib/api/common';
+
+vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
+vi.mock('@/middleware/with-auth-rate-limit', () => ({
+  withAuthRateLimit: vi.fn((_req, handler) => handler(_req)),
+}));
+vi.mock('@/middleware/with-security', () => ({ withSecurity: (h: any) => h }));
+
+describe('POST /api/auth/update-password', () => {
+  const mockAuthService = {
+    getCurrentUser: vi.fn(),
+    updatePassword: vi.fn(),
+    updatePasswordWithToken: vi.fn(),
+  };
+  const createRequest = (body?: any) =>
+    new Request('http://localhost/api/auth/update-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    mockAuthService.getCurrentUser.mockResolvedValue({ id: '1' });
+    mockAuthService.updatePassword.mockResolvedValue(undefined);
+    mockAuthService.updatePasswordWithToken.mockResolvedValue({ success: true, user: { id: '1' } });
+  });
+
+  it('validates request body', async () => {
+    const res = await POST(createRequest({}) as any);
+    expect(res.status).toBe(400);
+  });
+
+  it('updates password using token when provided', async () => {
+    const res = await POST(createRequest({ password: 'Password1', token: 't' }) as any);
+    expect(res.status).toBe(200);
+    expect(mockAuthService.updatePasswordWithToken).toHaveBeenCalledWith('t', 'Password1');
+  });
+
+  it('requires auth when no token', async () => {
+    mockAuthService.getCurrentUser.mockResolvedValueOnce(null);
+    const res = await POST(createRequest({ password: 'Password1' }) as any);
+    const data = await res.json();
+    expect(res.status).toBe(401);
+    expect(data.error.code).toBe(ERROR_CODES.UNAUTHORIZED);
+  });
+});

--- a/app/api/auth/verify-reset-token/__tests__/route.test.ts
+++ b/app/api/auth/verify-reset-token/__tests__/route.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+import { getApiAuthService } from '@/services/auth/factory';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+
+vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
+vi.mock('@/middleware/with-auth-rate-limit', () => ({
+  withAuthRateLimit: vi.fn((_req, handler) => handler(_req)),
+}));
+vi.mock('@/middleware/with-security', () => ({ withSecurity: (h: any) => h }));
+
+describe('POST /api/auth/verify-reset-token', () => {
+  const mockAuthService = { verifyPasswordResetToken: vi.fn() };
+  const createRequest = (token?: string) =>
+    new Request('http://localhost/api/auth/verify-reset-token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: token ? JSON.stringify({ token }) : undefined,
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    mockAuthService.verifyPasswordResetToken.mockResolvedValue({ valid: true });
+  });
+
+  it('validates request body', async () => {
+    const res = await POST(createRequest() as any);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns success when token is valid', async () => {
+    const res = await POST(createRequest('abc') as any);
+    expect(res.status).toBe(200);
+    expect(mockAuthService.verifyPasswordResetToken).toHaveBeenCalledWith('abc');
+  });
+});

--- a/app/api/auth/verify-reset-token/route.ts
+++ b/app/api/auth/verify-reset-token/route.ts
@@ -1,0 +1,34 @@
+import { type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+import { getApiAuthService } from '@/services/auth/factory';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+  withValidation,
+  ApiError,
+  ERROR_CODES,
+} from '@/lib/api/common';
+
+const VerifySchema = z.object({ token: z.string().min(1) });
+
+async function handleVerify(req: NextRequest, data: z.infer<typeof VerifySchema>) {
+  const authService = getApiAuthService();
+  const result = await authService.verifyPasswordResetToken(data.token);
+  if (!result.valid) {
+    throw new ApiError(ERROR_CODES.INVALID_REQUEST, result.error || 'Invalid or expired token', 400);
+  }
+  return createSuccessResponse({ message: 'Token valid' });
+}
+
+async function handler(request: NextRequest) {
+  return withErrorHandling(
+    async (req) => withValidation(VerifySchema, handleVerify, req),
+    request,
+  );
+}
+
+export const POST = withSecurity(async (request: NextRequest) =>
+  withAuthRateLimit(request, handler),
+);

--- a/src/adapters/auth/interfaces.ts
+++ b/src/adapters/auth/interfaces.ts
@@ -61,6 +61,21 @@ export interface AuthDataProvider {
   updatePassword(oldPassword: string, newPassword: string): Promise<void>;
 
   /**
+   * Verify a password reset token
+   */
+  verifyPasswordResetToken(token: string): Promise<{ valid: boolean; user?: User; token?: string; error?: string }>;
+
+  /**
+   * Update password using a reset token
+   */
+  updatePasswordWithToken(token: string, newPassword: string): Promise<AuthResult>;
+
+  /**
+   * Invalidate all sessions for the given user
+   */
+  invalidateSessions(userId: string): Promise<void>;
+
+  /**
    * Send an email verification link.
    *
    * @param email Email address to verify

--- a/src/core/auth/interfaces.ts
+++ b/src/core/auth/interfaces.ts
@@ -74,14 +74,27 @@ export interface AuthService {
    * @returns Result object with success status and message or error
    */
   resetPassword(email: string): Promise<{ success: boolean; message?: string; error?: string }>;
-  
+
   /**
    * Update the user's password
-   * 
+   *
    * @param oldPassword Current password for verification
    * @param newPassword New password to set
    */
   updatePassword(oldPassword: string, newPassword: string): Promise<void>;
+
+  /**
+   * Verify a password reset token from the email link
+   */
+  verifyPasswordResetToken(token: string): Promise<{ valid: boolean; error?: string }>;
+
+  /**
+   * Update the password using a reset token and automatically log in
+   */
+  updatePasswordWithToken(
+    token: string,
+    newPassword: string,
+  ): Promise<AuthResult>;
   
   /**
    * Send an email verification link to the specified email address

--- a/src/core/auth/models.ts
+++ b/src/core/auth/models.ts
@@ -257,3 +257,10 @@ export const registerSchema = z.object({
 // Type inference from schemas
 export type LoginData = z.infer<typeof loginSchema>;
 export type RegisterData = z.infer<typeof registerSchema>;
+
+// Password reset token model
+export interface PasswordResetToken {
+  token: string;
+  userId: string;
+  expiresAt: number;
+}

--- a/src/services/auth/default-auth.service.ts
+++ b/src/services/auth/default-auth.service.ts
@@ -243,12 +243,48 @@ export class DefaultAuthService
   async updatePassword(oldPassword: string, newPassword: string): Promise<void> {
     try {
       await this.provider.updatePassword(oldPassword, newPassword);
+      if (this.user?.id) {
+        await this.provider.invalidateSessions(this.user.id);
+      }
       this.emit({ type: 'password_updated', timestamp: Date.now(), userId: this.user?.id ?? '' });
       await this.logAction({ userId: this.user?.id, action: 'PASSWORD_UPDATE', status: 'SUCCESS', targetResourceType: 'user', targetResourceId: this.user?.id });
     } catch (error) {
       const message = translateError(error, { defaultMessage: 'Password update failed' });
       await this.logAction({ userId: this.user?.id, action: 'PASSWORD_UPDATE', status: 'FAILURE', details: { error: message } });
       throw new Error(message);
+    }
+  }
+
+  async verifyPasswordResetToken(token: string): Promise<{ valid: boolean; error?: string }> {
+    try {
+      const result = await this.provider.verifyPasswordResetToken(token);
+      if (result.valid && result.user) {
+        this.user = result.user;
+        if (result.token) this.persistToken(result.token);
+      }
+      return { valid: result.valid, error: result.error };
+    } catch (error) {
+      const message = translateError(error, { defaultMessage: 'Invalid reset token' });
+      return { valid: false, error: message };
+    }
+  }
+
+  async updatePasswordWithToken(token: string, newPassword: string): Promise<AuthResult> {
+    try {
+      const res = await this.provider.updatePasswordWithToken(token, newPassword);
+      if (res.success) {
+        if (res.user) this.user = res.user;
+        if (res.token) this.persistToken(res.token);
+        if (res.user?.id) {
+          await this.provider.invalidateSessions(res.user.id);
+        }
+        this.emit({ type: 'password_reset_completed', timestamp: Date.now(), userId: res.user?.id ?? '' });
+      }
+      return res;
+    } catch (error) {
+      const message = translateError(error, { defaultMessage: 'Password update failed' });
+      await this.logAction({ action: 'PASSWORD_RESET_COMPLETED', status: 'FAILURE', details: { error: message } });
+      return { success: false, error: message };
     }
   }
 


### PR DESCRIPTION
## Summary
- create password reset token model
- allow sessions to be invalidated when password updates occur
- implement verification of reset tokens
- support updating password with a token
- expose new API endpoints for verifying reset links and updating passwords
- add tests for the new routes

## Testing
- `npx vitest run --coverage` *(fails: JavaScript heap out of memory)*