### PR TITLE
refactor: admin service provider

### DIFF
--- a/src/adapters/admin/factory.ts
+++ b/src/adapters/admin/factory.ts
@@ -1,0 +1,26 @@
+import type { IAdminDataProvider } from '@/core/admin';
+import { SupabaseAdminProvider } from './supabase-admin.provider';
+
+export function createSupabaseAdminProvider(
+  supabaseUrl: string,
+  supabaseKey: string
+): IAdminDataProvider {
+  return new SupabaseAdminProvider(supabaseUrl, supabaseKey);
+}
+
+export function createAdminProvider(config: {
+  type: 'supabase' | string;
+  options: Record<string, any>;
+}): IAdminDataProvider {
+  switch (config.type) {
+    case 'supabase':
+      return createSupabaseAdminProvider(
+        config.options.supabaseUrl,
+        config.options.supabaseKey
+      );
+    default:
+      throw new Error(`Unsupported admin provider type: ${config.type}`);
+  }
+}
+
+export default createSupabaseAdminProvider;

--- a/src/adapters/admin/index.ts
+++ b/src/adapters/admin/index.ts
@@ -1,0 +1,3 @@
+export * from '@/core/admin/IAdminDataProvider';
+export * from './factory';
+export * from './supabase-admin.provider';

--- a/src/adapters/admin/supabase-admin.provider.ts
+++ b/src/adapters/admin/supabase-admin.provider.ts
@@ -1,0 +1,104 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import type { IAdminDataProvider } from '@/core/admin/IAdminDataProvider';
+import type { ListUsersParams, SearchUsersParams } from '@/core/admin/interfaces';
+import type { PaginationMeta } from '@/lib/api/common/response-formatter';
+import type { UserProfile } from '@/core/user/models';
+
+export class SupabaseAdminProvider implements IAdminDataProvider {
+  private supabase: SupabaseClient;
+
+  constructor(supabaseUrl: string, supabaseKey: string) {
+    this.supabase = createClient(supabaseUrl, supabaseKey);
+  }
+
+  async listUsers(_params: ListUsersParams): Promise<{ users: UserProfile[]; pagination: PaginationMeta }> {
+    throw new Error('Not implemented');
+  }
+
+  async getUserById(_id: string): Promise<UserProfile | null> {
+    throw new Error('Not implemented');
+  }
+
+  async updateUser(_id: string, _data: Partial<UserProfile>): Promise<UserProfile> {
+    throw new Error('Not implemented');
+  }
+
+  async deleteUser(_id: string): Promise<void> {
+    throw new Error('Not implemented');
+  }
+
+  async getAuditLogs(_query: any): Promise<{ logs: any[]; pagination: PaginationMeta }> {
+    throw new Error('Not implemented');
+  }
+
+  async searchUsers(params: SearchUsersParams): Promise<{ users: UserProfile[]; pagination: PaginationMeta }> {
+    const {
+      query,
+      page = 1,
+      limit = 10,
+      status,
+      role,
+      dateCreatedStart,
+      dateCreatedEnd,
+      dateLastLoginStart,
+      dateLastLoginEnd,
+      sortBy = 'createdAt',
+      sortOrder = 'desc',
+      teamId,
+    } = params;
+
+    const offset = (page - 1) * limit;
+
+    let baseQuery = this.supabase
+      .from('profiles')
+      .select('id, first_name, last_name, email, user_type, created_at, last_login_at, status, role', { count: 'exact' });
+
+    if (query && query.trim() !== '') {
+      baseQuery = baseQuery.or(
+        `first_name.ilike.%${query}%,last_name.ilike.%${query}%,email.ilike.%${query}%`
+      );
+    }
+    if (status && status !== 'all') {
+      baseQuery = baseQuery.eq('status', status);
+    }
+    if (role) {
+      baseQuery = baseQuery.eq('role', role);
+    }
+    if (dateCreatedStart) {
+      baseQuery = baseQuery.gte('created_at', dateCreatedStart);
+    }
+    if (dateCreatedEnd) {
+      baseQuery = baseQuery.lte('created_at', dateCreatedEnd);
+    }
+    if (dateLastLoginStart) {
+      baseQuery = baseQuery.gte('last_login_at', dateLastLoginStart);
+    }
+    if (dateLastLoginEnd) {
+      baseQuery = baseQuery.lte('last_login_at', dateLastLoginEnd);
+    }
+    if (teamId) {
+      baseQuery = baseQuery.eq('team_id', teamId);
+    }
+
+    baseQuery = baseQuery.order(sortBy === 'name' ? 'first_name' : sortBy, {
+      ascending: sortOrder === 'asc',
+    });
+
+    baseQuery = baseQuery.range(offset, offset + limit - 1);
+
+    const { data: users, error, count } = await baseQuery;
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    const pagination = {
+      page,
+      limit,
+      totalCount: count || 0,
+      totalPages: Math.ceil((count || 0) / limit),
+    };
+
+    return { users: (users as any[]) || [], pagination };
+  }
+}

