### PR TITLE
Add provider linking notifications & verification API

### DIFF
--- a/app/api/auth/oauth/link/__tests__/route.test.ts
+++ b/app/api/auth/oauth/link/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach, MockedFunction } from 'vitest';
 // import { cookies } from 'next/headers'; // Mocked
 // import { createServerClient } from '@supabase/ssr'; // Mocked
 import { logUserAction } from '@/lib/audit/auditLogger'; // Mocked, but type used
+import { sendProviderLinkedNotification } from '@/lib/notifications/sendProviderLinkedNotification';
 
 // --- Mocks ---
 
@@ -59,8 +60,12 @@ function createBuilder(response: any = { data: null, error: null }): Builder {
 vi.mock('@/lib/audit/auditLogger', () => ({
   logUserAction: vi.fn(),
 }));
+vi.mock('@/lib/notifications/sendProviderLinkedNotification', () => ({
+  sendProviderLinkedNotification: vi.fn(),
+}));
 
 const mockLogUserAction = logUserAction as MockedFunction<typeof logUserAction>;
+const mockSendNotification = sendProviderLinkedNotification as MockedFunction<typeof sendProviderLinkedNotification>;
 
 // --- Test Data ---
 const validCode = 'valid-linking-code';
@@ -213,6 +218,7 @@ describe('POST /api/auth/oauth/link', () => {
 
     expect(mockFrom).toHaveBeenCalledTimes(4);
     expect(mockLogUserAction).toHaveBeenCalledWith(expect.objectContaining({ userId: loggedInUserId, action: 'SSO_LINK', status: 'SUCCESS' }));
+    expect(mockSendNotification).toHaveBeenCalledWith(loggedInUserId, providerToLink);
   });
 
   it('should handle errors during prisma account create', async () => {

--- a/app/api/auth/oauth/link/route.ts
+++ b/app/api/auth/oauth/link/route.ts
@@ -4,6 +4,7 @@ import { cookies } from 'next/headers';
 import { z } from 'zod';
 import { OAuthProvider } from '@/types/oauth';
 import { logUserAction } from '@/lib/audit/auditLogger';
+import { sendProviderLinkedNotification } from '@/lib/notifications/sendProviderLinkedNotification';
 
 // Request schema
 const linkRequestSchema = z.object({
@@ -108,6 +109,9 @@ export async function POST(request: Request) {
     if (insertError) {
       throw insertError;
     }
+
+    // Notify user about newly linked provider
+    await sendProviderLinkedNotification(user.id, provider);
 
     // Audit log: SSO link success
     try {

--- a/app/api/auth/oauth/verify/__tests__/route.test.ts
+++ b/app/api/auth/oauth/verify/__tests__/route.test.ts
@@ -1,0 +1,89 @@
+import { POST } from '../route';
+import { OAuthProvider } from '@/types/oauth';
+import { describe, it, expect, vi, beforeEach, MockedFunction } from 'vitest';
+import { logUserAction } from '@/lib/audit/auditLogger';
+import { sendProviderLinkedNotification } from '@/lib/notifications/sendProviderLinkedNotification';
+
+// Mock cookies
+const mockCookies = new Map<string, any>();
+vi.mock('next/headers', () => ({
+  cookies: () => ({
+    get: (key: string) => mockCookies.get(key),
+    set: (key: string | { name: string; [key: string]: any }, value?: string | object) => {
+      if (typeof key === 'string') {
+        mockCookies.set(key, { name: key, value, httpOnly: true, secure: true, sameSite: 'lax', maxAge: 600, path: '/', ...((typeof value === 'object') ? value : {}) });
+      } else {
+        mockCookies.set(key.name, { httpOnly: true, secure: true, sameSite: 'lax', maxAge: 600, path: '/', ...key });
+      }
+    },
+    has: (key: string) => mockCookies.has(key),
+    delete: (key: string) => mockCookies.delete(key),
+    getAll: () => Array.from(mockCookies.values()),
+  }),
+}));
+
+// Mock Supabase client
+const mockSupabaseAuth = {
+  getUser: vi.fn(),
+};
+const mockFrom = vi.fn();
+const mockSupabaseClient = {
+  auth: mockSupabaseAuth,
+  from: mockFrom,
+};
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: vi.fn(() => mockSupabaseClient),
+}));
+
+vi.mock('@/lib/audit/auditLogger', () => ({
+  logUserAction: vi.fn(),
+}));
+vi.mock('@/lib/notifications/sendProviderLinkedNotification', () => ({
+  sendProviderLinkedNotification: vi.fn(),
+}));
+const mockLogUserAction = logUserAction as MockedFunction<typeof logUserAction>;
+const mockSendNotification = sendProviderLinkedNotification as MockedFunction<typeof sendProviderLinkedNotification>;
+
+const createRequest = (body: object) => new Request('http://localhost/api/auth/oauth/verify', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(body),
+});
+
+const loggedInUser = { id: 'user1', email: 'test@example.com' };
+
+describe('oauth verify route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCookies.clear();
+    mockSupabaseAuth.getUser.mockResolvedValue({ data: { user: loggedInUser }, error: null });
+    mockFrom.mockReset();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockSupabaseAuth.getUser.mockResolvedValueOnce({ data: { user: null }, error: { message: 'auth', status: 401 } });
+    const request = createRequest({ providerId: OAuthProvider.GITHUB, email: 'new@example.com' });
+    const res = await POST(request);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 409 when email already used by another user', async () => {
+    const builder = { select: vi.fn(() => builder), eq: vi.fn(() => builder), maybeSingle: vi.fn(() => Promise.resolve({ data: { user_id: 'other' }, error: null })) };
+    mockFrom.mockReturnValueOnce(builder as any);
+    const request = createRequest({ providerId: OAuthProvider.GITHUB, email: 'existing@example.com' });
+    const res = await POST(request);
+    expect(res.status).toBe(409);
+  });
+
+  it('returns success and sends notification', async () => {
+    const builder = { select: vi.fn(() => builder), eq: vi.fn(() => builder), maybeSingle: vi.fn(() => Promise.resolve({ data: null, error: null })) };
+    mockFrom.mockReturnValueOnce(builder as any);
+    const request = createRequest({ providerId: OAuthProvider.GITHUB, email: 'new@example.com' });
+    const res = await POST(request);
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(mockSendNotification).toHaveBeenCalledWith(loggedInUser.id, OAuthProvider.GITHUB);
+    expect(mockLogUserAction).toHaveBeenCalled();
+  });
+});

