### PR TITLE
Add unified auth middleware

### DIFF
--- a/app/api/addresses/route.ts
+++ b/app/api/addresses/route.ts
@@ -8,7 +8,7 @@ import {
 } from '@/lib/api/common';
 import { withRateLimit } from '@/middleware/rate-limit';
 import { withErrorHandling } from '@/middleware/error-handling';
-import { withRouteAuth } from '@/middleware/auth';
+import { withAuthRequest } from '@/middleware/auth';
 import { withSecurity } from '@/middleware/with-security';
 
 async function handleGet(_req: NextRequest, userId: string) {
@@ -28,11 +28,11 @@ async function handlePost(req: NextRequest, userId: string) {
 
 // Combined approach with both rate limiting and proper authentication
 export const GET = (req: NextRequest) =>
-  withRateLimit(req, r => withSecurity(q => 
-    withRouteAuth((s, uid) => handleGet(s, uid), q)
+  withRateLimit(req, r => withSecurity(q =>
+    withAuthRequest(q, (s, ctx) => handleGet(s, ctx.userId))
   )(r));
 
 export const POST = (req: NextRequest) =>
-  withRateLimit(req, r => withSecurity(q => 
-    withRouteAuth((s, uid) => handlePost(s, uid), q)
+  withRateLimit(req, r => withSecurity(q =>
+    withAuthRequest(q, (s, ctx) => handlePost(s, ctx.userId))
   )(r));

--- a/app/api/user/avatar/__tests__/route.test.ts
+++ b/app/api/user/avatar/__tests__/route.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 import { GET, POST, DELETE } from '../route';
 import { getApiUserService } from '@/services/user/factory';
-import { withRouteAuth } from '@/middleware/auth';
+import { withAuthRequest } from '@/middleware/auth';
 import createMockUserService from '@/tests/mocks/user.service.mock';
 
 vi.mock('@/services/user/factory', () => ({ getApiUserService: vi.fn() }));
 vi.mock('@/middleware/auth', () => ({
-  withRouteAuth: vi.fn((handler: any, req: any) => handler(req, 'user-1')),
+  withAuthRequest: vi.fn((req: any, handler: any) => handler(req, { userId: 'user-1', role: 'user' })),
 }));
 
 const service = createMockUserService();

--- a/app/api/user/profile/__tests__/route.test.ts
+++ b/app/api/user/profile/__tests__/route.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 import { GET, PATCH } from '../route';
 import { getApiUserService } from '@/services/user/factory';
-import { withRouteAuth } from '@/middleware/auth';
+import { withAuthRequest } from '@/middleware/auth';
 import createMockUserService from '@/tests/mocks/user.service.mock';
 
 vi.mock('@/services/user/factory', () => ({ getApiUserService: vi.fn() }));
 vi.mock('@/middleware/auth', () => ({
-  withRouteAuth: vi.fn((handler: any, req: any) => handler(req, 'user-1')),
+  withAuthRequest: vi.fn((req: any, handler: any) => handler(req, { userId: 'user-1', role: 'user' })),
 }));
 
 const service = createMockUserService();

--- a/app/api/user/profile/route.ts
+++ b/app/api/user/profile/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { createSuccessResponse } from '@/lib/api/common';
 import { withErrorHandling } from '@/middleware/error-handling';
-import { withRouteAuth } from '@/middleware/auth';
+import { withAuthRequest } from '@/middleware/auth';
 import { withValidation } from '@/middleware/validation';
 import { getApiUserService } from '@/services/user/factory';
 import { profileSchema } from '@/types/database';
@@ -40,7 +40,7 @@ async function handlePatch(
 
 export async function GET(request: NextRequest) {
   return withErrorHandling(
-    (req) => withRouteAuth((r, uid) => handleGet(r, uid), req),
+    (req) => withAuthRequest(req, (r, ctx) => handleGet(r, ctx.userId)),
     request
   );
 }
@@ -48,10 +48,8 @@ export async function GET(request: NextRequest) {
 export async function PATCH(request: NextRequest) {
   return withErrorHandling(
     (req) =>
-      withRouteAuth(
-        (r, uid) =>
-          withValidation(UpdateSchema, (r2, data) => handlePatch(r2, uid, data), r),
-        req
+      withAuthRequest(req, (r, ctx) =>
+        withValidation(UpdateSchema, (r2, data) => handlePatch(r2, ctx.userId, data), r)
       ),
     request
   );

--- a/app/api/user/settings/__tests__/route.test.ts
+++ b/app/api/user/settings/__tests__/route.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 import { GET, PATCH } from '../route';
 import { getApiUserService } from '@/services/user/factory';
-import { withRouteAuth } from '@/middleware/auth';
+import { withAuthRequest } from '@/middleware/auth';
 import createMockUserService from '@/tests/mocks/user.service.mock';
 
 vi.mock('@/services/user/factory', () => ({ getApiUserService: vi.fn() }));
 vi.mock('@/middleware/auth', () => ({
-  withRouteAuth: vi.fn((handler: any, req: any) => handler(req, 'user-1')),
+  withAuthRequest: vi.fn((req: any, handler: any) => handler(req, { userId: 'user-1', role: 'user' })),
 }));
 
 const service = createMockUserService();

--- a/app/api/user/settings/route.ts
+++ b/app/api/user/settings/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { createSuccessResponse } from '@/lib/api/common';
 import { withErrorHandling } from '@/middleware/error-handling';
-import { withRouteAuth } from '@/middleware/auth';
+import { withAuthRequest } from '@/middleware/auth';
 import { withValidation } from '@/middleware/validation';
 import { getApiUserService } from '@/services/user/factory';
 import { userPreferencesSchema } from '@/types/database';
@@ -34,7 +34,7 @@ async function handlePatch(
 
 export async function GET(request: NextRequest) {
   return withErrorHandling(
-    (req) => withRouteAuth((r, uid) => handleGet(r, uid), req),
+    (req) => withAuthRequest(req, (r, ctx) => handleGet(r, ctx.userId)),
     request
   );
 }
@@ -42,10 +42,8 @@ export async function GET(request: NextRequest) {
 export async function PATCH(request: NextRequest) {
   return withErrorHandling(
     (req) =>
-      withRouteAuth(
-        (r, uid) =>
-          withValidation(UpdateSchema, (r2, data) => handlePatch(r2, uid, data), r),
-        req
+      withAuthRequest(req, (r, ctx) =>
+        withValidation(UpdateSchema, (r2, data) => handlePatch(r2, ctx.userId, data), r)
       ),
     request
   );

--- a/src/lib/auth/hasPermission.ts
+++ b/src/lib/auth/hasPermission.ts
@@ -1,6 +1,5 @@
-import { prisma } from '@/lib/database/prisma';
 import { Permission } from '@/types/rbac';
-import { checkRolePermission } from '@/lib/rbac/roleService';
+import { getApiPermissionService } from '@/services/permission/factory';
 
 /**
  * Check if a user has a specific permission
@@ -10,27 +9,16 @@ import { checkRolePermission } from '@/lib/rbac/roleService';
  * @returns A boolean indicating if the user has the permission
  */
 export async function hasPermission(userId: string, permission: Permission): Promise<boolean> {
-  // For E2E tests and development, always return true
   if (process.env.NODE_ENV === 'development' || process.env.E2E_TEST === 'true') {
     console.log(`[DEV/TEST] Permitting access to ${permission} for user ${userId}`);
     return true;
   }
-  
+
   try {
-    // Get the user's role
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      select: { role: true }
-    });
-
-    if (!user) {
-      return false;
-    }
-
-    // Check if the role has the required permission
-    return await checkRolePermission(user.role, permission);
+    const service = getApiPermissionService();
+    return await service.hasPermission(userId, permission as any);
   } catch (error) {
     console.error(`Error checking permission ${permission} for user ${userId}:`, error);
     return false;
   }
-} 
+}

--- a/src/services/auth/factory.ts
+++ b/src/services/auth/factory.ts
@@ -12,6 +12,7 @@ import type { AuthStorage } from './auth-storage';
 import { BrowserAuthStorage } from './auth-storage';
 import { AdapterRegistry } from '@/adapters/registry';
 import { createSupabaseAuthProvider } from '@/adapters/auth/factory';
+import { getServiceSupabase } from '@/lib/database/supabase';
 
 /**
  * Options for {@link getApiAuthService}
@@ -94,4 +95,15 @@ export function getApiAuthService(options: ApiAuthServiceOptions = {}): AuthServ
   }
 
   return cachedService;
+}
+
+/**
+ * Retrieve a Supabase user session directly from an access token.
+ */
+export async function getSessionFromToken(token: string) {
+  if (!token) return null;
+  const supabase = getServiceSupabase();
+  const { data, error } = await supabase.auth.getUser(token);
+  if (error || !data.user) return null;
+  return data.user;
 }

--- a/src/tests/mocks/auth.mock.ts
+++ b/src/tests/mocks/auth.mock.ts
@@ -1,0 +1,8 @@
+import { vi } from 'vitest';
+
+export function createAuthMock(userId = 'user-1', role = 'user') {
+  return {
+    withAuthRequest: vi.fn((req: any, handler: any) => handler(req, { userId, role })),
+  };
+}
+


### PR DESCRIPTION
## Summary
- add new `withAuthRequest` middleware
- use permission service in `hasPermission`
- expose `getSessionFromToken`
- update user profile & settings API to use new auth
- adjust tests to mock new middleware
- add auth mock helper

## Testing
- `npx vitest run --coverage` *(fails: JavaScript heap out of memory)*