### PR TITLE
Add integration tests for auth flows

### DIFF
--- a/src/tests/integration/change-password.integration.test.tsx
+++ b/src/tests/integration/change-password.integration.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { ChangePasswordForm } from '@/ui/styled/auth/ChangePasswordForm';
+
+const mockUpdatePassword = vi.fn();
+vi.mock('@/hooks/auth/useAuth', () => {
+  const store = {
+    updatePassword: mockUpdatePassword,
+    isLoading: false,
+    error: null,
+    successMessage: null,
+    clearError: vi.fn(),
+    clearSuccessMessage: vi.fn(),
+  };
+  const useAuthMock: any = vi.fn(() => store);
+  return { useAuth: useAuthMock };
+});
+
+describe('ChangePasswordForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('submits with valid data and shows success message', async () => {
+    mockUpdatePassword.mockResolvedValueOnce({ success: true, message: 'ok' });
+    const user = userEvent.setup();
+    render(<ChangePasswordForm />);
+
+    await user.type(screen.getByLabelText(/current password/i), 'OldPass1!');
+    await user.type(screen.getByLabelText(/new password/i), 'NewPass1!');
+    await user.type(screen.getByLabelText(/confirm new password/i), 'NewPass1!');
+    await user.click(screen.getByRole('button', { name: /update password/i }));
+
+    await waitFor(() => expect(mockUpdatePassword).toHaveBeenCalled());
+    expect(await screen.findByText(/password updated successfully/i)).toBeInTheDocument();
+  });
+
+  it('shows validation errors for weak passwords and mismatched confirm', async () => {
+    const user = userEvent.setup();
+    render(<ChangePasswordForm />);
+
+    await user.type(screen.getByLabelText(/current password/i), 'old');
+    await user.type(screen.getByLabelText(/new password/i), 'weak');
+    await user.type(screen.getByLabelText(/confirm new password/i), 'different');
+    await user.click(screen.getByRole('button', { name: /update password/i }));
+
+    expect(await screen.findByText(/at least 8 characters/i)).toBeInTheDocument();
+    expect(await screen.findByText(/new passwords do not match/i)).toBeInTheDocument();
+    expect(mockUpdatePassword).not.toHaveBeenCalled();
+  });
+
+  it('displays password strength helper as user types', async () => {
+    const user = userEvent.setup();
+    render(<ChangePasswordForm />);
+
+    const newPassword = screen.getByLabelText(/new password/i);
+    await user.type(newPassword, 'Short1');
+
+    const helper = screen.getByTestId('password-requirements-helper');
+    expect(helper).toBeInTheDocument();
+    expect(screen.getByText(/at least 8 characters/i)).toHaveAttribute('data-met', 'false');
+  });
+});

