### PR TITLE
Add database interface definitions

### DIFF
--- a/docs/Product documentation/database-interfaces.md
+++ b/docs/Product documentation/database-interfaces.md
@@ -1,0 +1,44 @@
+# Core Database Interfaces
+
+This document describes the generic database interfaces located under
+`src/core/database/interfaces`.
+
+These interfaces provide a database agnostic abstraction that can be
+implemented by different persistence layers (Supabase, Prisma, REST APIs, etc.).
+They allow the service layer to operate independently of any particular
+storage technology.
+
+## Overview
+
+- **`BaseDatabaseInterface`** – CRUD operations, connection management and
+  optional query/transaction support.
+- **`QueryBuilder`** – Fluent query builder for filtering, sorting and
+  pagination.
+- **`TransactionInterface`** – Simple transaction lifecycle control.
+- **Entity interfaces** – Aliases that extend existing data provider
+  interfaces (`IUserRepository`, `ITeamDataProvider`, etc.).
+
+### Usage Example
+
+```ts
+import { QueryBuilder } from '@/core/database/interfaces';
+
+async function listUsers(builder: QueryBuilder<UserProfile>) {
+  return builder
+    .filter({ field: 'active', operator: '=', value: true })
+    .sort({ field: 'createdAt', direction: 'desc' })
+    .paginate({ page: 1, limit: 20 })
+    .execute();
+}
+```
+
+## Error Handling
+
+All methods should resolve with a `DatabaseError` when validation or business
+rules fail. Unexpected provider errors may cause promise rejections.
+
+## Migration Notes
+
+Adapters that previously depended directly on Supabase or Prisma should migrate
+to these interfaces. Implement the appropriate interface and expose the
+implementation through the existing factory functions in `src/lib/database`.

--- a/src/core/database/interfaces/__tests__/typeGuards.test.ts
+++ b/src/core/database/interfaces/__tests__/typeGuards.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isQueryResult,
+  isFilterCondition,
+  type QueryResult,
+  type FilterCondition
+} from '../index';
+
+describe('database interface type guards', () => {
+  it('validates QueryResult objects', () => {
+    const value: QueryResult<number> = { items: [1, 2], count: 2 };
+    expect(isQueryResult<number>(value)).toBe(true);
+    expect(isQueryResult<number>({ items: [], count: 'x' })).toBe(false);
+  });
+
+  it('validates FilterCondition objects', () => {
+    const cond: FilterCondition = { field: 'name', operator: '=', value: 'a' };
+    expect(isFilterCondition(cond)).toBe(true);
+    expect(isFilterCondition({ field: 1, operator: '=' })).toBe(false);
+  });
+});

--- a/src/core/database/interfaces/base.interface.ts
+++ b/src/core/database/interfaces/base.interface.ts
@@ -1,0 +1,49 @@
+/**
+ * Generic database interface defining basic CRUD operations,
+ * connection management and transaction support.
+ *
+ * Implementations of this interface should remain database agnostic so that
+ * the service layer can swap providers without code changes.
+ *
+ * Errors should be surfaced using {@link DatabaseError} objects.
+ * Unexpected provider failures may reject the returned promises.
+ *
+ * @typeParam T - Entity type handled by the repository
+ */
+import type {
+  ConnectionOptions,
+  QueryOptions,
+  QueryResult,
+  TransactionInterface,
+  DatabaseError
+} from './index';
+
+export interface BaseDatabaseInterface<T> {
+  /** Connect to the underlying database */
+  connect(options?: ConnectionOptions): Promise<void>;
+
+  /** Close the database connection */
+  disconnect(): Promise<void>;
+
+  /** Create a new entity */
+  create(data: Omit<T, 'id'>): Promise<T | DatabaseError>;
+
+  /** Find an entity by its identifier */
+  findById(id: string): Promise<T | null | DatabaseError>;
+
+  /** Update an existing entity */
+  update(id: string, data: Partial<T>): Promise<T | DatabaseError>;
+
+  /** Delete an entity */
+  delete(id: string): Promise<{ success: boolean; error?: DatabaseError }>;
+
+  /**
+   * Query entities using filtering and pagination.
+   *
+   * Implementations may throw for unexpected database errors.
+   */
+  query?(options?: QueryOptions): Promise<QueryResult<T>>;
+
+  /** Execute operations in a transaction */
+  transaction?<R>(fn: (tx: TransactionInterface) => Promise<R>): Promise<R>;
+}

