### PR TITLE
Add loading components and optimistic hook

### DIFF
--- a/docs/loading-states.md
+++ b/docs/loading-states.md
@@ -1,0 +1,58 @@
+# Loading Patterns
+
+This document outlines the available loading components and how to integrate them.
+
+## Skeleton Loaders
+
+```tsx
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function UserCardSkeleton() {
+  return (
+    <div className="flex items-center space-x-4">
+      <Skeleton className="h-10 w-10 rounded-full" />
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-[150px]" />
+        <Skeleton className="h-4 w-[100px]" />
+      </div>
+    </div>
+  );
+}
+```
+
+## Progress Indicator
+
+```tsx
+import { Progress } from '@/components/ui/progress';
+
+<Progress value={60} className="h-2" />
+```
+
+## Inline Button Loading
+
+```tsx
+import { LoadingButton } from '@/components/ui/loading-button';
+
+<LoadingButton isLoading onClick={save}>Save</LoadingButton>
+```
+
+## Full Page Loading
+
+```tsx
+import { PageLoader } from '@/components/ui/page-loader';
+
+// In layout or suspense fallback
+<PageLoader label="Loading application" />
+```
+
+## Optimistic Updates
+
+```tsx
+import { useOptimistic } from '@/hooks/useOptimistic';
+
+const { data, run } = useOptimistic(initialData);
+
+async function handleUpdate(newValue: number) {
+  await run(apiUpdate, newValue);
+}
+```

--- a/src/components/ui/loading-button.tsx
+++ b/src/components/ui/loading-button.tsx
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/loading-button';

--- a/src/components/ui/page-loader.tsx
+++ b/src/components/ui/page-loader.tsx
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/page-loader';

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/progress';

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/skeleton';

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,1 @@
+export * from '../../ui/primitives/spinner';

--- a/src/hooks/__tests__/useOptimistic.test.tsx
+++ b/src/hooks/__tests__/useOptimistic.test.tsx
@@ -1,0 +1,24 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useOptimistic } from '../useOptimistic';
+
+describe('useOptimistic', () => {
+  it('updates optimistically and rolls back on failure', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('fail'));
+    const { result } = renderHook(() => useOptimistic(0));
+    await act(async () => {
+      await result.current.run(fn, 1);
+    });
+    expect(result.current.data).toBe(0);
+  });
+
+  it('queues actions when offline', async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(navigator, 'onLine', 'get').mockReturnValueOnce(false);
+    const { result } = renderHook(() => useOptimistic(0));
+    await act(async () => {
+      await result.current.run(fn, 2);
+    });
+    expect(result.current.data).toBe(2);
+  });
+});

--- a/src/hooks/useOptimistic.ts
+++ b/src/hooks/useOptimistic.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react';
+
+export interface OptimisticAction<T> {
+  apply: (data: T) => Promise<void>;
+  optimisticData: T;
+}
+
+/**
+ * Provides optimistic UI updates with automatic rollback on failure
+ * and offline queue synchronization.
+ */
+export function useOptimistic<T>(initial: T) {
+  const [data, setData] = useState(initial);
+  const queue = useRef<OptimisticAction<T>[]>([]);
+  const rollingBack = useRef(false);
+
+  const flushQueue = async () => {
+    if (queue.current.length === 0 || rollingBack.current) return;
+    const action = queue.current[0];
+    try {
+      await action.apply(action.optimisticData);
+      queue.current.shift();
+      flushQueue();
+    } catch {
+      rollingBack.current = true;
+      setData(initial);
+      queue.current = [];
+      rollingBack.current = false;
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('online', flushQueue);
+    return () => window.removeEventListener('online', flushQueue);
+  }, []);
+
+  const run = async (apply: (data: T) => Promise<void>, optimisticData: T) => {
+    const prev = data;
+    setData(optimisticData);
+    const action = { apply, optimisticData };
+    if (navigator.onLine) {
+      try {
+        await apply(optimisticData);
+      } catch {
+        setData(prev);
+      }
+    } else {
+      queue.current.push(action);
+    }
+  };
+
+  return { data, setData, run };
+}

--- a/src/ui/primitives/__tests__/loading-button.test.tsx
+++ b/src/ui/primitives/__tests__/loading-button.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { LoadingButton } from '../loading-button';
+
+describe('LoadingButton', () => {
+  it('shows spinner when loading and disables button', async () => {
+    render(
+      <LoadingButton isLoading>Submit</LoadingButton>
+    );
+    const btn = screen.getByRole('button');
+    expect(btn).toBeDisabled();
+    expect(screen.getByTestId('button-spinner')).toBeInTheDocument();
+  });
+
+  it('calls onClick when not loading', async () => {
+    const user = userEvent.setup();
+    const fn = vi.fn();
+    render(<LoadingButton onClick={fn}>Ok</LoadingButton>);
+    await user.click(screen.getByRole('button'));
+    expect(fn).toHaveBeenCalled();
+  });
+});

--- a/src/ui/primitives/__tests__/page-loader.test.tsx
+++ b/src/ui/primitives/__tests__/page-loader.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { PageLoader } from '../page-loader';
+
+describe('PageLoader', () => {
+  it('renders spinner and label', () => {
+    render(<PageLoader label="Waiting" />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'Waiting');
+    expect(screen.getByText('Waiting')).toBeInTheDocument();
+  });
+});

--- a/src/ui/primitives/loading-button.tsx
+++ b/src/ui/primitives/loading-button.tsx
@@ -1,0 +1,39 @@
+import { Button, type ButtonProps } from './button';
+import { Spinner } from './spinner';
+import { cn } from '@/lib/utils';
+
+export interface LoadingButtonProps extends ButtonProps {
+  isLoading?: boolean;
+  loadingText?: string;
+}
+
+/**
+ * Button with built-in loading spinner.
+ */
+export function LoadingButton({
+  isLoading = false,
+  loadingText = 'Loading',
+  children,
+  className,
+  disabled,
+  ...props
+}: LoadingButtonProps) {
+  return (
+    <Button
+      aria-busy={isLoading}
+      disabled={isLoading || disabled}
+      className={cn('relative', className)}
+      {...props}
+    >
+      {isLoading && (
+        <span className="absolute left-2 flex items-center" data-testid="button-spinner">
+          <Spinner className="h-4 w-4" />
+        </span>
+      )}
+      <span className={cn({ 'opacity-0': isLoading })}>{children}</span>
+      {isLoading && <span className="sr-only">{loadingText}</span>}
+    </Button>
+  );
+}
+
+export default LoadingButton;

--- a/src/ui/primitives/page-loader.tsx
+++ b/src/ui/primitives/page-loader.tsx
@@ -1,0 +1,24 @@
+import { Spinner } from './spinner';
+
+interface PageLoaderProps {
+  label?: string;
+}
+
+/**
+ * Full page loading indicator used during initial application load.
+ */
+export function PageLoader({ label = 'Loading' }: PageLoaderProps) {
+  return (
+    <div
+      className="flex items-center justify-center min-h-screen"
+      role="status"
+      aria-live="polite"
+      aria-label={label}
+    >
+      <Spinner className="h-12 w-12" />
+      <span className="sr-only">{label}</span>
+    </div>
+  );
+}
+
+export default PageLoader;


### PR DESCRIPTION
## Summary
- add full page loader and loading button components
- export loading primitives via UI layer
- introduce `useOptimistic` hook for optimistic UI updates
- document loading patterns
- add unit tests

## Testing
- `npx vitest run --coverage` *(fails: JavaScript heap out of memory)*