### PR TITLE
Add skeleton WebAuthn MFA

### DIFF
--- a/app/api/2fa/webauthn/register/__tests__/route.test.ts
+++ b/app/api/2fa/webauthn/register/__tests__/route.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { POST } from '../route';
+
+describe('WebAuthn register API', () => {
+  it('returns not implemented', async () => {
+    const res = await POST();
+    expect(res.status).toBe(501);
+  });
+});

--- a/app/api/2fa/webauthn/register/route.ts
+++ b/app/api/2fa/webauthn/register/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(): Promise<NextResponse> {
+  return NextResponse.json({ error: 'WebAuthn registration not implemented' }, { status: 501 });
+}

--- a/app/api/2fa/webauthn/verify/__tests__/route.test.ts
+++ b/app/api/2fa/webauthn/verify/__tests__/route.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { POST } from '../route';
+
+describe('WebAuthn verify API', () => {
+  it('returns not implemented', async () => {
+    const res = await POST();
+    expect(res.status).toBe(501);
+  });
+});

--- a/app/api/2fa/webauthn/verify/route.ts
+++ b/app/api/2fa/webauthn/verify/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(): Promise<NextResponse> {
+  return NextResponse.json({ error: 'WebAuthn verification not implemented' }, { status: 501 });
+}

--- a/src/adapters/auth/interfaces.ts
+++ b/src/adapters/auth/interfaces.ts
@@ -121,6 +121,16 @@ export interface AuthDataProvider {
   disableMFA(code: string): Promise<AuthResult>;
 
   /**
+   * Begin WebAuthn registration for the current user.
+   */
+  startWebAuthnRegistration(): Promise<MFASetupResponse>;
+
+  /**
+   * Complete WebAuthn registration with client response.
+   */
+  verifyWebAuthnRegistration(data: unknown): Promise<MFAVerifyResponse>;
+
+  /**
    * Refresh the authentication token.
    *
    * @returns True if token was refreshed successfully, false otherwise

--- a/src/adapters/auth/providers/oauth-provider.ts
+++ b/src/adapters/auth/providers/oauth-provider.ts
@@ -215,6 +215,14 @@ export class BasicOAuthProvider implements OAuthDataProvider {
   async disableMFA(_code: string): Promise<AuthResult> {
     return { success: false, error: 'Not implemented' };
   }
+
+  async startWebAuthnRegistration(): Promise<MFASetupResponse> {
+    return { success: false, error: 'WebAuthn registration not implemented' };
+  }
+
+  async verifyWebAuthnRegistration(_data: unknown): Promise<MFAVerifyResponse> {
+    return { success: false, error: 'WebAuthn registration not implemented' };
+  }
   async refreshToken(): Promise<
     { accessToken: string; refreshToken: string; expiresAt: number } | null
   > {

--- a/src/adapters/auth/providers/supabase-auth-provider.ts
+++ b/src/adapters/auth/providers/supabase-auth-provider.ts
@@ -495,6 +495,28 @@ export class SupabaseAuthProvider implements AuthDataProvider {
       };
     }
   }
+
+  /**
+   * Begin WebAuthn registration for the current user
+   */
+  async startWebAuthnRegistration(): Promise<MFASetupResponse> {
+    this.log('startWebAuthnRegistration');
+    return {
+      success: false,
+      error: 'WebAuthn registration not implemented'
+    };
+  }
+
+  /**
+   * Complete WebAuthn registration
+   */
+  async verifyWebAuthnRegistration(_data: unknown): Promise<MFAVerifyResponse> {
+    this.log('verifyWebAuthnRegistration');
+    return {
+      success: false,
+      error: 'WebAuthn registration not implemented'
+    };
+  }
   
   /**
    * Refresh the authentication token

--- a/src/core/two-factor/ITwoFactorDataProvider.ts
+++ b/src/core/two-factor/ITwoFactorDataProvider.ts
@@ -57,4 +57,10 @@ export interface ITwoFactorDataProvider {
    * @returns New backup codes or an error
    */
   regenerateBackupCodes(userId: string): Promise<BackupCodesResponse>;
+
+  /** Begin WebAuthn registration */
+  startWebAuthnRegistration(userId: string): Promise<TwoFactorSetupResponse>;
+
+  /** Complete WebAuthn registration */
+  verifyWebAuthnRegistration(payload: TwoFactorVerifyPayload): Promise<TwoFactorVerifyResponse>;
 }

