### PR TITLE
Add admin user search capability

### DIFF
--- a/app/admin/users/UserSearch.tsx
+++ b/app/admin/users/UserSearch.tsx
@@ -1,0 +1,187 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Button } from '@/ui/primitives/button';
+import { Input } from '@/ui/primitives/input';
+import { Select } from '@/ui/primitives/select';
+import { DatePicker } from '@/ui/primitives/datepicker';
+import { Card, CardContent, CardHeader, CardTitle } from '@/ui/primitives/card';
+import { Alert, AlertDescription } from '@/ui/primitives/alert';
+import { Skeleton } from '@/ui/primitives/skeleton';
+import { useAdminUsers } from '@/hooks/admin/useAdminUsers';
+
+const searchFormSchema = z.object({
+  query: z.string().optional(),
+  status: z.enum(['active', 'inactive', 'suspended', 'all']).default('all'),
+  role: z.string().optional(),
+  dateCreatedStart: z.date().optional(),
+  dateCreatedEnd: z.date().optional(),
+  dateLastLoginStart: z.date().optional(),
+  dateLastLoginEnd: z.date().optional(),
+  sortBy: z.enum(['name', 'email', 'createdAt', 'lastLoginAt', 'status']).default('createdAt'),
+  sortOrder: z.enum(['asc', 'desc']).default('desc'),
+  teamId: z.string().optional(),
+});
+
+type SearchFormValues = z.infer<typeof searchFormSchema>;
+
+export function UserSearch() {
+  const [page, setPage] = useState(1);
+  const { users, pagination, isLoading, error, searchUsers } = useAdminUsers();
+
+  const { register, handleSubmit, control, reset, watch } = useForm<SearchFormValues>({
+    resolver: zodResolver(searchFormSchema),
+    defaultValues: {
+      status: 'all',
+      sortBy: 'createdAt',
+      sortOrder: 'desc',
+    },
+  });
+
+  const watchedValues = watch();
+
+  useEffect(() => {
+    searchUsers({
+      page,
+      ...watchedValues,
+    });
+  }, [page]);
+
+  const onSubmit = (data: SearchFormValues) => {
+    setPage(1);
+    searchUsers({ ...data, page: 1 });
+  };
+
+  const handleReset = () => {
+    reset();
+    setPage(1);
+    searchUsers({ page: 1, status: 'all', sortBy: 'createdAt', sortOrder: 'desc' });
+  };
+
+  const handlePageChange = (newPage: number) => {
+    if (newPage >= 1 && newPage <= (pagination?.totalPages || 1)) {
+      setPage(newPage);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>User Search</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <label htmlFor="query" className="text-sm font-medium">Search</label>
+                <Input id="query" placeholder="Name, email, etc." {...register('query')} />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="status" className="text-sm font-medium">Status</label>
+                <Select id="status" {...register('status')}>
+                  <option value="all">All Statuses</option>
+                  <option value="active">Active</option>
+                  <option value="inactive">Inactive</option>
+                  <option value="suspended">Suspended</option>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="role" className="text-sm font-medium">Role</label>
+                <Select id="role" {...register('role')}>
+                  <option value="">All Roles</option>
+                  <option value="admin">Admin</option>
+                  <option value="user">User</option>
+                  <option value="viewer">Viewer</option>
+                </Select>
+              </div>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Created Date Range</label>
+                <div className="grid grid-cols-2 gap-2">
+                  <DatePicker control={control} name="dateCreatedStart" placeholder="From" />
+                  <DatePicker control={control} name="dateCreatedEnd" placeholder="To" />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Last Login Range</label>
+                <div className="grid grid-cols-2 gap-2">
+                  <DatePicker control={control} name="dateLastLoginStart" placeholder="From" />
+                  <DatePicker control={control} name="dateLastLoginEnd" placeholder="To" />
+                </div>
+              </div>
+            </div>
+            <div className="flex justify-between">
+              <Button type="button" variant="outline" onClick={handleReset}>Reset</Button>
+              <Button type="submit" disabled={isLoading}>Search</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+      {error ? (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : isLoading ? (
+        <div className="space-y-4">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-64 w-full" />
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <div className="flex justify-between items-center">
+            <p className="text-sm text-muted-foreground">
+              Showing {users.length} of {pagination?.totalCount || 0} results
+            </p>
+            <div className="flex items-center space-x-2">
+              <Button variant="outline" size="sm" onClick={() => handlePageChange(page - 1)} disabled={page === 1}>Previous</Button>
+              <span className="text-sm">Page {page} of {pagination?.totalPages || 1}</span>
+              <Button variant="outline" size="sm" onClick={() => handlePageChange(page + 1)} disabled={page === pagination?.totalPages}>Next</Button>
+            </div>
+          </div>
+          <div className="rounded-md border">
+            <table className="w-full">
+              <thead className="bg-muted/50">
+                <tr className="text-left">
+                  <th className="p-3 font-medium">Name</th>
+                  <th className="p-3 font-medium">Email</th>
+                  <th className="p-3 font-medium">Status</th>
+                  <th className="p-3 font-medium">Role</th>
+                  <th className="p-3 font-medium">Created</th>
+                  <th className="p-3 font-medium">Last Login</th>
+                  <th className="p-3 font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((user) => (
+                  <tr key={user.id} className="border-t">
+                    <td className="p-3">{`${user.firstName} ${user.lastName}`}</td>
+                    <td className="p-3">{user.email}</td>
+                    <td className="p-3">
+                      <span className={`px-2 py-1 rounded-full text-xs ${
+                        user.status === 'active'
+                          ? 'bg-green-100 text-green-800'
+                          : user.status === 'inactive'
+                          ? 'bg-gray-100 text-gray-800'
+                          : 'bg-red-100 text-red-800'
+                      }`}>{user.status}</span>
+                    </td>
+                    <td className="p-3">{user.role}</td>
+                    <td className="p-3">{new Date(user.createdAt).toLocaleDateString()}</td>
+                    <td className="p-3">{user.lastLoginAt ? new Date(user.lastLoginAt).toLocaleDateString() : 'Never'}</td>
+                    <td className="p-3">
+                      <Button variant="ghost" size="sm">View</Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/api/admin/users/search/__tests__/route.test.ts
+++ b/app/api/admin/users/search/__tests__/route.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET } from '../route';
+
+vi.mock('@/services/admin/factory', () => ({
+  getApiAdminService: vi.fn(),
+}));
+
+import { getApiAdminService } from '@/services/admin/factory';
+
+function createRequest(query: Record<string, string> = {}) {
+  const url = new URL('http://localhost/api/admin/users/search');
+  Object.entries(query).forEach(([k, v]) => url.searchParams.append(k, v));
+  return { method: 'GET', url: url.toString() } as unknown as NextRequest;
+}
+
+describe('admin search API', () => {
+  const service = { searchUsers: vi.fn() } as any;
+
+  beforeEach(() => {
+    vi.mocked(getApiAdminService).mockReturnValue(service);
+    service.searchUsers.mockResolvedValue({ users: [], pagination: { page: 1, limit: 10, totalCount: 0, totalPages: 0 } });
+  });
+
+  it('calls service with parsed params', async () => {
+    const res = await GET(createRequest({ query: 'john' }));
+    expect(res.status).toBe(200);
+    expect(service.searchUsers).toHaveBeenCalled();
+  });
+});

--- a/app/api/admin/users/search/route.ts
+++ b/app/api/admin/users/search/route.ts
@@ -1,0 +1,46 @@
+import { type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { createSuccessResponse } from '@/lib/api/common';
+import { withErrorHandling } from '@/middleware/error-handling';
+import { withValidation } from '@/middleware/validation';
+import { createProtectedHandler } from '@/middleware/permissions';
+import { getApiAdminService } from '@/services/admin/factory';
+
+const searchSchema = z.object({
+  query: z.string().optional(),
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(100).default(10),
+  status: z.enum(['active', 'inactive', 'suspended', 'all']).optional().default('all'),
+  role: z.string().optional(),
+  dateCreatedStart: z.string().optional(),
+  dateCreatedEnd: z.string().optional(),
+  dateLastLoginStart: z.string().optional(),
+  dateLastLoginEnd: z.string().optional(),
+  sortBy: z.enum(['name', 'email', 'createdAt', 'lastLoginAt', 'status']).optional().default('createdAt'),
+  sortOrder: z.enum(['asc', 'desc']).optional().default('desc'),
+  teamId: z.string().optional(),
+});
+
+export type SearchQuery = z.infer<typeof searchSchema>;
+
+async function handleSearchUsers(_req: NextRequest, params: SearchQuery) {
+  const adminService = getApiAdminService();
+  const result = await adminService.searchUsers(params);
+  return createSuccessResponse({
+    users: result.users,
+    pagination: result.pagination,
+  });
+}
+
+async function handler(req: NextRequest) {
+  return withErrorHandling(
+    async (r) => {
+      const url = new URL(r.url);
+      const query = Object.fromEntries(url.searchParams.entries());
+      return withValidation(searchSchema, handleSearchUsers, r, query as any);
+    },
+    req
+  );
+}
+
+export const GET = createProtectedHandler(handler, 'admin.users.list');

--- a/src/core/admin/interfaces.ts
+++ b/src/core/admin/interfaces.ts
@@ -8,6 +8,21 @@ export interface ListUsersParams {
   sortOrder?: 'asc' | 'desc';
 }
 
+export interface SearchUsersParams {
+  query?: string;
+  page?: number;
+  limit?: number;
+  status?: 'active' | 'inactive' | 'suspended' | 'all';
+  role?: string;
+  dateCreatedStart?: string;
+  dateCreatedEnd?: string;
+  dateLastLoginStart?: string;
+  dateLastLoginEnd?: string;
+  sortBy?: 'name' | 'email' | 'createdAt' | 'lastLoginAt' | 'status';
+  sortOrder?: 'asc' | 'desc';
+  teamId?: string;
+}
+
 export interface AuditLogQuery {
   page: number;
   limit: number;
@@ -26,4 +41,5 @@ export interface AdminService {
   updateUser(id: string, data: Record<string, any>): Promise<any>;
   deleteUser(id: string): Promise<void>;
   getAuditLogs(params: AuditLogQuery): Promise<{ logs: any[]; pagination: PaginationMeta }>;
+  searchUsers(params: SearchUsersParams): Promise<{ users: any[]; pagination: PaginationMeta }>;
 }

--- a/src/hooks/admin/__tests__/useAdminUsers.test.tsx
+++ b/src/hooks/admin/__tests__/useAdminUsers.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useAdminUsers } from '../useAdminUsers';
+import { useApi } from '@/hooks/core/useApi';
+
+vi.mock('@/hooks/core/useApi');
+
+describe('useAdminUsers', () => {
+  const fetchApi = vi.fn();
+  beforeEach(() => {
+    vi.mocked(useApi).mockReturnValue({ isLoading: false, error: null, fetchApi });
+    fetchApi.mockResolvedValue({ users: [{ id: '1' }], pagination: { page: 1, limit: 10, totalCount: 1, totalPages: 1 } });
+  });
+
+  it('fetches users', async () => {
+    const { result } = renderHook(() => useAdminUsers());
+    await act(async () => {
+      await result.current.searchUsers({ query: 'a' });
+    });
+    expect(fetchApi).toHaveBeenCalled();
+    expect(result.current.users.length).toBe(1);
+    expect(result.current.pagination?.totalCount).toBe(1);
+  });
+});

--- a/src/hooks/admin/useAdminUsers.ts
+++ b/src/hooks/admin/useAdminUsers.ts
@@ -1,0 +1,69 @@
+import { useState } from 'react';
+import { useApi } from '@/hooks/core/useApi';
+
+interface SearchParams {
+  query?: string;
+  page?: number;
+  limit?: number;
+  status?: 'active' | 'inactive' | 'suspended' | 'all';
+  role?: string;
+  dateCreatedStart?: Date;
+  dateCreatedEnd?: Date;
+  dateLastLoginStart?: Date;
+  dateLastLoginEnd?: Date;
+  sortBy?: 'name' | 'email' | 'createdAt' | 'lastLoginAt' | 'status';
+  sortOrder?: 'asc' | 'desc';
+  teamId?: string;
+}
+
+interface User {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  status: string;
+  role: string;
+  createdAt: string;
+  lastLoginAt: string | null;
+}
+
+interface Pagination {
+  page: number;
+  limit: number;
+  totalCount: number;
+  totalPages: number;
+}
+
+interface SearchResponse {
+  users: User[];
+  pagination: Pagination;
+}
+
+export function useAdminUsers() {
+  const [users, setUsers] = useState<User[]>([]);
+  const [pagination, setPagination] = useState<Pagination | null>(null);
+  const { isLoading, error, fetchApi } = useApi();
+
+  const searchUsers = async (params: SearchParams) => {
+    const formattedParams: Record<string, string> = {};
+    Object.entries({
+      ...params,
+      dateCreatedStart: params.dateCreatedStart?.toISOString(),
+      dateCreatedEnd: params.dateCreatedEnd?.toISOString(),
+      dateLastLoginStart: params.dateLastLoginStart?.toISOString(),
+      dateLastLoginEnd: params.dateLastLoginEnd?.toISOString(),
+    }).forEach(([k, v]) => {
+      if (v !== undefined && v !== null && v !== '') {
+        formattedParams[k] = String(v);
+      }
+    });
+    const query = new URLSearchParams(formattedParams).toString();
+    const result = await fetchApi<SearchResponse>(`/api/admin/users/search?${query}`);
+    if (result) {
+      setUsers(result.users);
+      setPagination(result.pagination);
+    }
+  };
+
+  return { users, pagination, isLoading, error, searchUsers };
+}

--- a/src/hooks/core/useApi.ts
+++ b/src/hooks/core/useApi.ts
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+
+export function useApi() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchApi = async <T>(url: string, options?: RequestInit): Promise<T | null> => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(url, options);
+      const data = await res.json();
+      if (!res.ok) {
+        const message = data?.error?.message || res.statusText;
+        throw new Error(message);
+      }
+      return data.data ?? data;
+    } catch (e: any) {
+      setError(e.message);
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { isLoading, error, fetchApi };
+}
+export default useApi;

--- a/src/services/admin/default-admin.service.ts
+++ b/src/services/admin/default-admin.service.ts
@@ -1,0 +1,121 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { AdminService } from '@/core/admin/interfaces';
+import type { SearchQuery } from '@/app/api/admin/users/search/route';
+import { getServiceSupabase } from '@/lib/database/supabase';
+
+interface SearchResult {
+  users: any[];
+  pagination: {
+    page: number;
+    limit: number;
+    totalCount: number;
+    totalPages: number;
+  };
+}
+
+export class DefaultAdminService implements AdminService {
+  private supabase: SupabaseClient;
+
+  constructor() {
+    this.supabase = getServiceSupabase();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async listUsers(_params: any): Promise<{ users: any[]; pagination: any }> {
+    throw new Error('Not implemented');
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async getUserById(_id: string): Promise<any | null> {
+    throw new Error('Not implemented');
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async updateUser(_id: string, _data: Record<string, any>): Promise<any> {
+    throw new Error('Not implemented');
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async deleteUser(_id: string): Promise<void> {
+    throw new Error('Not implemented');
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async getAuditLogs(_params: any): Promise<{ logs: any[]; pagination: any }> {
+    throw new Error('Not implemented');
+  }
+
+  async searchUsers(params: SearchQuery): Promise<SearchResult> {
+    const {
+      query,
+      page,
+      limit,
+      status,
+      role,
+      dateCreatedStart,
+      dateCreatedEnd,
+      dateLastLoginStart,
+      dateLastLoginEnd,
+      sortBy,
+      sortOrder,
+      teamId,
+    } = params;
+
+    const offset = (page - 1) * limit;
+
+    let baseQuery = this.supabase
+      .from('profiles')
+      .select(
+        'id, first_name, last_name, email, user_type, created_at, last_login_at, status, role',
+        { count: 'exact' }
+      );
+
+    if (query && query.trim() !== '') {
+      baseQuery = baseQuery.or(
+        `first_name.ilike.%${query}%,last_name.ilike.%${query}%,email.ilike.%${query}%`
+      );
+    }
+    if (status && status !== 'all') {
+      baseQuery = baseQuery.eq('status', status);
+    }
+    if (role) {
+      baseQuery = baseQuery.eq('role', role);
+    }
+    if (dateCreatedStart) {
+      baseQuery = baseQuery.gte('created_at', dateCreatedStart);
+    }
+    if (dateCreatedEnd) {
+      baseQuery = baseQuery.lte('created_at', dateCreatedEnd);
+    }
+    if (dateLastLoginStart) {
+      baseQuery = baseQuery.gte('last_login_at', dateLastLoginStart);
+    }
+    if (dateLastLoginEnd) {
+      baseQuery = baseQuery.lte('last_login_at', dateLastLoginEnd);
+    }
+    if (teamId) {
+      baseQuery = baseQuery.eq('team_id', teamId);
+    }
+
+    baseQuery = baseQuery.order(sortBy === 'name' ? 'first_name' : sortBy, {
+      ascending: sortOrder === 'asc',
+    });
+
+    baseQuery = baseQuery.range(offset, offset + limit - 1);
+
+    const { data: users, error, count } = await baseQuery;
+
+    if (error) {
+      console.error('Error searching users:', error);
+      throw new Error(`Failed to search users: ${error.message}`);
+    }
+
+    const totalPages = Math.ceil((count || 0) / limit);
+
+    return {
+      users: users || [],
+      pagination: {
+        page,
+        limit,
+        totalCount: count || 0,
+        totalPages,
+      },
+    };
+  }
+}

--- a/src/services/admin/index.ts
+++ b/src/services/admin/index.ts
@@ -1,0 +1,10 @@
+import { AdminService } from '@/core/admin/interfaces';
+import { DefaultAdminService } from './default-admin.service';
+
+export interface AdminServiceConfig {}
+
+export function createAdminService(_: AdminServiceConfig = {}): AdminService {
+  return new DefaultAdminService();
+}
+
+export default { createAdminService };

--- a/src/ui/primitives/datepicker.tsx
+++ b/src/ui/primitives/datepicker.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { Control, Controller } from 'react-hook-form';
+import { Input } from './input';
+
+interface DatePickerProps {
+  control: Control<any>;
+  name: string;
+  placeholder?: string;
+}
+
+export function DatePicker({ control, name, placeholder }: DatePickerProps) {
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <Input
+          type="date"
+          placeholder={placeholder}
+          value={field.value ? new Date(field.value).toISOString().substring(0, 10) : ''}
+          onChange={(e) => field.onChange(e.target.value ? new Date(e.target.value) : undefined)}
+        />
+      )}
+    />
+  );
+}

--- a/supabase/migrations/20240628000000_add_user_search_indexes.sql
+++ b/supabase/migrations/20240628000000_add_user_search_indexes.sql
@@ -1,0 +1,6 @@
+-- Indexes to optimize admin user search
+CREATE INDEX IF NOT EXISTS idx_profiles_search ON profiles USING GIN (to_tsvector('english', coalesce(first_name, '') || ' ' || coalesce(last_name, '') || ' ' || coalesce(email, '')));
+CREATE INDEX IF NOT EXISTS idx_profiles_status ON profiles(status);
+CREATE INDEX IF NOT EXISTS idx_profiles_role ON profiles(role);
+CREATE INDEX IF NOT EXISTS idx_profiles_created_at ON profiles(created_at);
+CREATE INDEX IF NOT EXISTS idx_profiles_last_login_at ON profiles(last_login_at);


### PR DESCRIPTION
## Summary
- implement backend user search API and service
- add admin user search hook
- create user search component
- add DatePicker primitive
- add SQL indexes for search performance
- include tests for new hook and route

## Testing
- `npx vitest run --coverage app/api/admin/users/search/__tests__/route.test.ts src/hooks/admin/__tests__/useAdminUsers.test.tsx` *(fails: runs entire suite)*