--- a/src/adapters/admin/supabase/factory.ts
+++ b/src/adapters/admin/supabase/factory.ts
@@ -1,0 +1,12 @@
+import { SupabaseAdminProvider } from '../supabase-admin.provider';
+import type { IAdminDataProvider } from '@/core/admin';
+
+export function createSupabaseAdminProvider(options: {
+  supabaseUrl: string;
+  supabaseKey: string;
+  [key: string]: any;
+}): IAdminDataProvider {
+  return new SupabaseAdminProvider(options.supabaseUrl, options.supabaseKey);
+}
+
+export default createSupabaseAdminProvider;

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -18,6 +18,7 @@ export * from './consent';
 export * from './session';
 export * from './subscription';
 export * from './organization';
+export * from './admin';
 export * from './csrf';
 export * from './webhooks';
 export * from './database';

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -19,6 +19,7 @@ import { SubscriptionDataProvider } from '@/core/subscription/ISubscriptionDataP
 import { ApiKeyDataProvider } from '@/core/api-keys/IApiKeyDataProvider';
 import { IWebhookDataProvider } from '@/core/webhooks/IWebhookDataProvider';
 import { IOrganizationDataProvider } from '@/core/organization/IOrganizationDataProvider';
+import { IAdminDataProvider } from '@/core/admin/IAdminDataProvider';
 
 
 /**
@@ -47,6 +48,11 @@ export interface AdapterFactory {
    * Create a team data provider
    */
   createTeamProvider(): TeamDataProvider;
+
+  /**
+   * Create an admin data provider
+   */
+  createAdminProvider?(): IAdminDataProvider;
 
   /**
    * Create an organization data provider

--- a/src/adapters/supabase-factory.ts
+++ b/src/adapters/supabase-factory.ts
@@ -19,6 +19,7 @@ import { SubscriptionDataProvider } from './subscription/interfaces';
 import { ApiKeyDataProvider } from './api-keys/interfaces';
 import { IWebhookDataProvider } from '@/core/webhooks/IWebhookDataProvider';
 import { IOrganizationDataProvider } from '@/core/organization/IOrganizationDataProvider';
+import { IAdminDataProvider } from '@/core/admin/IAdminDataProvider';
 
 
 // Import domain-specific factories
@@ -34,6 +35,7 @@ import createSupabaseSsoProvider from './sso/supabase/factory';
 import createSupabaseSubscriptionProvider from './subscription/factory';
 import createSupabaseApiKeyProvider from './api-keys/supabase/factory';
 import { createSupabaseWebhookProvider } from './webhooks';
+import createSupabaseAdminProvider from './admin/supabase/factory';
 
 
 /**
@@ -77,6 +79,13 @@ export class SupabaseAdapterFactory implements AdapterFactory {
    */
   createUserProvider(): UserDataProvider {
     return createSupabaseUserProvider(this.options);
+  }
+
+  /**
+   * Create a Supabase admin provider
+   */
+  createAdminProvider(): IAdminDataProvider {
+    return createSupabaseAdminProvider(this.options);
   }
 
   /**

--- a/src/core/admin/IAdminDataProvider.ts
+++ b/src/core/admin/IAdminDataProvider.ts
@@ -9,7 +9,7 @@
 import type { UserProfile } from '../user/models';
 import type { AuditLogEntry, AuditLogQuery } from '../audit/models';
 import type { PaginationMeta } from '@/lib/api/common/response-formatter';
-import type { ListUsersParams } from './interfaces';
+import type { ListUsersParams, SearchUsersParams } from './interfaces';
 
 export interface IAdminDataProvider {
   /**
@@ -45,6 +45,13 @@ export interface IAdminDataProvider {
    * @param id Unique identifier of the user
    */
   deleteUser(id: string): Promise<void>;