--- a/app/api/auth/oauth/verify/route.ts
+++ b/app/api/auth/oauth/verify/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { z } from 'zod';
+import { OAuthProvider } from '@/types/oauth';
+import { logUserAction } from '@/lib/audit/auditLogger';
+import { sendProviderLinkedNotification } from '@/lib/notifications/sendProviderLinkedNotification';
+
+const verifySchema = z.object({
+  providerId: z.nativeEnum(OAuthProvider),
+  email: z.string().email(),
+});
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { providerId, email } = verifySchema.parse(body);
+
+    const cookieStore = cookies();
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          get(name: string) { return cookieStore.get(name)?.value; },
+          set(name: string, value: string, options: any) { cookieStore.set({ name, value, ...options }); },
+          remove(name: string, options: any) { cookieStore.set({ name, value: '', ...options }); },
+        },
+      },
+    );
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    }
+
+    const { data: existing } = await supabase
+      .from('account')
+      .select('user_id')
+      .eq('provider_email', email)
+      .maybeSingle();
+
+    if (existing && existing.user_id !== user.id) {
+      return NextResponse.json({ error: 'Email is already linked to another account.' }, { status: 409 });
+    }
+
+    await sendProviderLinkedNotification(user.id, providerId);
+    await logUserAction({
+      userId: user.id,
+      action: 'SSO_LINK_VERIFY',
+      status: 'SUCCESS',
+      details: { provider: providerId },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message || 'Failed to verify provider' }, { status: 400 });
+  }
+}

--- a/src/lib/notifications/sendProviderLinkedNotification.ts
+++ b/src/lib/notifications/sendProviderLinkedNotification.ts
@@ -1,0 +1,24 @@
+import { getApiNotificationService } from '@/services/notification/factory';
+import { NotificationChannel, NotificationCategory } from '@/core/notification/models';
+
+/**
+ * Send a notification informing the user that a new OAuth provider
+ * was linked to their account.
+ *
+ * @param userId - ID of the user to notify
+ * @param provider - Provider that was linked
+ */
+export async function sendProviderLinkedNotification(userId: string, provider: string) {
+  try {
+    const notificationService = getApiNotificationService();
+    await notificationService.sendNotification(userId, {
+      channel: NotificationChannel.IN_APP,
+      title: 'New provider linked',
+      message: `A new ${provider} account was linked to your profile.`,
+      category: NotificationCategory.SECURITY,
+    });
+  } catch (error) {
+    // Log but do not block main flow
+    console.error('Failed to send provider linked notification:', error);
+  }
+}


### PR DESCRIPTION
## Summary
- add helper to send notification when a provider is linked
- send notification after provider is linked
- add OAuth provider verification API route
- test notification is triggered and verification endpoint works

## Testing
- `npx vitest run --coverage` *(fails: 93 failed, 92 passed)*