--- a/src/core/two-factor/interfaces.ts
+++ b/src/core/two-factor/interfaces.ts
@@ -38,4 +38,10 @@ export interface TwoFactorService {
 
   /** Generate a new set of backup codes for a user */
   regenerateBackupCodes(userId: string): Promise<BackupCodesResponse>;
+
+  /** Begin WebAuthn registration flow */
+  startWebAuthnRegistration(userId: string): Promise<TwoFactorSetupResponse>;
+
+  /** Complete WebAuthn registration */
+  verifyWebAuthnRegistration(payload: TwoFactorVerifyPayload): Promise<TwoFactorVerifyResponse>;
 }

--- a/src/core/two-factor/models.ts
+++ b/src/core/two-factor/models.ts
@@ -1,4 +1,4 @@
-export type TwoFactorMethodType = 'totp' | 'sms' | 'email';
+export type TwoFactorMethodType = 'totp' | 'sms' | 'email' | 'webauthn';
 
 export interface TwoFactorSetupPayload {
   userId: string;

--- a/src/services/auth/__tests__/mfa-handler.test.ts
+++ b/src/services/auth/__tests__/mfa-handler.test.ts
@@ -4,7 +4,9 @@ import { DefaultMFAHandler } from '../mfa-handler';
 const provider = {
   setupMFA: vi.fn(),
   verifyMFA: vi.fn(),
-  disableMFA: vi.fn()
+  disableMFA: vi.fn(),
+  startWebAuthnRegistration: vi.fn(),
+  verifyWebAuthnRegistration: vi.fn()
 };
 
 const handler = new DefaultMFAHandler(provider as any);
@@ -28,6 +30,20 @@ describe('DefaultMFAHandler', () => {
     provider.disableMFA.mockResolvedValue({ success: true });
     const res = await handler.disableMFA('456');
     expect(provider.disableMFA).toHaveBeenCalledWith('456');
+    expect(res.success).toBe(true);
+  });
+
+  it('delegates WebAuthn registration start', async () => {
+    provider.startWebAuthnRegistration.mockResolvedValue({ success: true });
+    const res = await handler.startWebAuthnRegistration();
+    expect(provider.startWebAuthnRegistration).toHaveBeenCalled();
+    expect(res.success).toBe(true);
+  });
+
+  it('delegates WebAuthn registration verification', async () => {
+    provider.verifyWebAuthnRegistration.mockResolvedValue({ success: true });
+    const res = await handler.verifyWebAuthnRegistration('data');
+    expect(provider.verifyWebAuthnRegistration).toHaveBeenCalledWith('data');
     expect(res.success).toBe(true);
   });
 });

--- a/src/services/auth/mfa-handler.ts
+++ b/src/services/auth/mfa-handler.ts
@@ -5,6 +5,8 @@ export interface MFAHandler {
   setupMFA(): Promise<MFASetupResponse>;
   verifyMFA(code: string): Promise<MFAVerifyResponse>;
   disableMFA(code: string): Promise<AuthResult>;
+  startWebAuthnRegistration(): Promise<MFASetupResponse>;
+  verifyWebAuthnRegistration(data: unknown): Promise<MFAVerifyResponse>;
 }
 
 export class DefaultMFAHandler implements MFAHandler {
@@ -20,5 +22,13 @@ export class DefaultMFAHandler implements MFAHandler {
 
   disableMFA(code: string): Promise<AuthResult> {
     return this.provider.disableMFA(code);
+  }
+
+  startWebAuthnRegistration(): Promise<MFASetupResponse> {
+    return this.provider.startWebAuthnRegistration();
+  }
+
+  verifyWebAuthnRegistration(data: unknown): Promise<MFAVerifyResponse> {
+    return this.provider.verifyWebAuthnRegistration(data);
   }
 }

--- a/src/types/2fa.ts
+++ b/src/types/2fa.ts
@@ -4,7 +4,8 @@ import { z } from 'zod';
 export enum TwoFactorMethod {
   TOTP = 'totp', // Time-based One-Time Password
   SMS = 'sms',   // SMS-based verification
-  EMAIL = 'email' // Email-based verification
+  EMAIL = 'email', // Email-based verification
+  WEBAUTHN = 'webauthn' // Hardware security key (WebAuthn)
 }
 
 // 2FA status


### PR DESCRIPTION
## Summary
- extend `TwoFactorMethod` enum with `WEBAUTHN`
- add WebAuthn type support in two-factor models and interfaces
- expose WebAuthn methods in auth provider interfaces and handler
- provide stub implementations in providers
- add placeholder API routes for WebAuthn registration and verification
- update MFA handler tests

## Testing
- `npx vitest run --coverage` *(fails: JavaScript heap out of memory)*