+
+  /**
+   * Search users with advanced filtering and pagination.
+   */
+  searchUsers(
+    params: SearchUsersParams
+  ): Promise<{ users: UserProfile[]; pagination: PaginationMeta }>;
 
   /**
    * Retrieve audit logs based on query parameters.

--- a/src/core/initialization/initialize-adapters.ts
+++ b/src/core/initialization/initialize-adapters.ts
@@ -24,6 +24,7 @@ import { DefaultNotificationService } from '@/services/notification/default-noti
 import { DefaultAuditService } from '@/services/audit/default-audit.service';
 import { DefaultCsrfService } from '@/services/csrf/default-csrf.service';
 import { DefaultNotificationHandler } from '@/services/notification/default-notification.handler';
+import { DefaultAdminService } from '@/services/admin/default-admin.service';
 import {
   createAddressProvider
 } from '@/adapters/address/factory';
@@ -101,6 +102,7 @@ export function initializeAdapters(
     const subscriptionAdapter = factory.createSubscriptionProvider();
     const apiKeyAdapter = factory.createApiKeyProvider();
     const webhookAdapter = factory.createWebhookProvider?.();
+    const adminAdapter = factory.createAdminProvider?.();
 
     const addressAdapter = createAddressProvider(config);
     const auditAdapter = createAuditProvider(config);
@@ -111,6 +113,7 @@ export function initializeAdapters(
     registry.registerAdapter('auth', authAdapter);
     registry.registerAdapter('user', userAdapter);
     registry.registerAdapter('team', teamAdapter);
+    if (adminAdapter) registry.registerAdapter('admin', adminAdapter);
     if (organizationAdapter) registry.registerAdapter('organization', organizationAdapter);
     registry.registerAdapter('permission', permissionAdapter);
     if (gdprAdapter) registry.registerAdapter('gdpr', gdprAdapter);
@@ -143,6 +146,7 @@ export function initializeAdapters(
     const csrfService = new DefaultCsrfService(csrfAdapter);
     const notificationService = new DefaultNotificationService(notificationAdapter, new DefaultNotificationHandler());
     const ssoService = new DefaultSsoService(ssoAdapter);
+    const adminService = adminAdapter ? new DefaultAdminService(adminAdapter) : undefined;
     
     return {
       authService,
@@ -161,6 +165,7 @@ export function initializeAdapters(
       csrfService,
       notificationService,
       ssoService,
+      adminService,
       adapters: {
         authAdapter,
         userAdapter,
@@ -177,7 +182,8 @@ export function initializeAdapters(
         auditAdapter,
         csrfAdapter,
         notificationAdapter,
-        ssoAdapter
+        ssoAdapter,
+        adminAdapter
       }
       };
   } catch (error) {
@@ -214,6 +220,7 @@ export function initializeUserManagement(config = {}, options = {}) {
       csrfService: services.csrfService,
       notificationService: services.notificationService,
       ssoService: services.ssoService,
+      adminService: services.adminService,
       ...options.serviceProviders
     },
     options: {

--- a/src/services/admin/__tests__/default-admin.service.test.ts
+++ b/src/services/admin/__tests__/default-admin.service.test.ts
@@ -1,19 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DefaultAdminService } from '../default-admin.service';
-
-vi.mock('@/lib/database/supabase', () => ({ getServiceSupabase: () => ({}) }));
+import type { IAdminDataProvider } from '@/core/admin';
 
 describe('DefaultAdminService.exportUsers', () => {
   let service: DefaultAdminService;
+  let provider: IAdminDataProvider;
   beforeEach(() => {
-    service = new DefaultAdminService();
+    provider = {
+      listUsers: vi.fn(),
+      getUserById: vi.fn(),
+      updateUser: vi.fn(),
+      deleteUser: vi.fn(),
+      getAuditLogs: vi.fn(),
+      searchUsers: vi.fn()
+    };
+    service = new DefaultAdminService(provider);
   });
 
   it('exports csv', async () => {
     const users = [
       { id: '1', firstName: 'A', lastName: 'B', email: 'a@b.com', status: 'active', role: 'user', createdAt: '2020-01-01T00:00:00Z', lastLoginAt: null },
     ];
-    service.searchUsers = vi.fn().mockResolvedValue({ users, pagination: { page: 1, limit: 1, totalCount: 1, totalPages: 1 } }) as any;
+    provider.searchUsers = vi.fn().mockResolvedValue({ users, pagination: { page: 1, limit: 1, totalCount: 1, totalPages: 1 } });
     const result = await service.exportUsers({}, 'csv');
     expect(result.filename).toMatch(/\.csv$/);
     expect(result.data).toContain('ID');
@@ -23,7 +31,7 @@ describe('DefaultAdminService.exportUsers', () => {
     const users = [
       { id: '1', firstName: 'A', lastName: 'B', email: 'a@b.com', status: 'active', role: 'user', createdAt: '2020-01-01T00:00:00Z', lastLoginAt: null },
     ];
-    service.searchUsers = vi.fn().mockResolvedValue({ users, pagination: { page: 1, limit: 1, totalCount: 1, totalPages: 1 } }) as any;
+    provider.searchUsers = vi.fn().mockResolvedValue({ users, pagination: { page: 1, limit: 1, totalCount: 1, totalPages: 1 } });
     const result = await service.exportUsers({}, 'json');
     expect(result.filename).toMatch(/\.json$/);
     expect(result.data).toContain('"id": "1"');

--- a/src/services/admin/default-admin.service.ts
+++ b/src/services/admin/default-admin.service.ts
@@ -1,7 +1,6 @@
-import { SupabaseClient } from '@supabase/supabase-js';
 import { AdminService } from '@/core/admin/interfaces';
-import type { SearchQuery } from '@/app/api/admin/users/search/route';
-import { getServiceSupabase } from '@/lib/database/supabase';
+import type { SearchUsersParams } from '@/core/admin/interfaces';
+import type { IAdminDataProvider } from '@/core/admin/IAdminDataProvider';
 import { objectsToCSV } from '@/utils/export/csvExport';
 import { formatJSONForExport } from '@/utils/export/jsonExport';
 import { SearchCache } from '@/utils/cache/searchCache';
@@ -17,11 +16,9 @@ interface SearchResult {
 }
 
 export class DefaultAdminService implements AdminService {
-  private supabase: SupabaseClient;
   private searchCache: SearchCache<SearchResult>;
 
-  constructor() {
-    this.supabase = getServiceSupabase();
+  constructor(private provider: IAdminDataProvider) {
     this.searchCache = new SearchCache<SearchResult>(60000);
   }
 
@@ -46,95 +43,20 @@ export class DefaultAdminService implements AdminService {
     throw new Error('Not implemented');
   }
 
-  async searchUsers(params: SearchQuery): Promise<SearchResult> {
+  async searchUsers(params: SearchUsersParams): Promise<SearchResult> {
     const cacheKey = this.searchCache.generateKey(params);
     const cached = this.searchCache.get(cacheKey);
     if (cached) {
-      console.log('Using cached search result');
       return cached;
     }
 
-    const {
-      query,
-      page,
-      limit,
-      status,
-      role,
-      dateCreatedStart,
-      dateCreatedEnd,
-      dateLastLoginStart,
-      dateLastLoginEnd,
-      sortBy,
-      sortOrder,
-      teamId,
-    } = params;
+    const result = await this.provider.searchUsers(params);
 
-    const offset = (page - 1) * limit;
-
-    let baseQuery = this.supabase
-      .from('profiles')
-      .select(
-        'id, first_name, last_name, email, user_type, created_at, last_login_at, status, role',
-        { count: 'exact' }
-      );
-
-    if (query && query.trim() !== '') {
-      baseQuery = baseQuery.or(
-        `first_name.ilike.%${query}%,last_name.ilike.%${query}%,email.ilike.%${query}%`
-      );
-    }
-    if (status && status !== 'all') {
-      baseQuery = baseQuery.eq('status', status);
-    }
-    if (role) {
-      baseQuery = baseQuery.eq('role', role);
-    }
-    if (dateCreatedStart) {
-      baseQuery = baseQuery.gte('created_at', dateCreatedStart);
-    }
-    if (dateCreatedEnd) {
-      baseQuery = baseQuery.lte('created_at', dateCreatedEnd);
-    }
-    if (dateLastLoginStart) {
-      baseQuery = baseQuery.gte('last_login_at', dateLastLoginStart);
-    }
-    if (dateLastLoginEnd) {
-      baseQuery = baseQuery.lte('last_login_at', dateLastLoginEnd);
-    }
-    if (teamId) {
-      baseQuery = baseQuery.eq('team_id', teamId);
-    }
-
-    baseQuery = baseQuery.order(sortBy === 'name' ? 'first_name' : sortBy, {
-      ascending: sortOrder === 'asc',
-    });
-
-    baseQuery = baseQuery.range(offset, offset + limit - 1);
-
-    const { data: users, error, count } = await baseQuery;
-
-    if (error) {
-      console.error('Error searching users:', error);
-      throw new Error(`Failed to search users: ${error.message}`);
-    }
-
-    const totalPages = Math.ceil((count || 0) / limit);
-
-    const result = {
-      users: users || [],
-      pagination: {
-        page,
-        limit,
-        totalCount: count || 0,
-        totalPages,
-      },
-    };
-
-    this.searchCache.set(cacheKey, result);
-    return result;
+    this.searchCache.set(cacheKey, result as SearchResult);
+    return result as SearchResult;
   }
 
-  async exportUsers(params: SearchQuery, format: 'csv' | 'json'): Promise<{ data: string; filename: string }> {
+  async exportUsers(params: SearchUsersParams, format: 'csv' | 'json'): Promise<{ data: string; filename: string }> {
     const { users } = await this.searchUsers({ ...params, page: 1, limit: 10000 });
     const timestamp = new Date().toISOString().split('T')[0];
     if (format === 'csv') {

--- a/src/services/admin/factory.ts
+++ b/src/services/admin/factory.ts
@@ -6,9 +6,9 @@
  */
 
 import { AdminService } from '@/core/admin/interfaces';
