### PR TITLE
Improve API error handling

### DIFF
--- a/app/api/addresses/[id]/__tests__/route.test.ts
+++ b/app/api/addresses/[id]/__tests__/route.test.ts
@@ -33,6 +33,12 @@ describe('[id] address API', () => {
     expect(service.getAddress).toHaveBeenCalledWith('1', 'u1');
   });
 
+  it('GET requires auth', async () => {
+    const req = new NextRequest('http://test');
+    const res = await GET(req as any, { params: { id: '1' } });
+    expect(res.status).toBe(401);
+  });
+
   it('PUT updates address', async () => {
     const req = new NextRequest('http://test', { method: 'PUT', body: '{}' });
     req.headers.set('x-user-id', 'u1');
@@ -42,11 +48,25 @@ describe('[id] address API', () => {
     expect(service.updateAddress).toHaveBeenCalled();
   });
 
+  it('PUT validates input', async () => {
+    const req = new NextRequest('http://test', { method: 'PUT', body: '{}' });
+    req.headers.set('x-user-id', 'u1');
+    (req as any).json = async () => ({ postalCode: 123 });
+    const res = await PUT(req as any, { params: { id: '1' } });
+    expect(res.status).toBe(400);
+  });
+
   it('DELETE deletes address', async () => {
     const req = new NextRequest('http://test', { method: 'DELETE' });
     req.headers.set('x-user-id', 'u1');
     const res = await DELETE(req as unknown as NextRequest, { params: { id: '1' } });
     expect(res.status).toBe(204);
     expect(service.deleteAddress).toHaveBeenCalledWith('1', 'u1');
+  });
+
+  it('DELETE requires auth', async () => {
+    const req = new NextRequest('http://test', { method: 'DELETE' });
+    const res = await DELETE(req as any, { params: { id: '1' } });
+    expect(res.status).toBe(401);
   });
 });

--- a/app/api/addresses/[id]/route.ts
+++ b/app/api/addresses/[id]/route.ts
@@ -1,30 +1,49 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getApiAddressService } from '@/services/address/factory';
 import { addressSchema } from '@/core/address/validation';
+import {
+  createSuccessResponse,
+  createNoContentResponse,
+  createValidationError,
+  createUnauthorizedError,
+} from '@/lib/api/common';
+import { withRateLimit } from '@/middleware/rate-limit';
+import { withErrorHandling } from '@/middleware/error-handling';
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+async function handleGet(req: NextRequest, id: string) {
   const userId = req.headers.get('x-user-id');
-  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!userId) throw createUnauthorizedError();
   const service = getApiAddressService();
-  const address = await service.getAddress(params.id, userId);
-  return NextResponse.json({ address });
+  const address = await service.getAddress(id, userId);
+  return createSuccessResponse({ address });
 }
 
-export async function PUT(req: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+async function handlePut(req: NextRequest, id: string) {
   const userId = req.headers.get('x-user-id');
-  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!userId) throw createUnauthorizedError();
   const data = await req.json();
   const parse = addressSchema.partial().safeParse(data);
-  if (!parse.success) return NextResponse.json({ error: parse.error.message }, { status: 400 });
+  if (!parse.success) throw createValidationError('Invalid address data', parse.error.flatten());
   const service = getApiAddressService();
-  const updated = await service.updateAddress(params.id, parse.data, userId);
-  return NextResponse.json({ address: updated });
+  const updated = await service.updateAddress(id, parse.data, userId);
+  return createSuccessResponse({ address: updated });
 }
 
-export async function DELETE(req: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+async function handleDelete(req: NextRequest, id: string) {
   const userId = req.headers.get('x-user-id');
-  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!userId) throw createUnauthorizedError();
   const service = getApiAddressService();
-  await service.deleteAddress(params.id, userId);
-  return NextResponse.json({}, { status: 204 });
+  await service.deleteAddress(id, userId);
+  return createNoContentResponse();
 }
