### PR TITLE
Add user repository interface

### DIFF
--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -1,0 +1,1 @@
+export * from './interfaces/IUserRepository';

--- a/src/repositories/interfaces/IUserRepository.ts
+++ b/src/repositories/interfaces/IUserRepository.ts
@@ -1,0 +1,22 @@
+/**
+ * User Repository Interface
+ *
+ * Defines the contract for basic CRUD operations on User entities.
+ * Implementations should encapsulate all persistence logic
+ * so that the rest of the application remains database agnostic.
+ */
+import type { User, CreateUserDto } from '@/types/user';
+
+export interface IUserRepository {
+  /** Find a user by their unique ID */
+  findById(id: string): Promise<User | null>;
+
+  /** Find a user by their email address */
+  findByEmail(email: string): Promise<User | null>;
+
+  /** Create a new user */
+  create(data: CreateUserDto): Promise<User>;
+
+  /** Update an existing user */
+  update(id: string, data: Partial<User>): Promise<User>;
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -20,3 +20,10 @@ export const userSchema = z.object({
 });
 
 export type User = z.infer<typeof userSchema>; 
+export interface CreateUserDto {
+  email: string;
+  password: string;
+  firstName?: string;
+  lastName?: string;
+  metadata?: Record<string, any>;
+}


### PR DESCRIPTION
## Summary
- add `CreateUserDto` type to user types
- define `IUserRepository` interface for user persistence
- export new repository interface

## Testing
- `npm run test:coverage` *(fails: JavaScript heap out of memory)*