--- a/src/tests/integration/login-mfa.integration.test.tsx
+++ b/src/tests/integration/login-mfa.integration.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock auth hook with stateful functions
+const mockLogin = vi.fn();
+const mockVerifyMFA = vi.fn();
+
+vi.mock('@/hooks/auth/useAuth', () => {
+  const store = {
+    login: mockLogin,
+    verifyMFA: mockVerifyMFA,
+    isLoading: false,
+    error: null,
+    successMessage: null,
+    clearError: vi.fn(),
+    clearSuccessMessage: vi.fn(),
+  };
+  const useAuthMock: any = vi.fn(() => store);
+  return { useAuth: useAuthMock };
+});
+
+const pushMock = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+  useSearchParams: () => ({ get: vi.fn() }),
+}));
+
+import { LoginForm } from '@/ui/styled/auth/LoginForm';
+import { MFAVerificationForm } from '@/ui/styled/auth/MFAVerificationForm';
+
+describe('Login Flow with MFA', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('allows standard email/password login', async () => {
+    mockLogin.mockResolvedValueOnce({ success: true, requiresMfa: false });
+    const user = userEvent.setup();
+    render(<LoginForm />);
+
+    await user.type(screen.getByLabelText(/email/i), 'user@example.com');
+    await user.type(screen.getByLabelText(/^password$/i), 'Password123!');
+    await user.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith({
+        email: 'user@example.com',
+        password: 'Password123!',
+        rememberMe: false,
+      });
+      expect(pushMock).toHaveBeenCalledWith('/dashboard/overview');
+    });
+  });
+
+  it('prompts for TOTP code when MFA is required and verifies successfully', async () => {
+    mockLogin.mockResolvedValueOnce({ success: true, requiresMfa: true, token: 'tmp' });
+    mockVerifyMFA.mockResolvedValueOnce({ success: true, user: { id: '1' }, token: 'tok' });
+    const user = userEvent.setup();
+    render(<LoginForm />);
+
+    await user.type(screen.getByLabelText(/email/i), 'user@example.com');
+    await user.type(screen.getByLabelText(/^password$/i), 'Password123!');
+    await user.click(screen.getByRole('button', { name: /login/i }));
+
+    // MFA form should appear
+    expect(await screen.findByText(/multi-factor authentication/i)).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText('000000'), '123456');
+    await user.click(screen.getByRole('button', { name: /verify/i }));
+
+    await waitFor(() => {
+      expect(mockVerifyMFA).toHaveBeenCalledWith('tmp', '123456');
+      expect(pushMock).toHaveBeenCalledWith('/dashboard/overview');
+    });
+  });
+
+  it('shows error on invalid credentials', async () => {
+    mockLogin.mockResolvedValueOnce({ success: false, error: 'Invalid credentials' });
+    const user = userEvent.setup();
+    render(<LoginForm />);
+
+    await user.type(screen.getByLabelText(/email/i), 'wrong@example.com');
+    await user.type(screen.getByLabelText(/^password$/i), 'wrong');
+    await user.click(screen.getByRole('button', { name: /login/i }));
+
+    expect(await screen.findByText(/invalid credentials/i)).toBeInTheDocument();
+  });
+
+  it('displays rate limit feedback when too many attempts occur', async () => {
+    mockLogin.mockResolvedValueOnce({
+      success: false,
+      error: 'Too many attempts',
+      code: 'RATE_LIMIT_EXCEEDED',
+      retryAfter: 30000,
+      remainingAttempts: 0,
+    });
+    const user = userEvent.setup();
+    render(<LoginForm />);
+
+    await user.type(screen.getByLabelText(/email/i), 'user@example.com');
+    await user.type(screen.getByLabelText(/^password$/i), 'Password123!');
+    await user.click(screen.getByRole('button', { name: /login/i }));
+
+    expect(await screen.findByText(/too many attempts/i)).toBeInTheDocument();
+  });
+});
+
+// Additional success cases for email and sms MFA verification
+describe('MFAVerificationForm standalone', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('verifies code via email', async () => {
+    mockVerifyMFA.mockResolvedValueOnce({ success: true });
+    const user = userEvent.setup();
+    const onSuccess = vi.fn();
+    render(<MFAVerificationForm accessToken="tmp" mfaMethod="email" onSuccess={onSuccess} />);
+    await user.type(screen.getByPlaceholderText('000000'), '654321');
+    await user.click(screen.getByRole('button', { name: /verify/i }));
+    await waitFor(() => {
+      expect(mockVerifyMFA).toHaveBeenCalledWith('tmp', '654321');
+      expect(onSuccess).toHaveBeenCalled();
+    });
+  });
+
+  it('verifies code via sms', async () => {
+    mockVerifyMFA.mockResolvedValueOnce({ success: true });
+    const user = userEvent.setup();
+    const onSuccess = vi.fn();
+    render(<MFAVerificationForm accessToken="tmp" mfaMethod="sms" onSuccess={onSuccess} />);
+    await user.type(screen.getByPlaceholderText('000000'), '777777');
+    await user.click(screen.getByRole('button', { name: /verify/i }));
+    await waitFor(() => {
+      expect(mockVerifyMFA).toHaveBeenCalledWith('tmp', '777777');
+      expect(onSuccess).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/tests/integration/registration-flow.integration.test.tsx
+++ b/src/tests/integration/registration-flow.integration.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { RegistrationForm } from '@/ui/styled/auth/RegistrationForm';
+import { EmailVerification } from '@/ui/styled/auth/EmailVerification';
+import { UserManagementProvider } from '@/lib/auth/UserManagementProvider';
+import { UserType } from '@/types/user-type';
+
+const mockRegister = vi.fn();
+const mockVerifyEmail = vi.fn();
+const mockSendVerification = vi.fn();
+
+vi.mock('@/hooks/auth/useAuth', () => {
+  const store = {
+    register: mockRegister,
+    verifyEmail: mockVerifyEmail,
+    sendVerificationEmail: mockSendVerification,
+    isLoading: false,
+    error: null,
+    successMessage: null,
+    clearError: vi.fn(),
+    clearSuccessMessage: vi.fn(),
+  };
+  const useAuthMock: any = vi.fn(() => store);
+  return { useAuth: useAuthMock };
+});
+
+const pushMock = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+  useSearchParams: () => ({ get: vi.fn() }),
+}));
+
+describe('Registration Flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const provider = (
+    <UserManagementProvider>
+      <RegistrationForm />
+    </UserManagementProvider>
+  );
+
+  it('submits registration and redirects to email verification', async () => {
+    mockRegister.mockResolvedValueOnce({ success: true });
+    vi.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(provider);
+
+    await user.type(screen.getByLabelText(/email/i), 'new@example.com');
+    await user.type(screen.getByLabelText(/^password \*/i), 'Password123!');
+    await user.type(screen.getByLabelText(/confirm password/i), 'Password123!');
+    await user.type(screen.getByLabelText(/first name/i), 'New');
+    await user.type(screen.getByLabelText(/last name/i), 'User');
+    await user.click(screen.getByLabelText(/accept terms/i));
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => expect(mockRegister).toHaveBeenCalled());
+    act(() => { vi.advanceTimersByTime(2000); });
+    expect(pushMock).toHaveBeenCalledWith(expect.stringContaining('/check-email'));
+    vi.useRealTimers();
+  });
+
+  it('shows validation errors for mismatched passwords', async () => {
+    const user = userEvent.setup();
+    render(provider);
+
+    await user.type(screen.getByLabelText(/^password \*/i), 'Password123!');
+    await user.type(screen.getByLabelText(/confirm password/i), 'OtherPass!');
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    expect(await screen.findByText(/passwords don/i)).toBeInTheDocument();
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('shows error if email already exists', async () => {
+    mockRegister.mockResolvedValueOnce({ success: false, error: 'Email exists' });
+    const user = userEvent.setup();
+    render(provider);
+
+    await user.type(screen.getByLabelText(/email/i), 'dup@example.com');
+    await user.type(screen.getByLabelText(/^password \*/i), 'Password123!');
+    await user.type(screen.getByLabelText(/confirm password/i), 'Password123!');
+    await user.type(screen.getByLabelText(/first name/i), 'Dup');
+    await user.type(screen.getByLabelText(/last name/i), 'User');
+    await user.click(screen.getByLabelText(/accept terms/i));
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    expect(await screen.findByText(/email exists/i)).toBeInTheDocument();
+  });
+
+  it('requires company info when business user type selected', async () => {
+    const user = userEvent.setup();
+    render(provider);
+
+    const corporateRadio = screen.getByTestId('user-type-corporate');
+    await user.click(corporateRadio);
+    expect(screen.getByTestId('company-name-input')).toBeInTheDocument();
+  });
+});
+
+describe('Email Verification Component', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('verifies token and allows resending email', async () => {
+    mockVerifyEmail.mockResolvedValueOnce();
+    mockSendVerification.mockResolvedValueOnce({ success: true });
+    const user = userEvent.setup();
+    render(<EmailVerification />);
+
+    await user.type(screen.getByLabelText(/verification token/i), 'tok123');
+    await user.click(screen.getByRole('button', { name: /verify email/i }));
+    await waitFor(() => expect(mockVerifyEmail).toHaveBeenCalledWith('tok123'));
+
+    await user.type(screen.getByLabelText(/^email$/i), 'resend@example.com');
+    await user.click(screen.getByRole('button', { name: /resend verification email/i }));
+    await waitFor(() => expect(mockSendVerification).toHaveBeenCalledWith('resend@example.com'));
+  });
+});


### PR DESCRIPTION
## Summary
- add integration tests for login including MFA and rate limiting
- add registration flow tests with email verification and corporate info
- add change password integration tests with validation

## Testing
- `vitest run --coverage` *(fails: FATAL ERROR: JavaScript heap out of memory)*