+
+export const GET = (req: NextRequest, { params }: { params: { id: string } }) =>
+  withRateLimit(req, r => withErrorHandling(q => handleGet(q, params.id), r));
+
+export const PUT = (req: NextRequest, { params }: { params: { id: string } }) =>
+  withRateLimit(req, r => withErrorHandling(q => handlePut(q, params.id), r));
+
+export const DELETE = (
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) => withRateLimit(req, r => withErrorHandling(q => handleDelete(q, params.id), r));

--- a/app/api/addresses/__tests__/route.test.ts
+++ b/app/api/addresses/__tests__/route.test.ts
@@ -26,6 +26,12 @@ describe('addresses API', () => {
     expect(service.getAddresses).toHaveBeenCalledWith('u1');
   });
 
+  it('GET requires auth', async () => {
+    const req = new NextRequest('http://test');
+    const res = await GET(req as any);
+    expect(res.status).toBe(401);
+  });
+
   it('POST creates address', async () => {
     const req = new NextRequest('http://test', { method: 'POST', body: JSON.stringify({ type: 'shipping', fullName: 'John', street1: '123', city: 'A', state: 'B', postalCode: '1', country: 'US' }) });
     req.headers.set('x-user-id', 'u1');
@@ -33,5 +39,13 @@ describe('addresses API', () => {
     const res = await POST(req as any);
     expect(res.status).toBe(201);
     expect(service.createAddress).toHaveBeenCalled();
+  });
+
+  it('POST validates input', async () => {
+    const req = new NextRequest('http://test', { method: 'POST', body: '{}' });
+    req.headers.set('x-user-id', 'u1');
+    (req as any).json = async () => ({}) ;
+    const res = await POST(req as any);
+    expect(res.status).toBe(400);
   });
 });

--- a/app/api/addresses/route.ts
+++ b/app/api/addresses/route.ts
@@ -1,22 +1,36 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getApiAddressService } from '@/services/address/factory';
 import { addressSchema } from '@/core/address/validation';
+import {
+  createSuccessResponse,
+  createCreatedResponse,
+  createValidationError,
+  createUnauthorizedError,
+} from '@/lib/api/common';
+import { withRateLimit } from '@/middleware/rate-limit';
+import { withErrorHandling } from '@/middleware/error-handling';
 
-export async function GET(req: NextRequest) {
+async function handleGet(req: NextRequest) {
   const userId = req.headers.get('x-user-id');
-  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!userId) throw createUnauthorizedError();
   const service = getApiAddressService();
   const addresses = await service.getAddresses(userId);
-  return NextResponse.json({ addresses });
+  return createSuccessResponse({ addresses });
 }
 
-export async function POST(req: NextRequest) {
+async function handlePost(req: NextRequest) {
   const userId = req.headers.get('x-user-id');
-  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!userId) throw createUnauthorizedError();
   const data = await req.json();
   const parse = addressSchema.safeParse(data);
-  if (!parse.success) return NextResponse.json({ error: parse.error.message }, { status: 400 });
+  if (!parse.success) throw createValidationError('Invalid address data', parse.error.flatten());
   const service = getApiAddressService();
   const address = await service.createAddress({ ...parse.data, userId });
-  return NextResponse.json({ address }, { status: 201 });
+  return createCreatedResponse({ address });
 }
+
+export const GET = (req: NextRequest) =>
+  withRateLimit(req, r => withErrorHandling(handleGet, r));
+
+export const POST = (req: NextRequest) =>
+  withRateLimit(req, r => withErrorHandling(handlePost, r));

