### PR TITLE
Improve keyboard navigation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,6 +8,21 @@ body {
   /* background-color: theme('colors.background'); */
 }
 
+/* Skip link - hidden until focused */
+.skip-link {
+  position: absolute;
+  left: 0.5rem;
+  top: -40px;
+  z-index: 100;
+}
+
+@media (prefers-contrast: more) {
+  .skip-link:focus,
+  .skip-link:focus-visible {
+    outline: 3px solid CanvasText;
+  }
+}
+
 @layer base {
   :root {
     --background: 0 0% 100%;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,12 @@
 // import '@/lib/i18n';
+import React from 'react';
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import { AppInitializer } from '@/core/config/AppInitializer';
 import { UserManagementClientBoundary } from '@/lib/auth/UserManagementClientBoundary';
+import { SkipLink } from '@/ui/styled/navigation/SkipLink';
+import { KeyboardShortcutsDialog } from '@/ui/styled/common/KeyboardShortcutsDialog';
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 
 
 // Define viewport configuration
@@ -38,13 +42,27 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  useKeyboardShortcuts([
+    {
+      keys: ['Shift', '?'],
+      description: 'Show keyboard shortcuts',
+      handler: () => setDialogOpen(true),
+    },
+  ]);
   return (
     <html lang="en" className="antialiased">
       <head />
       <body className="font-sans">
+        <SkipLink />
         <AppInitializer>
           <UserManagementClientBoundary>
             {children}
+            <KeyboardShortcutsDialog
+              shortcuts={[{ keys: ['Shift', '?'], description: 'Show this help' }]}
+              open={dialogOpen}
+              onOpenChange={setDialogOpen}
+            />
           </UserManagementClientBoundary>
         </AppInitializer>
       </body>

--- a/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
@@ -1,0 +1,18 @@
+import { renderHook } from '@testing-library/react';
+import { useKeyboardShortcuts, Shortcut } from '../useKeyboardShortcuts';
+
+const shortcut: Shortcut = {
+  keys: ['Shift', '?'],
+  description: 'Test',
+  handler: vi.fn(),
+};
+
+describe('useKeyboardShortcuts', () => {
+  it('calls handler when keys pressed', () => {
+    const { unmount } = renderHook(() => useKeyboardShortcuts([shortcut]));
+    const event = new KeyboardEvent('keydown', { key: '?', shiftKey: true });
+    window.dispatchEvent(event);
+    expect(shortcut.handler).toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+export interface Shortcut {
+  keys: string[];
+  description: string;
+  handler: () => void;
+}
+
+/**
+ * Registers global keyboard shortcuts.
+ */
+export function useKeyboardShortcuts(shortcuts: Shortcut[]) {
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      shortcuts.forEach(({ keys, handler }) => {
+        if (keys.every(k => (k === 'Shift' ? e.shiftKey : e.key.toLowerCase() === k.toLowerCase()))) {
+          e.preventDefault();
+          handler();
+        }
+      });
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [shortcuts]);
+}

--- a/src/ui/styled/common/DataTable.tsx
+++ b/src/ui/styled/common/DataTable.tsx
@@ -131,7 +131,16 @@ export function DataTable<T extends Record<string, any>>({
               <TableHeader>
                 <TableRow>
                   {getVisibleColumns().map((column) => (
-                    <TableHead key={String(column.key)}>
+                    <TableHead
+                      key={String(column.key)}
+                      aria-sort={
+                        sortConfig?.key === column.key
+                          ? sortConfig.direction === 'asc'
+                            ? 'ascending'
+                            : 'descending'
+                          : 'none'
+                      }
+                    >
                       {column.sortable ? (
                         <Button
                           variant="ghost"
@@ -157,7 +166,7 @@ export function DataTable<T extends Record<string, any>>({
               </TableHeader>
               <TableBody>
                 {filteredData.map((row, rowIndex) => (
-                  <TableRow key={rowIndex}>
+                  <TableRow key={rowIndex} tabIndex={0}>
                     {getVisibleColumns().map((column) => {
                       const col = column as Column<T>;
                       const cellValue = col.render

--- a/src/ui/styled/common/KeyboardShortcutsDialog.tsx
+++ b/src/ui/styled/common/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,41 @@
+'use client';
+import React, { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/ui/primitives/dialog';
+import { Button } from '@/ui/primitives/button';
+
+export interface ShortcutInfo {
+  keys: string[];
+  description: string;
+}
+
+interface Props {
+  shortcuts: ShortcutInfo[];
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function KeyboardShortcutsDialog({ shortcuts, open: controlledOpen, onOpenChange }: Props) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = onOpenChange ?? setInternalOpen;
+  return (
+    <>
+      <Button onClick={() => setOpen(true)} className="sr-only" aria-label="Show keyboard shortcuts" />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Keyboard Shortcuts</DialogTitle>
+          </DialogHeader>
+          <ul className="space-y-2">
+            {shortcuts.map(s => (
+              <li key={s.description} className="flex justify-between">
+                <span>{s.description}</span>
+                <span className="font-mono">{s.keys.join(' + ')}</span>
+              </li>
+            ))}
+          </ul>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/ui/styled/common/__tests__/DataTable.a11y.test.tsx
+++ b/src/ui/styled/common/__tests__/DataTable.a11y.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@/tests/utils/test-utils';
+import { DataTable } from '../DataTable';
+
+interface Row { id: number; name: string; }
+
+const data = [{ id: 1, name: 'A' }];
+const columns = [{ key: 'id', header: 'ID', sortable: true }, { key: 'name', header: 'Name' }];
+
+describe('DataTable accessibility', () => {
+  it('adds aria-sort on sortable headers', () => {
+    render(<DataTable data={data} columns={columns} />);
+    const header = screen.getByRole('columnheader', { name: 'ID' });
+    expect(header).toHaveAttribute('aria-sort', 'none');
+  });
+});

--- a/src/ui/styled/common/__tests__/KeyboardShortcutsDialog.test.tsx
+++ b/src/ui/styled/common/__tests__/KeyboardShortcutsDialog.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen, fireEvent } from '@/tests/utils/test-utils';
+import { KeyboardShortcutsDialog } from '../KeyboardShortcutsDialog';
+
+const shortcuts = [
+  { keys: ['?'], description: 'Open help' }
+];
+
+describe('KeyboardShortcutsDialog', () => {
+  it('shows shortcuts when button clicked', () => {
+    render(<KeyboardShortcutsDialog shortcuts={shortcuts} />);
+    const button = screen.getByRole('button', { name: /show keyboard shortcuts/i });
+    fireEvent.click(button);
+    expect(screen.getByText('Open help')).toBeInTheDocument();
+  });
+});

--- a/src/ui/styled/navigation/SkipLink.tsx
+++ b/src/ui/styled/navigation/SkipLink.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+/**
+ * SkipLink component to allow keyboard users to jump directly to the main content.
+ */
+export function SkipLink() {
+  return (
+    <a
+      href="#main-content"
+      className="skip-link absolute left-4 top-[-40px] rounded bg-primary text-primary-foreground px-2 py-1 focus:top-4 focus-visible:top-4"
+    >
+      Skip to main content
+    </a>
+  );
+}

--- a/src/ui/styled/navigation/__tests__/SkipLink.test.tsx
+++ b/src/ui/styled/navigation/__tests__/SkipLink.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@/tests/utils/test-utils';
+import { SkipLink } from '../SkipLink';
+
+describe('SkipLink', () => {
+  it('renders an anchor with correct href', () => {
+    render(<SkipLink />);
+    const link = screen.getByRole('link', { name: /skip to main content/i });
+    expect(link).toHaveAttribute('href', '#main-content');
+  });
+});

--- a/src/ui/styled/registration/MultiStepRegistration.tsx
+++ b/src/ui/styled/registration/MultiStepRegistration.tsx
@@ -7,7 +7,7 @@ import { Progress } from '../ui/progress';
 import { Checkbox } from '../ui/checkbox';
 import { MultiStepRegistration as HeadlessMultiStepRegistration } from '@/ui/headless/registration/MultiStepRegistration';
 import { z } from 'zod';
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 
 // Define schema for validation - this is UI-specific validation
 const registrationSchema = z.object({
@@ -67,6 +67,10 @@ export function MultiStepRegistration() {
       steps={steps}
       onComplete={handleComplete}
       render={({ currentStep, next, back, setValue, values, handleSubmit }) => {
+        const firstFieldRef = useRef<HTMLInputElement>(null);
+        useEffect(() => {
+          firstFieldRef.current?.focus();
+        }, [currentStep]);
         const progress = ((currentStep + 1) / steps.length) * 100;
         
         const renderStep = () => {
@@ -79,6 +83,7 @@ export function MultiStepRegistration() {
                     <Input
                       id="email"
                       type="email"
+                      ref={firstFieldRef}
                       value={values.email || ''}
                       onChange={(e) => setValue('email', e.target.value)}
                     />
@@ -109,6 +114,7 @@ export function MultiStepRegistration() {
                     <Label htmlFor="name">Full Name</Label>
                     <Input
                       id="name"
+                      ref={firstFieldRef}
                       value={values.name || ''}
                       onChange={(e) => setValue('name', e.target.value)}
                     />
@@ -136,6 +142,7 @@ export function MultiStepRegistration() {
                 <div className="space-y-4">
                   <p>Enter the verification code sent to your email</p>
                   <Input
+                    ref={firstFieldRef}
                     value={verificationCode}
                     onChange={(e) => {
                       setVerificationCode(e.target.value);
@@ -171,7 +178,7 @@ export function MultiStepRegistration() {
         };
         
         return (
-          <div className="space-y-8">
+          <div className="space-y-8" role="region" aria-live="polite">
             <Progress value={progress} className="w-full" />
             
             <div className="text-center">

--- a/src/ui/styled/registration/__tests__/MultiStepRegistration.test.tsx
+++ b/src/ui/styled/registration/__tests__/MultiStepRegistration.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen, fireEvent } from '@/tests/utils/test-utils';
+import { MultiStepRegistration } from '../MultiStepRegistration';
+
+describe('MultiStepRegistration', () => {
+  it('moves focus to first input on step change', () => {
+    render(<MultiStepRegistration />);
+    const email = screen.getByLabelText(/email/i);
+    expect(document.activeElement).toBe(email);
+    fireEvent.change(email, { target: { value: 'a@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    const name = screen.getByLabelText(/full name/i);
+    expect(document.activeElement).toBe(name);
+  });
+});


### PR DESCRIPTION
## Summary
- add skip link for keyboard users
- implement keyboard shortcuts hook and dialog
- manage focus between multi-step registration steps
- add aria-sort and focusable rows for DataTable
- include basic tests for new accessibility helpers

## Testing
- `npx vitest run --coverage` *(fails: Reached heap limit Allocation failed - JavaScript heap out of memory)*