--- a/src/core/database/interfaces/index.ts
+++ b/src/core/database/interfaces/index.ts
@@ -1,0 +1,102 @@
+/**
+ * Core database interface exports and common types.
+ */
+
+import type { DataProviderError } from '../../common/errors';
+export { isDataProviderError as isDatabaseError } from '../../common/errors';
+
+/** Connection configuration options */
+export interface ConnectionOptions {
+  host?: string;
+  port?: number;
+  database?: string;
+  user?: string;
+  password?: string;
+  ssl?: boolean;
+}
+
+/** Isolation levels for transactions */
+export type IsolationLevel =
+  | 'read_uncommitted'
+  | 'read_committed'
+  | 'repeatable_read'
+  | 'serializable';
+
+/** Options for starting a transaction */
+export interface TransactionOptions {
+  isolationLevel?: IsolationLevel;
+}
+
+/** Filtering condition */
+export interface FilterCondition {
+  field: string;
+  operator:
+    | '='
+    | '!='
+    | '<'
+    | '>'
+    | '<='
+    | '>='
+    | 'like'
+    | 'ilike'
+    | 'in';
+  value: unknown;
+}
+
+/** Sort order option */
+export interface SortOption {
+  field: string;
+  direction: 'asc' | 'desc';
+}
+
+/** Pagination parameters */
+export interface PaginationParams {
+  page?: number;
+  limit?: number;
+  offset?: number;
+}
+
+/** Options for query operations */
+export interface QueryOptions {
+  filters?: FilterCondition[];
+  sort?: SortOption[];
+  pagination?: PaginationParams;
+  relations?: string[];
+}
+
+/** Generic query result */
+export interface QueryResult<T> {
+  items: T[];
+  count: number;
+}
+
+export type DatabaseError = DataProviderError;
+
+/** Type guard for {@link QueryResult} */
+export function isQueryResult<T>(value: unknown): value is QueryResult<T> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Array.isArray((value as any).items) &&
+    typeof (value as any).count === 'number'
+  );
+}
+
+/** Type guard for {@link FilterCondition} */
+export function isFilterCondition(value: unknown): value is FilterCondition {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as any).field === 'string' &&
+    typeof (value as any).operator === 'string' &&
+    'value' in (value as any)
+  );
+}
+
+export * from './base.interface';
+export * from './query.interface';
+export * from './transaction.interface';
+export * from './user.interface';
+export * from './team.interface';
+export * from './organization.interface';
+export * from './permission.interface';

--- a/src/core/database/interfaces/organization.interface.ts
+++ b/src/core/database/interfaces/organization.interface.ts
@@ -1,0 +1,9 @@
+import type { IOrganizationDataProvider } from '../../organization/IOrganizationDataProvider';
+import type { BaseDatabaseInterface } from './base.interface';
+import type { Organization } from '../../organization/models';
+
+/**
+ * Database interface for organizations.
+ */
+export interface OrganizationDatabaseInterface
+  extends BaseDatabaseInterface<Organization>, IOrganizationDataProvider {}

--- a/src/core/database/interfaces/permission.interface.ts
+++ b/src/core/database/interfaces/permission.interface.ts
@@ -1,0 +1,9 @@
+import type { IPermissionDataProvider } from '../../permission/IPermissionDataProvider';
+import type { BaseDatabaseInterface } from './base.interface';
+import type { RoleWithPermissions } from '../../permission/models';
+
+/**
+ * Database interface for permissions and roles.
+ */
+export interface PermissionDatabaseInterface
+  extends BaseDatabaseInterface<RoleWithPermissions>, IPermissionDataProvider {}

--- a/src/core/database/interfaces/query.interface.ts
+++ b/src/core/database/interfaces/query.interface.ts
@@ -1,0 +1,32 @@
+/**
+ * Interface describing a fluent query builder.
+ *
+ * Allows consumers to build database agnostic queries with filtering,
+ * sorting, pagination and relationship handling.
+ *
+ * Implementations should return a new builder instance on each method
+ * to maintain immutability.
+ */
+import type {
+  FilterCondition,
+  SortOption,
+  PaginationParams,
+  QueryResult
+} from './index';
+
+export interface QueryBuilder<T> {
+  /** Apply a filter condition */
+  filter(condition: FilterCondition): QueryBuilder<T>;
+
+  /** Sort results by the given field */
+  sort(option: SortOption): QueryBuilder<T>;
+
+  /** Limit results using pagination */
+  paginate(params: PaginationParams): QueryBuilder<T>;
+
+  /** Load related entities */
+  with(relations: string[]): QueryBuilder<T>;
+
+  /** Execute the built query */
+  execute(): Promise<QueryResult<T>>;
+}

--- a/src/core/database/interfaces/team.interface.ts
+++ b/src/core/database/interfaces/team.interface.ts
@@ -1,0 +1,9 @@
+import type { ITeamDataProvider } from '../../team/ITeamDataProvider';
+import type { BaseDatabaseInterface } from './base.interface';
+import type { Team } from '../../team/models';
+
+/**
+ * Database interface for teams.
+ */
+export interface TeamDatabaseInterface
+  extends BaseDatabaseInterface<Team>, ITeamDataProvider {}

--- a/src/core/database/interfaces/transaction.interface.ts
+++ b/src/core/database/interfaces/transaction.interface.ts
@@ -1,0 +1,17 @@
+/**
+ * Transaction management interface used by {@link BaseDatabaseInterface}.
+ *
+ * Supports explicit control over commit/rollback and isolation levels.
+ */
+import type { TransactionOptions } from './index';
+
+export interface TransactionInterface {
+  /** Begin a new transaction */
+  begin(options?: TransactionOptions): Promise<void>;
+
+  /** Commit the current transaction */
+  commit(): Promise<void>;
+
+  /** Rollback the current transaction */
+  rollback(): Promise<void>;
+}

--- a/src/core/database/interfaces/user.interface.ts
+++ b/src/core/database/interfaces/user.interface.ts
@@ -1,0 +1,12 @@
+import type { IUserRepository } from '../../user/IUserRepository';
+import type { BaseDatabaseInterface } from './base.interface';
+import type { UserProfile } from '../../user/models';
+
+/**
+ * Database interface for user entities.
+ *
+ * This simply extends the existing {@link IUserRepository}
+ * to make it part of the generic database interface collection.
+ */
+export interface UserDatabaseInterface
+  extends BaseDatabaseInterface<UserProfile>, IUserRepository {}


### PR DESCRIPTION
## Summary
- add generic base database interface and query/transaction contracts
- define entity interfaces for users, teams, organizations and permissions
- export common types and guards
- document database interfaces
- add tests for type guards

## Testing
- `npx vitest run --coverage src/core/database/interfaces/__tests__/typeGuards.test.ts` *(fails: ran out of memory)*