### PR TITLE
Add passwordless magic link login

### DIFF
--- a/app/api/auth/passwordless/__tests__/route.test.ts
+++ b/app/api/auth/passwordless/__tests__/route.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+import { getApiAuthService } from '@/services/auth/factory';
+
+vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
+vi.mock('@/middleware/with-auth-rate-limit', () => ({
+  withAuthRateLimit: vi.fn((_req, handler) => handler(_req))
+}));
+vi.mock('@/middleware/with-security', () => ({
+  withSecurity: (handler: any) => handler
+}));
+
+describe('POST /api/auth/passwordless', () => {
+  const mockAuthService = { sendMagicLink: vi.fn() };
+  const createRequest = (email?: string) => new Request('http://localhost/api/auth/passwordless', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: email ? JSON.stringify({ email }) : undefined
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    mockAuthService.sendMagicLink.mockResolvedValue({ success: true });
+  });
+
+  it('returns 400 when body is missing', async () => {
+    const res = await POST(createRequest() as any);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns success when magic link sent', async () => {
+    const res = await POST(createRequest('test@example.com') as any);
+    expect(res.status).toBe(200);
+    expect(mockAuthService.sendMagicLink).toHaveBeenCalledWith('test@example.com');
+  });
+});

--- a/app/api/auth/passwordless/route.ts
+++ b/app/api/auth/passwordless/route.ts
@@ -1,0 +1,51 @@
+import { type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { withAuthRateLimit } from '@/middleware/with-auth-rate-limit';
+import { withSecurity } from '@/middleware/with-security';
+import { getApiAuthService } from '@/services/auth/factory';
+import { logUserAction } from '@/lib/audit/auditLogger';
+import { createSuccessResponse, ApiError, ERROR_CODES } from '@/lib/api/common';
+import { withErrorHandling } from '@/middleware/error-handling';
+import { withValidation } from '@/middleware/validation';
+
+const MagicLinkSchema = z.object({
+  email: z.string().email({ message: 'Invalid email address' }),
+});
+
+async function handleMagicLink(
+  req: NextRequest,
+  data: z.infer<typeof MagicLinkSchema>,
+) {
+  const ipAddress = req.headers.get('x-forwarded-for') || 'unknown';
+  const userAgent = req.headers.get('user-agent') || 'unknown';
+
+  const authService = getApiAuthService();
+  const result = await authService.sendMagicLink(data.email);
+
+  await logUserAction({
+    action: 'MAGIC_LINK_REQUEST',
+    status: result.success ? 'SUCCESS' : 'FAILURE',
+    ipAddress,
+    userAgent,
+    targetResourceType: 'auth',
+    targetResourceId: data.email,
+    details: { error: result.error || null },
+  });
+
+  if (!result.success) {
+    throw new ApiError(ERROR_CODES.INTERNAL_ERROR, result.error || 'Failed to send magic link', 500);
+  }
+
+  return createSuccessResponse({ message: 'If an account exists with this email, a login link has been sent.' });
+}
+
+async function handler(req: NextRequest) {
+  return withErrorHandling(
+    async (r) => withValidation(MagicLinkSchema, handleMagicLink, r),
+    req,
+  );
+}
+
+export const POST = withSecurity(async (request: NextRequest) =>
+  withAuthRateLimit(request, handler),
+);

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -24,6 +24,11 @@ export default function LoginPage() { // Use default export for Next.js pages
                 {t('auth.login.forgotPassword', 'Forgot your password?')}
               </Link>
             </div>
+            <div className="mt-2">
+              <Link href="/auth/passwordless" className="text-primary hover:underline">
+                {t('auth.login.magicLink', 'Send me a magic link')}
+              </Link>
+            </div>
             <div className="mt-4">
               {t('auth.login.noAccount', "Don't have an account?")}{' '}
               <Link href="/auth/register" className="text-primary font-medium hover:underline">

--- a/app/auth/passwordless/page.tsx
+++ b/app/auth/passwordless/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+import '@/lib/i18n';
+import { useTranslation } from 'react-i18next';
+import { PasswordlessLogin } from '@/ui/styled/auth/PasswordlessLogin';
+import Link from 'next/link';
+
+export default function PasswordlessPage() {
+  const { t } = useTranslation();
+  return (
+    <div className="container max-w-md mx-auto py-12 space-y-4">
+      <h1 className="text-3xl font-bold text-center mb-8">
+        {t('auth.magicLink.title', 'Login with Magic Link')}
+      </h1>
+      <PasswordlessLogin />
+      <p className="text-center text-sm">
+        <Link href="/auth/login" className="text-primary hover:underline">
+          {t('auth.magicLink.backToLogin', 'Back to regular login')}
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/src/adapters/auth/interfaces.ts
+++ b/src/adapters/auth/interfaces.ts
@@ -80,15 +80,25 @@ export interface AuthDataProvider {
    *
    * @param email Email address to verify
    * @returns Authentication result with success status or error
-   */
+  */
   sendVerificationEmail(email: string): Promise<AuthResult>;
+
+  /**
+   * Send a passwordless login link to the specified email address.
+   */
+  sendMagicLink(email: string): Promise<{ success: boolean; error?: string }>;
 
   /**
    * Verify an email address using a verification token.
    *
    * @param token - Verification token from the email link
-   */
+  */
   verifyEmail(token: string): Promise<void>;
+
+  /**
+   * Verify a magic link token and authenticate the user.
+   */
+  verifyMagicLink(token: string): Promise<AuthResult>;
 
   /**
    * Permanently delete the current user's account.

--- a/src/core/auth/interfaces.ts
+++ b/src/core/auth/interfaces.ts
@@ -101,15 +101,30 @@ export interface AuthService {
    * 
    * @param email Email address to verify
    * @returns Authentication result with success status or error
-   */
+  */
   sendVerificationEmail(email: string): Promise<AuthResult>;
-  
+
+  /**
+   * Send a passwordless login link to the specified email address
+   *
+   * @param email Email address to send the magic link to
+   */
+  sendMagicLink(email: string): Promise<{ success: boolean; error?: string }>;
+
   /**
    * Verify an email address using a token
-   * 
+   *
    * @param token Verification token from the email link
    */
   verifyEmail(token: string): Promise<void>;
+
+  /**
+   * Verify a magic link token and authenticate the user
+   *
+   * @param token Magic link token
+   * @returns Authentication result with success status and user data or error
+   */
+  verifyMagicLink(token: string): Promise<AuthResult>;
   
   /**
    * Delete the current user's account

--- a/src/services/auth/default-auth.service.ts
+++ b/src/services/auth/default-auth.service.ts
@@ -311,6 +311,15 @@ export class DefaultAuthService
     }
   }
 
+  async sendMagicLink(email: string): Promise<{ success: boolean; error?: string }> {
+    try {
+      return await this.provider.sendMagicLink(email);
+    } catch (error) {
+      const message = translateError(error, { defaultMessage: 'Failed to send magic link' });
+      return { success: false, error: message };
+    }
+  }
+
   async verifyEmail(token: string): Promise<void> {
     try {
       await this.provider.verifyEmail(token);
@@ -318,6 +327,20 @@ export class DefaultAuthService
     } catch (error) {
       const message = translateError(error, { defaultMessage: 'Email verification failed' });
       throw new Error(message);
+    }
+  }
+
+  async verifyMagicLink(token: string): Promise<AuthResult> {
+    try {
+      const result = await this.provider.verifyMagicLink(token);
+      if (result.success) {
+        this.user = result.user ?? null;
+        this.persistToken(result.token ?? null, result.expiresAt);
+      }
+      return result;
+    } catch (error) {
+      const message = translateError(error, { defaultMessage: 'Magic link verification failed' });
+      return { success: false, error: message };
     }
   }
 


### PR DESCRIPTION
## Summary
- add magic link login page
- implement magic link API endpoint
- extend auth service and provider for magic link support
- expose magic link methods in auth hook
- link from login page to magic link flow

## Testing
- `npx vitest run --coverage` *(fails: No "Circle" export is defined on lucide-react mock)*