### PR TITLE
Implement generic database provider classes

### DIFF
--- a/src/adapters/database/__tests__/mock-repository.test.ts
+++ b/src/adapters/database/__tests__/mock-repository.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { MockRepository } from '../mock';
+
+interface Item { id: string; name: string; type?: string }
+
+describe('MockRepository', () => {
+  it('supports basic CRUD operations', async () => {
+    const repo = new MockRepository<Item>();
+    await repo.connect();
+
+    const created = await repo.create({ name: 'test' });
+    expect(created).toHaveProperty('id');
+
+    const found = await repo.findById(created.id);
+    expect(found?.name).toBe('test');
+
+    const updated = await repo.update(created.id, { name: 'updated' });
+    expect(updated.name).toBe('updated');
+
+    const del = await repo.delete(created.id);
+    expect(del.success).toBe(true);
+    const missing = await repo.findById(created.id);
+    expect(missing).toBeNull();
+  });
+
+  it('filters results via query', async () => {
+    const repo = new MockRepository<Item>();
+    await repo.connect();
+    await repo.create({ name: 'a', type: 'one' });
+    await repo.create({ name: 'b', type: 'two' });
+
+    const res = await repo.query({ filters: [{ field: 'type', operator: '=', value: 'one' }] });
+    expect(res.items.length).toBe(1);
+    expect(res.items[0].name).toBe('a');
+  });
+});

--- a/src/adapters/database/index.ts
+++ b/src/adapters/database/index.ts
@@ -1,0 +1,3 @@
+export * from './supabase';
+export * from './prisma';
+export * from './mock';

--- a/src/adapters/database/mock/index.ts
+++ b/src/adapters/database/mock/index.ts
@@ -1,0 +1,1 @@
+export { MockRepository } from './mock-repository';

--- a/src/adapters/database/mock/mock-repository.ts
+++ b/src/adapters/database/mock/mock-repository.ts
@@ -1,0 +1,68 @@
+import type {
+  BaseDatabaseInterface,
+  ConnectionOptions,
+  QueryOptions,
+  QueryResult,
+  TransactionInterface,
+  DatabaseError
+} from '@/core/database/interfaces';
+
+/**
+ * Simple in-memory database implementation for testing.
+ */
+export class MockRepository<T extends { id: string }> implements BaseDatabaseInterface<T> {
+  private items: T[] = [];
+
+  async connect(_options?: ConnectionOptions): Promise<void> {}
+
+  async disconnect(): Promise<void> {
+    this.items = [];
+  }
+
+  async create(data: Omit<T, 'id'>): Promise<T | DatabaseError> {
+    const item = { ...(data as object), id: `${Date.now()}-${Math.random()}` } as T;
+    this.items.push(item);
+    return item;
+  }
+
+  async findById(id: string): Promise<T | null | DatabaseError> {
+    return this.items.find((i) => i.id === id) || null;
+  }
+
+  async update(id: string, data: Partial<T>): Promise<T | DatabaseError> {
+    const index = this.items.findIndex((i) => i.id === id);
+    if (index === -1) return { code: 'mock/not_found', message: 'Item not found' };
+    this.items[index] = { ...this.items[index], ...data } as T;
+    return this.items[index];
+  }
+
+  async delete(id: string): Promise<{ success: boolean; error?: DatabaseError }> {
+    const index = this.items.findIndex((i) => i.id === id);
+    if (index === -1) {
+      return { success: false, error: { code: 'mock/not_found', message: 'Item not found' } };
+    }
+    this.items.splice(index, 1);
+    return { success: true };
+  }
+
+  async query(options?: QueryOptions): Promise<QueryResult<T>> {
+    let result = [...this.items];
+    if (options?.filters) {
+      for (const cond of options.filters) {
+        result = result.filter((i: any) => i[cond.field] === cond.value);
+      }
+    }
+    return { items: result, count: result.length };
+  }
+
+  async transaction<R>(fn: (tx: TransactionInterface) => Promise<R>): Promise<R> {
+    const tx: TransactionInterface = {
+      begin: async () => {},
+      commit: async () => {},
+      rollback: async () => {}
+    };
+    return fn(tx);
+  }
+}
+
+export default MockRepository;

--- a/src/adapters/database/prisma/index.ts
+++ b/src/adapters/database/prisma/index.ts
@@ -1,0 +1,1 @@
+export { PrismaRepository } from './prisma-repository';

