### PR TITLE
Add repository user service

### DIFF
--- a/src/services/user/__tests__/repository-user.service.test.ts
+++ b/src/services/user/__tests__/repository-user.service.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { RepositoryUserService } from '../repository-user.service';
+import { MockAuthService } from '../../auth/__tests__/mocks/mock-auth-service';
+import type { IUserRepository } from '@/repositories/interfaces/IUserRepository';
+
+function createRepoMock(): IUserRepository {
+  return {
+    findById: vi.fn(),
+    findByEmail: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  };
+}
+
+describe('RepositoryUserService', () => {
+  let repo: IUserRepository;
+  let auth: MockAuthService;
+  let service: RepositoryUserService;
+
+  beforeEach(() => {
+    repo = createRepoMock();
+    auth = new MockAuthService();
+    service = new RepositoryUserService({ userRepository: repo, authService: auth });
+  });
+
+  it('registers user through auth and repository', async () => {
+    (auth.register as any).mockResolvedValue({ success: true, user: { id: '1', email: 'a' } });
+    (repo.create as any).mockResolvedValue({ id: '1', email: 'a' });
+
+    const res = await service.register({ email: 'a', password: 'p', firstName: 'A', lastName: 'B' });
+
+    expect(auth.register).toHaveBeenCalled();
+    expect(repo.create).toHaveBeenCalled();
+    expect(res.success).toBe(true);
+  });
+
+  it('does not create profile if auth fails', async () => {
+    (auth.register as any).mockResolvedValue({ success: false, error: 'fail' });
+
+    const res = await service.register({ email: 'a', password: 'p', firstName: 'A', lastName: 'B' });
+
+    expect(repo.create).not.toHaveBeenCalled();
+    expect(res.success).toBe(false);
+    expect(res.error).toBe('fail');
+  });
+
+  it('updates profile via repository', async () => {
+    (repo.update as any).mockResolvedValue({ id: '1', email: 'a', firstName: 'A' });
+
+    const res = await service.updateProfile('1', { firstName: 'A' });
+
+    expect(repo.update).toHaveBeenCalledWith('1', { firstName: 'A' });
+    expect(res).toEqual({ success: true, user: { id: '1', email: 'a', firstName: 'A' } });
+  });
+
+  it('forwards login to auth service', async () => {
+    (auth.login as any).mockResolvedValue({ success: true, token: 't' });
+
+    const res = await service.login({ email: 'e', password: 'p' });
+
+    expect(auth.login).toHaveBeenCalledWith({ email: 'e', password: 'p' });
+    expect(res).toEqual({ success: true, token: 't' });
+  });
+});

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -7,6 +7,7 @@
 
 import { UserService } from '@/core/user/interfaces';
 import { DefaultUserService } from './default-user.service';
+export { RepositoryUserService } from './repository-user.service';
 export { ApiUserService, getApiUserService } from './api-user.service';
 import type { UserDataProvider } from '@/core/user/IUserDataProvider';
 

--- a/src/services/user/repository-user.service.ts
+++ b/src/services/user/repository-user.service.ts
@@ -1,0 +1,69 @@
+
+/**
+ * Repository-backed User Service
+ *
+ * Provides user management and authentication logic using the IUserRepository
+ * and AuthService abstractions. All methods return result objects instead of
+ * throwing synchronous errors to keep consumers simple.
+ */
+import type { AuthService } from '@/core/auth/interfaces';
+import type { LoginPayload, RegistrationPayload, AuthResult } from '@/core/auth/models';
+import type { IUserRepository } from '@/repositories/interfaces/IUserRepository';
+import type { User, CreateUserDto } from '@/types/user';
+
+export interface RepositoryUserServiceOptions {
+  userRepository: IUserRepository;
+  authService: AuthService;
+}
+
+export class RepositoryUserService {
+  constructor(private readonly options: RepositoryUserServiceOptions) {}
+
+  /** Register a new user via the auth service and persist a profile */
+  async register(data: RegistrationPayload): Promise<AuthResult> {
+    const authResult = await this.options.authService.register(data);
+    if (!authResult.success || !authResult.user) {
+      return authResult;
+    }
+    try {
+      const createDto: CreateUserDto = {
+        email: data.email,
+        password: data.password,
+        firstName: data.firstName,
+        lastName: data.lastName,
+        metadata: data.metadata,
+      };
+      await this.options.userRepository.create(createDto);
+      return authResult;
+    } catch (error: any) {
+      return { success: false, error: error.message };
+    }
+  }
+
+  /** Authenticate an existing user */
+  async login(credentials: LoginPayload): Promise<AuthResult> {
+    return this.options.authService.login(credentials);
+  }
+
+  /** Retrieve a user profile by id */
+  async getUserById(id: string): Promise<User | null> {
+    try {
+      return await this.options.userRepository.findById(id);
+    } catch {
+      return null;
+    }
+  }
+
+  /** Update profile information for a user */
+  async updateProfile(
+    id: string,
+    update: Partial<User>
+  ): Promise<{ success: boolean; user?: User; error?: string }> {
+    try {
+      const user = await this.options.userRepository.update(id, update);
+      return { success: true, user };
+    } catch (error: any) {
+      return { success: false, error: error.message };
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement RepositoryUserService using IUserRepository and AuthService
- export the new class
- add unit tests for repository-backed service

## Testing
- `npx vitest run src/services/user/__tests__/repository-user.service.test.ts --coverage` *(fails: could not complete test suite)*