### PR TITLE
Add database provider registry

### DIFF
--- a/src/adapters/README.md
+++ b/src/adapters/README.md
@@ -138,3 +138,25 @@ Each adapter should have corresponding tests in its `__tests__` directory. Tests
     - `supabaseKey`: Your Supabase anon/public key
 
 - **Custom**: Implement the `AdapterFactory` interface
+
+## Database Providers
+
+Database providers encapsulate the low-level database clients. Register provider
+factories with `AdapterRegistry.registerDatabaseFactory` and optionally set a
+default provider using `AdapterRegistry.setDefaultDatabaseProvider`.
+
+```typescript
+import { AdapterRegistry } from '@/adapters';
+import { createSupabaseDatabaseProvider } from '@/adapters/database/factory';
+
+AdapterRegistry.registerDatabaseFactory('supabase', createSupabaseDatabaseProvider);
+AdapterRegistry.setDefaultDatabaseProvider('supabase');
+
+const db = AdapterRegistry.getDefaultDatabaseProvider({
+  provider: 'supabase',
+  connectionString: 'https://project.supabase.co'
+});
+```
+
+Call `setActiveDatabaseProvider` on the registry instance to switch providers at
+runtime.

--- a/src/adapters/__tests__/database-provider-registry.test.ts
+++ b/src/adapters/__tests__/database-provider-registry.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AdapterRegistry } from '../registry';
+import type { DatabaseProvider, DatabaseConfig } from '@/lib/database/types';
+
+class DummyProvider implements DatabaseProvider {
+  async createUser() { return {} as any; }
+  async getUserById() { return null; }
+  async getUserByEmail() { return null; }
+  async updateUser() { return {} as any; }
+  async deleteUser() {}
+  async createProfile() { return {} as any; }
+  async getProfileByUserId() { return null; }
+  async updateProfile() { return {} as any; }
+  async deleteProfile() {}
+  async createUserPreferences() { return {} as any; }
+  async getUserPreferences() { return null; }
+  async updateUserPreferences() { return {} as any; }
+  async deleteUserPreferences() {}
+  async createActivityLog() { return {} as any; }
+  async getUserActivityLogs() { return []; }
+  async deleteUserActivityLogs() {}
+  async getUserWithRelations() { return null; }
+}
+
+type Factory = (c: DatabaseConfig) => DatabaseProvider;
+
+const factory: Factory = vi.fn(() => new DummyProvider());
+const factory2: Factory = vi.fn(() => new DummyProvider());
+
+beforeEach(() => {
+  (AdapterRegistry as any).databaseFactories = {};
+  (AdapterRegistry as any).defaultDatabaseProviderName = null;
+  (AdapterRegistry as any).instance = null;
+});
+
+describe('database provider registry', () => {
+  it('registers and retrieves provider by name', () => {
+    AdapterRegistry.registerDatabaseFactory('dummy', factory);
+    const provider = AdapterRegistry.getDatabaseProvider('dummy', { provider: 'supabase' } as any);
+    expect(provider).toBeInstanceOf(DummyProvider);
+    expect(factory).toHaveBeenCalled();
+  });
+
+  it('switches active provider', () => {
+    AdapterRegistry.registerDatabaseFactory('a', factory);
+    AdapterRegistry.registerDatabaseFactory('b', factory2);
+    const registry = AdapterRegistry.getInstance();
+    const first = registry.setActiveDatabaseProvider('a', { provider: 'supabase' } as any);
+    expect(registry.getActiveDatabaseProvider()).toBe(first);
+    const second = registry.setActiveDatabaseProvider('b', { provider: 'supabase' } as any);
+    expect(registry.getActiveDatabaseProvider()).toBe(second);
+  });
+
+  it('returns default provider', () => {
+    AdapterRegistry.registerDatabaseFactory('dummy', factory);
+    AdapterRegistry.setDefaultDatabaseProvider('dummy');
+    const provider = AdapterRegistry.getDefaultDatabaseProvider({ provider: 'supabase' } as any);
+    expect(provider).toBeInstanceOf(DummyProvider);
+  });
+
+  it('throws for unknown providers', () => {
+    expect(() => AdapterRegistry.getDatabaseProvider('missing', {} as any)).toThrow();
+    expect(() => AdapterRegistry.setDefaultDatabaseProvider('missing')).toThrow();
+  });
+});

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -26,9 +26,11 @@ export * from './database';
 // Import and register the Supabase adapter factory by default
 import { AdapterRegistry } from './registry';
 import { createSupabaseAdapterFactory } from './supabase-factory';
+import { createSupabaseDatabaseProvider } from './database/factory/supabase-factory';
 
 // Register the Supabase adapter factory
 AdapterRegistry.registerFactory('supabase', createSupabaseAdapterFactory);
