### PR TITLE
Add ABAC engine and admin stub

### DIFF
--- a/app/admin/access-rules/ClientPage.tsx
+++ b/app/admin/access-rules/ClientPage.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+export default function AccessRulesClientPage(): JSX.Element {
+  return (
+    <div className="container py-6 space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Access Rules</h1>
+        <p className="text-muted-foreground">
+          Create and manage attribute based access rules
+        </p>
+      </div>
+      <p className="text-muted-foreground">Administration interface placeholder.</p>
+    </div>
+  );
+}

--- a/app/admin/access-rules/page.tsx
+++ b/app/admin/access-rules/page.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from 'next';
+import AccessRulesClientPage from './ClientPage';
+
+export const metadata: Metadata = {
+  title: 'Access Rules',
+  description: 'Manage attribute based access rules'
+};
+
+export default function AccessRulesPage(): JSX.Element {
+  return <AccessRulesClientPage />;
+}

--- a/docs/Product documentation/Attribute Based Access Control.md
+++ b/docs/Product documentation/Attribute Based Access Control.md
@@ -1,0 +1,37 @@
+# Attribute Based Access Control
+
+This document describes the dynamic permission system built on top of the existing role based model. Rules can be defined using user, resource and environment attributes. Each rule targets a permission action and is evaluated dynamically at runtime.
+
+## Rule Syntax
+
+Rules consist of attribute conditions grouped by `user`, `resource` and `environment`.
+
+```json
+{
+  "id": "rule-id",
+  "action": "EDIT_PROJECT",
+  "user": [{ "field": "department", "operator": "eq", "value": "engineering" }],
+  "resource": [{ "field": "ownerId", "operator": "eq", "value": "{user.id}" }]
+}
+```
+
+Supported operators are `eq`, `neq`, `in`, `gt` and `lt`.
+
+## Evaluation Engine
+
+`AccessEvaluator` compiles rules into efficient functions and caches them. On each permission check the evaluator runs the compiled rules and records an audit entry with the decision reason. The audit trail can be retrieved for debugging or compliance purposes.
+
+## Developer Tools
+
+Use the `AccessEvaluator` class from `src/core/access-control` for custom checks:
+
+```ts
+import { AccessEvaluator } from '@/core/access-control';
+
+const evaluator = new AccessEvaluator(rules);
+const allowed = evaluator.check('EDIT_PROJECT', { user, resource, environment });
+```
+
+To add new rule types extend `AttributeCondition` and update the evaluator accordingly.
+
+Testing utilities live in `src/core/access-control/__tests__`.

--- a/src/core/access-control/__tests__/evaluator.test.ts
+++ b/src/core/access-control/__tests__/evaluator.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { AccessEvaluator, AccessRule } from '../index';
+
+const rules: AccessRule[] = [
+  {
+    id: 'r1',
+    action: 'EDIT_PROJECT',
+    user: [{ field: 'department', operator: 'eq', value: 'engineering' }],
+    resource: [{ field: 'ownerId', operator: 'eq', value: 'user1' }]
+  },
+  {
+    id: 'r2',
+    action: 'EDIT_PROJECT',
+    user: [{ field: 'isAdmin', operator: 'eq', value: true }]
+  }
+];
+
+describe('AccessEvaluator', () => {
+  it('grants access when rule matches', async () => {
+    const evalr = new AccessEvaluator(rules);
+    const allowed = await evalr.check('EDIT_PROJECT', {
+      user: { department: 'engineering', id: 'user1', isAdmin: false },
+      resource: { ownerId: 'user1' }
+    });
+    expect(allowed).toBe(true);
+  });
+
+  it('denies access when no rule matches', async () => {
+    const evalr = new AccessEvaluator(rules);
+    const allowed = await evalr.check('EDIT_PROJECT', {
+      user: { department: 'marketing', id: 'u2', isAdmin: false },
+      resource: { ownerId: 'user1' }
+    });
+    expect(allowed).toBe(false);
+  });
+
+  it('grants access for admin rule', async () => {
+    const evalr = new AccessEvaluator(rules);
+    const allowed = await evalr.check('EDIT_PROJECT', {
+      user: { department: 'sales', id: 'u3', isAdmin: true },
+      resource: { ownerId: 'user5' }
+    });
+    expect(allowed).toBe(true);
+  });
+});