--- a/src/lib/api/common/response-formatter.ts
+++ b/src/lib/api/common/response-formatter.ts
@@ -138,7 +138,7 @@ export function createErrorResponse(
  * Create a no content response (204)
  */
 export function createNoContentResponse(headers?: Record<string, string>) {
-  return NextResponse.json(null, {
+  return new NextResponse(null, {
     status: 204,
     headers: {
       ...headers,

--- a/src/lib/constants/sensitiveEndpoints.ts
+++ b/src/lib/constants/sensitiveEndpoints.ts
@@ -1,0 +1,5 @@
+export const SENSITIVE_ENDPOINTS = [
+  '/api/settings',
+  '/api/addresses',
+  '/api/addresses/[id]'
+];

--- a/src/middleware/__tests__/error-handling.test.ts
+++ b/src/middleware/__tests__/error-handling.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+import { withErrorHandling } from '../error-handling';
+import { ApiError } from '@/lib/api/common/api-error';
+import { createErrorResponse } from '@/lib/api/common/response-formatter';
+import { logUserAction } from '@/lib/audit/auditLogger';
+
+vi.mock('@/lib/audit/auditLogger', () => ({ logUserAction: vi.fn() }));
+vi.mock('@/lib/api/common/response-formatter', () => ({
+  createErrorResponse: vi.fn((err: ApiError) =>
+    NextResponse.json(err.toResponse(), { status: err.status })
+  ),
+}));
+
+describe('withErrorHandling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const req = new NextRequest('http://test');
+
+  it('handles ApiError and logs it', async () => {
+    const handler = vi.fn(async () => {
+      throw new ApiError('test/error', 'boom', 400);
+    });
+
+    const res = await withErrorHandling(handler, req);
+    expect(res.status).toBe(400);
+    expect(createErrorResponse).toHaveBeenCalled();
+    expect(logUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'API_ERROR', status: 'FAILURE' })
+    );
+  });
+
+  it('wraps unknown errors', async () => {
+    const handler = vi.fn(async () => {
+      throw new Error('oops');
+    });
+
+    const res = await withErrorHandling(handler, req);
+    expect(res.status).toBe(500);
+    expect(createErrorResponse).toHaveBeenCalled();
+  });
+});

--- a/src/middleware/error-handling.ts
+++ b/src/middleware/error-handling.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { ApiError } from '@/lib/api/common/api-error';
 import { createErrorResponse } from '@/lib/api/common/response-formatter';
+import { logUserAction } from '@/lib/audit/auditLogger';
 
 /**
  * Middleware to handle API errors for route handlers.
@@ -13,17 +14,29 @@ export async function withErrorHandling(
     return await handler(req);
   } catch (error) {
     console.error('API Error:', error);
+    const apiError =
+      error instanceof ApiError
+        ? error
+        : new ApiError(
+            'server/internal_error',
+            error instanceof Error ? error.message : 'An unexpected error occurred',
+            500
+          );
 
-    if (error instanceof ApiError) {
-      return createErrorResponse(error);
+    try {
+      await logUserAction({
+        action: 'API_ERROR',
+        status: 'FAILURE',
+        ipAddress: req.headers.get('x-forwarded-for') || 'unknown',
+        userAgent: req.headers.get('user-agent') || 'unknown',
+        targetResourceType: 'api',
+        targetResourceId: req.nextUrl.pathname,
+        details: { code: apiError.code, message: apiError.message }
+      });
+    } catch (logErr) {
+      console.error('Failed to log API error:', logErr);
     }
 
-    const serverError = new ApiError(
-      'server/internal_error',
-      error instanceof Error ? error.message : 'An unexpected error occurred',
-      500
-    );
-
-    return createErrorResponse(serverError);
+    return createErrorResponse(apiError);
   }
 }


### PR DESCRIPTION
## Summary
- log API errors via audit logger
- add rate limiting and unified error replies to address endpoints
- expose sensitive endpoint list
- provide helper for 204 responses
- test error handler and updated routes

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 npx vitest run --coverage src/middleware/__tests__/error-handling.test.ts app/api/addresses/__tests__/route.test.ts app/api/addresses/[id]/__tests__/route.test.ts`