+AdapterRegistry.registerDatabaseFactory('supabase', createSupabaseDatabaseProvider);
 
 // Re-export the registry instance for convenience
 export { AdapterRegistry as default } from "./registry";

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -19,6 +19,10 @@ import { SubscriptionDataProvider } from '@/core/subscription/ISubscriptionDataP
 import { ApiKeyDataProvider } from '@/core/api-keys/IApiKeyDataProvider';
 import { IWebhookDataProvider } from '@/core/webhooks/IWebhookDataProvider';
 import { IOrganizationDataProvider } from '@/core/organization/IOrganizationDataProvider';
+import type {
+  DatabaseProvider,
+  DatabaseConfig
+} from '@/lib/database/types';
 
 
 /**
@@ -96,6 +100,13 @@ export interface AdapterFactory {
 }
 
 /**
+ * Factory function for creating a {@link DatabaseProvider}.
+ */
+export type DatabaseProviderFactory = (
+  config: DatabaseConfig
+) => DatabaseProvider;
+
+/**
  * Factory creator function type
  */
 export type FactoryCreator = (options: AdapterFactoryOptions) => AdapterFactory;
@@ -106,9 +117,12 @@ export type FactoryCreator = (options: AdapterFactoryOptions) => AdapterFactory;
  */
 export class AdapterRegistry {
   private static factories: Record<string, FactoryCreator> = {};
+  private static databaseFactories: Record<string, DatabaseProviderFactory> = {};
+  private static defaultDatabaseProviderName: string | null = null;
   private static instance: AdapterRegistry | null = null;
 
   private adapters: Record<string, unknown> = {};
+  private activeDatabaseProvider: DatabaseProvider | null = null;
 
   private constructor() {}
 
@@ -192,5 +206,95 @@ export class AdapterRegistry {
    */
   static isAdapterAvailable(name: string): boolean {
     return !!this.factories[name];
+  }
+
+  /**
+   * Register a database provider factory.
+   *
+   * @param name    Unique provider name.
+   * @param factory Factory function that creates the provider.
+   */
+  static registerDatabaseFactory(
+    name: string,
+    factory: DatabaseProviderFactory
+  ): void {
+    if (this.databaseFactories[name]) {
+      throw new Error(`Database provider '${name}' is already registered`);
+    }
+    this.databaseFactories[name] = factory;
+  }
+
+  /**
+   * Retrieve a database provider instance by name.
+   *
+   * @param name   Provider identifier.
+   * @param config Configuration object passed to the factory.
+   * @returns A database provider instance.
+   */
+  static getDatabaseProvider(
+    name: string,
+    config: DatabaseConfig
+  ): DatabaseProvider {
+    const factory = this.databaseFactories[name];
+    if (!factory) {
+      throw new Error(
+        `Database provider '${name}' not registered. Available providers: ${Object.keys(
+          this.databaseFactories
+        ).join(', ')}`
+      );
+    }
+    return factory(config);
+  }
+
+  /**
+   * Set the default database provider for the application.
+   *
+   * @param name Provider name previously registered.
+   */
+  static setDefaultDatabaseProvider(name: string): void {
+    if (!this.databaseFactories[name]) {
+      throw new Error(`Database provider '${name}' is not registered`);
+    }
+    this.defaultDatabaseProviderName = name;
+  }
+
+  /**
+   * Get an instance of the default database provider.
+   *
+   * @param config Configuration passed to the provider factory.
+   */
+  static getDefaultDatabaseProvider(config: DatabaseConfig): DatabaseProvider {
+    if (!this.defaultDatabaseProviderName) {
+      throw new Error('Default database provider not set');
+    }
+    return this.getDatabaseProvider(this.defaultDatabaseProviderName, config);
+  }
+
+  /**
+   * Set the currently active database provider for this registry instance.
+   *
+   * @param name   Provider name.
+   * @param config Configuration passed to the factory.
+   * @returns The created provider instance.
+   */
+  setActiveDatabaseProvider(
+    name: string,
+    config: DatabaseConfig
+  ): DatabaseProvider {
+    const provider = AdapterRegistry.getDatabaseProvider(name, config);
+    this.activeDatabaseProvider = provider;
+    return provider;
+  }
+
+  /**
+   * Retrieve the active database provider.
+   *
+   * @returns The active provider instance.
+   */
+  getActiveDatabaseProvider(): DatabaseProvider {
+    if (!this.activeDatabaseProvider) {
+      throw new Error('Active database provider not set');
+    }
+    return this.activeDatabaseProvider;
   }
 }


### PR DESCRIPTION
## Summary
- extend AdapterRegistry to manage database provider factories
- register supabase database provider by default
- document database provider usage
- test database provider registration and switching

## Testing
- `npm run test:coverage` *(fails: JavaScript heap out of memory)*