### PR TITLE
Add integration tests for user management API

### DIFF
--- a/app/api/user/avatar/__tests__/route.test.ts
+++ b/app/api/user/avatar/__tests__/route.test.ts
@@ -1,18 +1,58 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { NextRequest } from 'next/server';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { GET, POST, DELETE } from '../route';
+import { getApiUserService } from '@/services/user/factory';
+import { withRouteAuth } from '@/middleware/auth';
+import createMockUserService from '@/tests/mocks/user.service.mock';
 
-// TODO: Add proper mocks and tests
+vi.mock('@/services/user/factory', () => ({ getApiUserService: vi.fn() }));
+vi.mock('@/middleware/auth', () => ({
+  withRouteAuth: vi.fn((handler: any, req: any) => handler(req, 'user-1')),
+}));
+
+const service = createMockUserService();
 
 beforeEach(() => {
   vi.clearAllMocks();
+  (getApiUserService as unknown as vi.Mock).mockReturnValue(service);
 });
 
-describe('/api/user/avatar (alias for /api/profile/avatar)', () => {
-  it('handles avatar endpoints', async () => {
-    // TODO
+describe('/api/user/avatar alias', () => {
+  it('returns predefined avatars', async () => {
+    const req = new NextRequest('http://localhost/api/user/avatar');
+    const res = await GET(req as any);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(Array.isArray(body.data.avatars)).toBe(true);
+  });
+
+  it('updates avatar using predefined id', async () => {
+    const req = new NextRequest('http://localhost/api/user/avatar', {
+      method: 'POST',
+      body: JSON.stringify({ avatarId: 'avatar1' }),
+    });
+    (req as any).json = async () => ({ avatarId: 'avatar1' });
+    const res = await POST(req as any);
+    expect(res.status).toBe(200);
+    expect(service.updateUserProfile).toHaveBeenCalled();
+  });
+
+  it('uploads custom avatar', async () => {
+    const data = 'data:image/png;base64,aGVsbG8=';
+    const req = new NextRequest('http://localhost/api/user/avatar', {
+      method: 'POST',
+      body: JSON.stringify({ avatar: data }),
+    });
+    (req as any).json = async () => ({ avatar: data });
+    const res = await POST(req as any);
+    expect(res.status).toBe(200);
+    expect(service.uploadProfilePicture).toHaveBeenCalled();
+  });
+
+  it('deletes avatar', async () => {
+    const req = new NextRequest('http://localhost/api/user/avatar', { method: 'DELETE' });
+    const res = await DELETE(req as any);
+    expect(res.status).toBe(204);
+    expect(service.deleteProfilePicture).toHaveBeenCalled();
   });
 });

--- a/app/api/user/profile/__tests__/route.test.ts
+++ b/app/api/user/profile/__tests__/route.test.ts
@@ -1,24 +1,64 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { NextRequest } from 'next/server';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { GET, PATCH } from '../route';
+import { getApiUserService } from '@/services/user/factory';
+import { withRouteAuth } from '@/middleware/auth';
+import createMockUserService from '@/tests/mocks/user.service.mock';
 
-// TODO: Add proper mocks and tests
+vi.mock('@/services/user/factory', () => ({ getApiUserService: vi.fn() }));
+vi.mock('@/middleware/auth', () => ({
+  withRouteAuth: vi.fn((handler: any, req: any) => handler(req, 'user-1')),
+}));
+
+const service = createMockUserService();
 
 beforeEach(() => {
   vi.clearAllMocks();
+  (getApiUserService as unknown as vi.Mock).mockReturnValue(service);
 });
 
 describe('/api/user/profile GET', () => {
   it('returns user profile', async () => {
-    // TODO
+    const req = new NextRequest('http://localhost/api/user/profile');
+    const res = await GET(req as any);
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(service.getUserProfile).toHaveBeenCalledWith('user-1');
+    expect(data.data.id).toBe('user-1');
+  });
+
+  it('returns 404 when profile missing', async () => {
+    (service.getUserProfile as vi.Mock).mockResolvedValueOnce(null);
+    const req = new NextRequest('http://localhost/api/user/profile');
+    const res = await GET(req as any);
+    expect(res.status).toBe(404);
   });
 });
 
 describe('/api/user/profile PATCH', () => {
   it('updates user profile', async () => {
-    // TODO
+    const req = new NextRequest('http://localhost/api/user/profile', {
+      method: 'PATCH',
+      body: JSON.stringify({ bio: 'Updated bio' }),
+    });
+    (req as any).json = async () => ({ bio: 'Updated bio' });
+    const res = await PATCH(req as any);
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(service.updateUserProfile).toHaveBeenCalledWith('user-1', {
+      bio: 'Updated bio',
+    });
+    expect(data.data.bio).toBe('Updated bio');
+  });
+
+  it('returns 500 when update fails', async () => {
+    (service.updateUserProfile as vi.Mock).mockResolvedValueOnce({ success: false, error: 'fail' });
+    const req = new NextRequest('http://localhost/api/user/profile', {
+      method: 'PATCH',
+      body: JSON.stringify({ name: 'Bad' }),
+    });
+    (req as any).json = async () => ({ name: 'Bad' });
+    const res = await PATCH(req as any);
+    expect(res.status).toBe(500);
   });
 });

--- a/app/api/user/settings/__tests__/route.test.ts
+++ b/app/api/user/settings/__tests__/route.test.ts
@@ -1,24 +1,60 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { NextRequest } from 'next/server';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { GET, PATCH } from '../route';
+import { getApiUserService } from '@/services/user/factory';
+import { withRouteAuth } from '@/middleware/auth';
+import createMockUserService from '@/tests/mocks/user.service.mock';
 
-// TODO: Add proper mocks and tests
+vi.mock('@/services/user/factory', () => ({ getApiUserService: vi.fn() }));
+vi.mock('@/middleware/auth', () => ({
+  withRouteAuth: vi.fn((handler: any, req: any) => handler(req, 'user-1')),
+}));
+
+const service = createMockUserService();
 
 beforeEach(() => {
   vi.clearAllMocks();
+  (getApiUserService as unknown as vi.Mock).mockReturnValue(service);
 });
 
 describe('/api/user/settings GET', () => {
   it('returns user settings', async () => {
-    // TODO
+    const req = new NextRequest('http://localhost/api/user/settings');
+    const res = await GET(req as any);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.data.notifications.email).toBe(true);
+    expect(service.getUserPreferences).toHaveBeenCalledWith('user-1');
   });
 });
 
 describe('/api/user/settings PATCH', () => {
   it('updates user settings', async () => {
-    // TODO
+    const req = new NextRequest('http://localhost/api/user/settings', {
+      method: 'PATCH',
+      body: JSON.stringify({ notifications: { email: false } }),
+    });
+    (req as any).json = async () => ({ notifications: { email: false } });
+    const res = await PATCH(req as any);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(service.updateUserPreferences).toHaveBeenCalledWith(
+      'user-1',
+      expect.objectContaining({
+        notifications: expect.objectContaining({ email: false }),
+      })
+    );
+    expect(body.data.notifications.email).toBe(true); // from mock
+  });
+
+  it('returns 500 on failure', async () => {
+    (service.updateUserPreferences as vi.Mock).mockResolvedValueOnce({ success: false, error: 'fail' });
+    const req = new NextRequest('http://localhost/api/user/settings', {
+      method: 'PATCH',
+      body: JSON.stringify({ notifications: { email: false } }),
+    });
+    (req as any).json = async () => ({ notifications: { email: false } });
+    const res = await PATCH(req as any);
+    expect(res.status).toBe(500);
   });
 });


### PR DESCRIPTION
## Summary
- write profile API tests for retrieval and update
- add avatar endpoint tests for predefined and custom upload flows
- implement settings API tests with update failure case

## Testing
- `npx vitest run --coverage app/api/user/profile/__tests__/route.test.ts app/api/user/avatar/__tests__/route.test.ts app/api/user/settings/__tests__/route.test.ts`