--- a/src/adapters/database/prisma/prisma-repository.ts
+++ b/src/adapters/database/prisma/prisma-repository.ts
@@ -1,0 +1,85 @@
+import { PrismaClient } from '@prisma/client';
+import type {
+  BaseDatabaseInterface,
+  ConnectionOptions,
+  QueryOptions,
+  QueryResult,
+  TransactionInterface,
+  DatabaseError
+} from '@/core/database/interfaces';
+import { SERVER_ERROR_CODES } from '@/lib/api/common/error-codes';
+
+/**
+ * Prisma implementation of the BaseDatabaseInterface.
+ *
+ * Each instance is configured with a Prisma model name which is
+ * used for all CRUD operations.
+ */
+export class PrismaRepository<T> implements BaseDatabaseInterface<T> {
+  private client: PrismaClient;
+  private model: any;
+
+  constructor(options: { client?: PrismaClient; model: string }) {
+    this.client = options.client || new PrismaClient();
+    this.model = (this.client as any)[options.model];
+    if (!this.model) {
+      throw new Error(`Model '${options.model}' not found in PrismaClient`);
+    }
+  }
+
+  async connect(_options?: ConnectionOptions): Promise<void> {
+    await this.client.$connect();
+  }
+
+  async disconnect(): Promise<void> {
+    await this.client.$disconnect();
+  }
+
+  async create(data: Omit<T, 'id'>): Promise<T | DatabaseError> {
+    try {
+      return (await this.model.create({ data })) as T;
+    } catch (error: any) {
+      return { code: SERVER_ERROR_CODES.DATABASE_ERROR, message: error.message };
+    }
+  }
+
+  async findById(id: string): Promise<T | null | DatabaseError> {
+    try {
+      return (await this.model.findUnique({ where: { id } })) as T | null;
+    } catch (error: any) {
+      return { code: SERVER_ERROR_CODES.RETRIEVAL_FAILED, message: error.message };
+    }
+  }
+
+  async update(id: string, data: Partial<T>): Promise<T | DatabaseError> {
+    try {
+      return (await this.model.update({ where: { id }, data })) as T;
+    } catch (error: any) {
+      return { code: SERVER_ERROR_CODES.DATABASE_ERROR, message: error.message };
+    }
+  }
+
+  async delete(id: string): Promise<{ success: boolean; error?: DatabaseError }> {
+    try {
+      await this.model.delete({ where: { id } });
+      return { success: true };
+    } catch (error: any) {
+      return { success: false, error: { code: SERVER_ERROR_CODES.DELETE_FAILED, message: error.message } };
+    }
+  }
+
+  async query(options?: QueryOptions): Promise<QueryResult<T>> {
+    try {
+      const items = await this.model.findMany({ where: options?.filters as any });
+      return { items: items as T[], count: items.length };
+    } catch (error: any) {
+      throw new Error(error.message);
+    }
+  }
+
+  async transaction<R>(_fn: (tx: TransactionInterface) => Promise<R>): Promise<R> {
+    throw new Error('Transactions are not implemented for PrismaRepository');
+  }
+}
+
+export default PrismaRepository;

--- a/src/adapters/database/supabase/index.ts
+++ b/src/adapters/database/supabase/index.ts
@@ -1,0 +1,1 @@
+export { SupabaseRepository } from './supabase-repository';

--- a/src/adapters/database/supabase/supabase-repository.ts
+++ b/src/adapters/database/supabase/supabase-repository.ts
@@ -1,0 +1,108 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import type {
+  BaseDatabaseInterface,
+  ConnectionOptions,
+  QueryOptions,
+  QueryResult,
+  TransactionInterface,
+  DatabaseError
+} from '@/core/database/interfaces';
+import { SERVER_ERROR_CODES } from '@/lib/api/common/error-codes';
+
+/**
+ * Generic Supabase repository implementing the BaseDatabaseInterface.
+ *
+ * This class isolates all Supabase specific logic and can be
+ * swapped out for other database providers via the adapter system.
+ */
+export class SupabaseRepository<T> implements BaseDatabaseInterface<T> {
+  private client: SupabaseClient<any, 'public'>;
+  private table: string;
+
+  constructor(private url: string, private key: string, table: string) {
+    this.client = createClient(url, key);
+    this.table = table;
+  }
+
+  /** Supabase manages connections automatically */
+  async connect(_options?: ConnectionOptions): Promise<void> {}
+
+  /** No-op for Supabase */
+  async disconnect(): Promise<void> {}
+
+  async create(data: Omit<T, 'id'>): Promise<T | DatabaseError> {
+    const { data: result, error } = await this.client
+      .from(this.table)
+      .insert(data)
+      .select()
+      .single();
+
+    if (error) {
+      return { code: SERVER_ERROR_CODES.DATABASE_ERROR, message: error.message };
+    }
+
+    return result as T;
+  }
+
+  async findById(id: string): Promise<T | null | DatabaseError> {
+    const { data, error } = await this.client
+      .from(this.table)
+      .select()
+      .eq('id', id)
+      .single();
+
+    if (error) {
+      return { code: SERVER_ERROR_CODES.RETRIEVAL_FAILED, message: error.message };
+    }
+
+    return data as T;
+  }
+
+  async update(id: string, data: Partial<T>): Promise<T | DatabaseError> {
+    const { data: result, error } = await this.client
+      .from(this.table)
+      .update(data)
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) {
+      return { code: SERVER_ERROR_CODES.DATABASE_ERROR, message: error.message };
+    }
+
+    return result as T;
+  }
+
+  async delete(id: string): Promise<{ success: boolean; error?: DatabaseError }> {
+    const { error } = await this.client.from(this.table).delete().eq('id', id);
+    if (error) {
+      return { success: false, error: { code: SERVER_ERROR_CODES.DELETE_FAILED, message: error.message } };
+    }
+    return { success: true };
+  }
+
+  async query(options?: QueryOptions): Promise<QueryResult<T>> {
+    let query: any = this.client.from(this.table).select('*', { count: 'exact' });
+    if (options?.filters) {
+      for (const cond of options.filters) {
+        query = query.eq(cond.field, cond.value);
+      }
+    }
+    if (options?.sort) {
+      for (const s of options.sort) {
+        query = query.order(s.field, { ascending: s.direction === 'asc' });
+      }
+    }
+    const { data, error, count } = await query;
+    if (error) {
+      throw new Error(error.message);
+    }
+    return { items: data as T[], count: count ?? data.length };
+  }
+
+  async transaction<R>(_fn: (tx: TransactionInterface) => Promise<R>): Promise<R> {
+    throw new Error('Transactions are not supported by SupabaseRepository');
+  }
+}
+
+export default SupabaseRepository;


### PR DESCRIPTION
## Summary
- add new database adapter directory with supabase, prisma, and mock implementations
- provide `SupabaseRepository`, `PrismaRepository`, and `MockRepository`
- export providers through adapter index
- add basic tests for the mock repository

## Testing
- `npx vitest run --coverage src/adapters/database/__tests__/mock-repository.test.ts`
- `npm run lint`