--- a/src/core/access-control/evaluator.ts
+++ b/src/core/access-control/evaluator.ts
@@ -1,0 +1,71 @@
+import { MemoryCache } from '@/lib/cache';
+import { AccessRule, AttributeCondition, AccessAuditEntry } from './models';
+
+export interface EvaluationContext {
+  user: Record<string, unknown>;
+  resource?: Record<string, unknown>;
+  environment?: Record<string, unknown>;
+}
+
+export class AccessEvaluator {
+  private ruleCache = new MemoryCache<string, (ctx: EvaluationContext) => boolean>();
+  private audit: AccessAuditEntry[] = [];
+
+  constructor(private rules: AccessRule[] = []) {}
+
+  setRules(rules: AccessRule[]): void {
+    this.rules = rules;
+    this.ruleCache = new MemoryCache({ ttl: 60_000 });
+  }
+
+  getAuditTrail(): AccessAuditEntry[] {
+    return [...this.audit];
+  }
+
+  async check(action: string, ctx: EvaluationContext): Promise<boolean> {
+    const relevant = this.rules.filter(r => r.action === action);
+    for (const rule of relevant) {
+      const fn = await this.ruleCache.getOrCreate(rule.id, () => Promise.resolve(this.compile(rule)));
+      if (fn(ctx)) {
+        this.audit.push({ ruleId: rule.id, action, allowed: true, reason: 'matched', timestamp: Date.now() });
+        return true;
+      }
+    }
+    this.audit.push({ ruleId: null, action, allowed: false, reason: 'no rule matched', timestamp: Date.now() });
+    return false;
+  }
+
+  private compile(rule: AccessRule): (ctx: EvaluationContext) => boolean {
+    const checks: Array<(ctx: EvaluationContext) => boolean> = [];
+
+    for (const cond of rule.user || []) {
+      checks.push(ctx => this.evaluateCondition(ctx.user, cond));
+    }
+    for (const cond of rule.resource || []) {
+      checks.push(ctx => this.evaluateCondition(ctx.resource || {}, cond));
+    }
+    for (const cond of rule.environment || []) {
+      checks.push(ctx => this.evaluateCondition(ctx.environment || {}, cond));
+    }
+
+    return ctx => checks.every(fn => fn(ctx));
+  }
+
+  private evaluateCondition(obj: Record<string, unknown>, cond: AttributeCondition): boolean {
+    const value = obj[cond.field];
+    switch (cond.operator) {
+      case 'eq':
+        return value === cond.value;
+      case 'neq':
+        return value !== cond.value;
+      case 'in':
+        return Array.isArray(cond.value) && cond.value.includes(value as any);
+      case 'gt':
+        return typeof value === 'number' && typeof cond.value === 'number' && value > cond.value;
+      case 'lt':
+        return typeof value === 'number' && typeof cond.value === 'number' && value < cond.value;
+      default:
+        return false;
+    }
+  }
+}

--- a/src/core/access-control/index.ts
+++ b/src/core/access-control/index.ts
@@ -1,0 +1,2 @@
+export * from './models';
+export * from './evaluator';

--- a/src/core/access-control/models.ts
+++ b/src/core/access-control/models.ts
@@ -1,0 +1,24 @@
+export type AttributeConditionOperator = 'eq' | 'neq' | 'in' | 'gt' | 'lt';
+
+export interface AttributeCondition {
+  field: string;
+  operator: AttributeConditionOperator;
+  value: string | number | boolean | Array<string | number | boolean>;
+}
+
+export interface AccessRule {
+  id: string;
+  action: string; // permission or role action
+  description?: string;
+  user?: AttributeCondition[];
+  resource?: AttributeCondition[];
+  environment?: AttributeCondition[];
+}
+
+export interface AccessAuditEntry {
+  ruleId: string | null;
+  action: string;
+  allowed: boolean;
+  reason: string;
+  timestamp: number;
+}

--- a/supabase/migrations/20240620000000_create_access_rules_table.sql
+++ b/supabase/migrations/20240620000000_create_access_rules_table.sql
@@ -1,0 +1,11 @@
+-- Create table for attribute based access control rules
+CREATE TABLE IF NOT EXISTS access_rules (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    action TEXT NOT NULL,
+    description TEXT,
+    rule JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_access_rules_action ON access_rules(action);


### PR DESCRIPTION
## Summary
- introduce Attribute Based Access Control models and evaluation engine
- add unit tests for access evaluator
- create migration for `access_rules` table
- document ABAC design
- add stub admin interface for access rules

## Testing
- `npx vitest run src/core/access-control/__tests__/evaluator.test.ts`