-import { UserManagementConfiguration } from '@/core/config';
 import type { IAdminDataProvider } from '@/core/admin';
 import { AdapterRegistry } from '@/adapters/registry';
+import { DefaultAdminService } from './default-admin.service';
 
 // Singleton instance for API routes
 let adminServiceInstance: AdminService | null = null;
@@ -20,16 +20,8 @@ let adminServiceInstance: AdminService | null = null;
  */
 export function getApiAdminService(): AdminService {
   if (!adminServiceInstance) {
-    // Get the admin adapter from the registry
-    AdapterRegistry.getInstance().getAdapter<IAdminDataProvider>('admin');
-
-    // Retrieve the service implementation
-    adminServiceInstance = UserManagementConfiguration.getServiceProvider('adminService') as AdminService;
-
-    // If no admin service is registered, throw an error
-    if (!adminServiceInstance) {
-      throw new Error('Admin service not registered in UserManagementConfiguration');
-    }
+    const provider = AdapterRegistry.getInstance().getAdapter<IAdminDataProvider>('admin');
+    adminServiceInstance = new DefaultAdminService(provider);
   }
 
   return adminServiceInstance;

--- a/src/services/admin/index.ts
+++ b/src/services/admin/index.ts
@@ -1,10 +1,13 @@
 import { AdminService } from '@/core/admin/interfaces';
 import { DefaultAdminService } from './default-admin.service';
+import type { IAdminDataProvider } from '@/core/admin/IAdminDataProvider';
 
-export interface AdminServiceConfig {}
+export interface AdminServiceConfig {
+  adminDataProvider: IAdminDataProvider;
+}
 
-export function createAdminService(_: AdminServiceConfig = {}): AdminService {
-  return new DefaultAdminService();
+export function createAdminService(config: AdminServiceConfig): AdminService {
+  return new DefaultAdminService(config.adminDataProvider);
 }
 
 export default { createAdminService };


### PR DESCRIPTION
## Summary
- inject admin data provider into `DefaultAdminService`
- create Supabase admin provider and factory
- register admin provider and service in initialization
- update adapter registry and factory interfaces
- revise admin service factory and tests
- export new admin adapter

## Testing
- `pnpm test:coverage` *(fails: The current testing environment is not configured to support act(...); JS heap out of memory)*