### PR TITLE
Document deprecated alias API routes

### DIFF
--- a/app/api/user/avatar/__tests__/route.test.ts
+++ b/app/api/user/avatar/__tests__/route.test.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('/api/user/avatar', () => {
+describe('/api/user/avatar (alias for /api/profile/avatar)', () => {
   it('handles avatar endpoints', async () => {
     // TODO
   });

--- a/app/api/user/avatar/route.ts
+++ b/app/api/user/avatar/route.ts
@@ -1,1 +1,2 @@
+// Deprecated alias - use /api/profile/avatar instead
 export { GET, POST, DELETE } from '../../profile/avatar/route';

--- a/app/api/user/connected-accounts/__tests__/route.test.ts
+++ b/app/api/user/connected-accounts/__tests__/route.test.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('/api/user/connected-accounts', () => {
+describe('/api/user/connected-accounts (alias for /api/connected-accounts)', () => {
   it('handles connected accounts endpoints', async () => {
     // TODO
   });

--- a/app/api/user/connected-accounts/route.ts
+++ b/app/api/user/connected-accounts/route.ts
@@ -1,2 +1,5 @@
+// Deprecated alias for connected accounts endpoints
+// GET & DELETE handled by /api/connected-accounts
+// POST handled by /api/auth/oauth/link
 export { GET, DELETE } from '../../connected-accounts/route';
 export { POST } from '../../auth/oauth/link/route';

--- a/docs/Project documentation/UserManagementModule_APIs_Services_Checklist.md
+++ b/docs/Project documentation/UserManagementModule_APIs_Services_Checklist.md
@@ -53,8 +53,10 @@ This checklist tracks the existence of API endpoints for the User Management Mod
 **API Endpoints:**
  - [x] `/api/user/profile` (GET, PATCH)
  - [x] `/api/user/settings` (GET, PATCH)
- - [x] `/api/user/avatar` (GET, POST, DELETE)
- - [x] `/api/user/connected-accounts` (GET, POST, DELETE)
+ - [x] `/api/profile/avatar` (GET, POST, DELETE) - canonical
+ - [x] `/api/user/avatar` (alias, DEPRECATED)
+ - [x] `/api/connected-accounts` (GET, DELETE)
+ - [x] `/api/user/connected-accounts` (alias, POST handled by `/api/auth/oauth/link`, DEPRECATED)
 
 **Core Implementation:**
  - [x] `UserService`

--- a/src/services/user/api-user.service.ts
+++ b/src/services/user/api-user.service.ts
@@ -75,7 +75,8 @@ export class ApiUserService implements UserService {
     const base64 = await imageData.arrayBuffer().then(buf =>
       Buffer.from(buf).toString('base64')
     );
-    const res = await fetch('/api/user/avatar', {
+    // Use canonical profile avatar route
+    const res = await fetch('/api/profile/avatar', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
@@ -90,7 +91,8 @@ export class ApiUserService implements UserService {
 
   async deleteProfilePicture(_userId: string): Promise<{ success: boolean; error?: string }> {
     void _userId;
-    const res = await fetch('/api/user/avatar', {
+    // Use canonical profile avatar route
+    const res = await fetch('/api/profile/avatar', {
       method: 'DELETE',
       credentials: 'include'
     });


### PR DESCRIPTION
## Summary
- document canonical and deprecated API route pairs
- mark `/api/user/avatar` and `/api/user/connected-accounts` as deprecated aliases
- use canonical route in `api-user.service`
- tweak related tests

## Testing
- `npx vitest run --coverage` *(fails: environment issues)*