### PR TITLE
Improve audit log API filtering

### DIFF
--- a/app/api/audit/__tests__/route.test.ts
+++ b/app/api/audit/__tests__/route.test.ts
@@ -1,13 +1,10 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { GET } from '../route';
-import { getApiAuditService } from '@/services/audit/factory';
 import { getUserFromRequest } from '@/lib/auth/utils';
 import { hasPermission } from '@/lib/auth/hasPermission';
+import { setTableMockData, resetSupabaseMock } from '@/tests/mocks/supabase';
 import { NextRequest } from 'next/server';
 
-vi.mock('@/services/audit/factory', () => ({
-  getApiAuditService: vi.fn(),
-}));
 vi.mock('@/lib/auth/utils', () => ({
   getUserFromRequest: vi.fn(),
 }));
@@ -17,13 +14,15 @@ vi.mock('@/lib/auth/hasPermission', () => ({
 
 describe('GET /api/audit', () => {
   const createRequest = (url: string) => new NextRequest(url);
-  const mockService = { getLogs: vi.fn() };
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (getApiAuditService as unknown as vi.Mock).mockReturnValue(mockService);
-    mockService.getLogs.mockResolvedValue({ logs: [], count: 0 });
+    resetSupabaseMock();
     (hasPermission as unknown as vi.Mock).mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    resetSupabaseMock();
   });
 
   it('returns 401 when unauthenticated', async () => {
@@ -45,13 +44,16 @@ describe('GET /api/audit', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns logs from service', async () => {
+  it('returns logs from database', async () => {
     (getUserFromRequest as unknown as vi.Mock).mockResolvedValue({ id: 'u1' });
-    mockService.getLogs.mockResolvedValueOnce({ logs: [{ id: '1' }], count: 1 });
+    setTableMockData('user_actions_log', {
+      data: [{ id: '1', created_at: '2023-01-01', user_id: 'u1', action: 'LOGIN', status: 'SUCCESS' }],
+      error: null,
+    });
+
     const res = await GET(createRequest('http://localhost/api/audit?page=1&limit=10'));
     const data = await res.json();
     expect(res.status).toBe(200);
-    expect(mockService.getLogs).toHaveBeenCalled();
     expect(data.logs.length).toBe(1);
     expect(data.pagination.total).toBe(1);
   });


### PR DESCRIPTION
## Summary
- refactor `/api/audit` route to query Supabase directly and add error handling
- update tests for new supabase query logic

## Testing
- `npx vitest run --coverage` *(fails: JavaScript heap out of memory)*