### PR TITLE
Refactor route authentication middleware

### DIFF
--- a/app/api/addresses/[id]/__tests__/route.test.ts
+++ b/app/api/addresses/[id]/__tests__/route.test.ts
@@ -10,7 +10,7 @@ vi.mock('@/services/address/factory', () => ({
 }));
 vi.mock('@/middleware/with-security', () => ({ withSecurity: (h: any) => h }));
 vi.mock('@/middleware/auth', () => ({
-  withRouteAuth: vi.fn((handler: any, req: any) => handler(req, 'u1')),
+  withRouteAuth: vi.fn((handler: any, req: any) => handler(req, { userId: 'u1', role: 'user', permissions: [] })),
 }));
 
 describe('[id] address API', () => {

--- a/app/api/addresses/[id]/route.ts
+++ b/app/api/addresses/[id]/route.ts
@@ -35,16 +35,16 @@ async function handleDelete(_req: NextRequest, id: string, userId: string): Prom
 
 // Use both rate limiting and security middleware with proper auth
 export const GET = (req: NextRequest, { params }: { params: { id: string } }) =>
-  withRateLimit(req, r => withSecurity(q => 
-    withRouteAuth((s, uid) => handleGet(s, params.id, uid), q)
+  withRateLimit(req, r => withSecurity(q =>
+    withRouteAuth((s, ctx) => handleGet(s, params.id, ctx.userId!), q)
   )(r));
 
 export const PUT = (req: NextRequest, { params }: { params: { id: string } }) =>
-  withRateLimit(req, r => withSecurity(q => 
-    withRouteAuth((s, uid) => handlePut(s, params.id, uid), q)
+  withRateLimit(req, r => withSecurity(q =>
+    withRouteAuth((s, ctx) => handlePut(s, params.id, ctx.userId!), q)
   )(r));
 
 export const DELETE = (req: NextRequest, { params }: { params: { id: string } }) =>
-  withRateLimit(req, r => withSecurity(q => 
-    withRouteAuth((s, uid) => handleDelete(s, params.id, uid), q)
+  withRateLimit(req, r => withSecurity(q =>
+    withRouteAuth((s, ctx) => handleDelete(s, params.id, ctx.userId!), q)
   )(r));

--- a/app/api/addresses/__tests__/route.test.ts
+++ b/app/api/addresses/__tests__/route.test.ts
@@ -10,7 +10,7 @@ vi.mock('@/services/address/factory', () => ({
 }));
 vi.mock('@/middleware/with-security', () => ({ withSecurity: (h: any) => h }));
 vi.mock('@/middleware/auth', () => ({
-  withRouteAuth: vi.fn((handler: any, req: any) => handler(req, 'u1')),
+  withRouteAuth: vi.fn((handler: any, req: any) => handler(req, { userId: 'u1', role: 'user', permissions: [] })),
 }));
 
 describe('addresses API', () => {

--- a/app/api/addresses/default/[id]/__tests__/route.test.ts
+++ b/app/api/addresses/default/[id]/__tests__/route.test.ts
@@ -10,7 +10,7 @@ vi.mock('@/services/address/factory', () => ({
 }));
 vi.mock('@/middleware/with-security', () => ({ withSecurity: (h: any) => h }));
 vi.mock('@/middleware/auth', () => ({
-  withRouteAuth: vi.fn((handler: any, req: any) => handler(req, 'u1')),
+  withRouteAuth: vi.fn((handler: any, req: any) => handler(req, { userId: 'u1', role: 'user', permissions: [] })),
 }));
 
 describe('default address API', () => {

--- a/app/api/addresses/default/[id]/route.ts
+++ b/app/api/addresses/default/[id]/route.ts
@@ -10,5 +10,5 @@ async function handlePost(_req: NextRequest, params: { id: string }, userId: str
 }
 
 export const POST = withSecurity((req: NextRequest, ctx: { params: { id: string } }) =>
-  withRouteAuth((r, uid) => handlePost(r, ctx.params, uid), req)
+  withRouteAuth((r, auth) => handlePost(r, ctx.params, auth.userId!), req)
 );

--- a/app/api/permissions/check/route.ts
+++ b/app/api/permissions/check/route.ts
@@ -46,10 +46,10 @@ async function handlePermissionCheck(
 export async function GET(request: NextRequest) {
   return withErrorHandling(
     (req) =>
-      withRouteAuth((r, userId) => {
+      withRouteAuth((r, ctx) => {
         const url = new URL(r.url);
         const params = Object.fromEntries(url.searchParams.entries());
-        return withValidation(querySchema, (r2, data) => handlePermissionCheck(r2, userId, data), r, params);
+        return withValidation(querySchema, (r2, data) => handlePermissionCheck(r2, ctx.userId!, data), r, params);
       }, req),
     request
   );

--- a/app/api/profile/avatar/route.ts
+++ b/app/api/profile/avatar/route.ts
@@ -120,14 +120,14 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   return withErrorHandling(
     (req) =>
-      withRouteAuth((r, userId) => withValidation(AvatarUploadSchema, (r2, data) => handleUploadAvatar(r2, userId, data), r), req),
+      withRouteAuth((r, auth) => withValidation(AvatarUploadSchema, (r2, data) => handleUploadAvatar(r2, auth.userId!, data), r), req),
     request
   );
 }
 
 export async function DELETE(request: NextRequest) {
   return withErrorHandling(
-    (req) => withRouteAuth((r, userId) => handleDeleteAvatar(userId), req),
+    (req) => withRouteAuth((r, auth) => handleDeleteAvatar(auth.userId!), req),
     request
   );
 }

--- a/app/api/user/avatar/__tests__/route.test.ts
+++ b/app/api/user/avatar/__tests__/route.test.ts
@@ -7,7 +7,7 @@ import createMockUserService from '@/tests/mocks/user.service.mock';
 
 vi.mock('@/services/user/factory', () => ({ getApiUserService: vi.fn() }));
 vi.mock('@/middleware/auth', () => ({
-  withAuthRequest: vi.fn((req: any, handler: any) => handler(req, { userId: 'user-1', role: 'user' })),
+  withAuthRequest: vi.fn((req: any, handler: any) => handler(req, { userId: 'user-1', role: 'user', permissions: [] })),
 }));
 
 const service = createMockUserService();

--- a/app/api/user/profile/__tests__/route.test.ts
+++ b/app/api/user/profile/__tests__/route.test.ts
@@ -7,7 +7,7 @@ import createMockUserService from '@/tests/mocks/user.service.mock';
 
 vi.mock('@/services/user/factory', () => ({ getApiUserService: vi.fn() }));
 vi.mock('@/middleware/auth', () => ({
-  withAuthRequest: vi.fn((req: any, handler: any) => handler(req, { userId: 'user-1', role: 'user' })),
+  withAuthRequest: vi.fn((req: any, handler: any) => handler(req, { userId: 'user-1', role: 'user', permissions: [] })),
 }));
 
 const service = createMockUserService();

--- a/app/api/user/settings/__tests__/route.test.ts
+++ b/app/api/user/settings/__tests__/route.test.ts
@@ -7,7 +7,7 @@ import createMockUserService from '@/tests/mocks/user.service.mock';
 
 vi.mock('@/services/user/factory', () => ({ getApiUserService: vi.fn() }));
 vi.mock('@/middleware/auth', () => ({
-  withAuthRequest: vi.fn((req: any, handler: any) => handler(req, { userId: 'user-1', role: 'user' })),
+  withAuthRequest: vi.fn((req: any, handler: any) => handler(req, { userId: 'user-1', role: 'user', permissions: [] })),
 }));
 
 const service = createMockUserService();

--- a/src/middleware/__tests__/route-auth.test.ts
+++ b/src/middleware/__tests__/route-auth.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+import { withRouteAuth } from '../auth';
+import { getSessionFromToken } from '@/services/auth/factory';
+import { getApiPermissionService } from '@/services/permission/factory';
+import { Permission } from '@/lib/rbac/roles';
+
+vi.mock('@/services/auth/factory');
+vi.mock('@/services/permission/factory');
+
+const mockPermissionService = {
+  getUserRoles: vi.fn(),
+  getRoleById: vi.fn(),
+  hasPermission: vi.fn(),
+};
+
+vi.mocked(getApiPermissionService).mockReturnValue(mockPermissionService as any);
+
+const mockUser = { id: 'user-1', role: 'user' } as any;
+
+describe('withRouteAuth', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getApiPermissionService).mockReturnValue(mockPermissionService as any);
+  });
+
+  it('returns 401 when token missing', async () => {
+    vi.mocked(getSessionFromToken).mockResolvedValue(null);
+    const req = new NextRequest('http://test');
+    const res = await withRouteAuth(() => Promise.resolve(new NextResponse('ok')), req);
+    expect(res.status).toBe(401);
+  });
+
+  it('passes context on success', async () => {
+    vi.mocked(getSessionFromToken).mockResolvedValue(mockUser);
+    mockPermissionService.getUserRoles.mockResolvedValue([]);
+    mockPermissionService.getRoleById.mockResolvedValue({ permissions: [] });
+    const handler = vi.fn().mockResolvedValue(new NextResponse('ok'));
+    const req = new NextRequest('http://test', { headers: { authorization: 'Bearer t' } });
+    const res = await withRouteAuth(handler, req);
+    expect(handler).toHaveBeenCalledWith(req, expect.objectContaining({ userId: 'user-1' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('checks required permission', async () => {
+    vi.mocked(getSessionFromToken).mockResolvedValue(mockUser);
+    mockPermissionService.getUserRoles.mockResolvedValue([]);
+    mockPermissionService.getRoleById.mockResolvedValue({ permissions: [] });
+    mockPermissionService.hasPermission.mockResolvedValue(false);
+    const req = new NextRequest('http://test', { headers: { authorization: 'Bearer t' } });
+    const res = await withRouteAuth(() => Promise.resolve(new NextResponse('ok')), req, { requiredPermissions: [Permission.VIEW_PROJECTS] });
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/tests/mocks/auth.mock.ts
+++ b/src/tests/mocks/auth.mock.ts
@@ -2,7 +2,7 @@ import { vi } from 'vitest';
 
 export function createAuthMock(userId = 'user-1', role = 'user') {
   return {
-    withAuthRequest: vi.fn((req: any, handler: any) => handler(req, { userId, role })),
+    withAuthRequest: vi.fn((req: any, handler: any) => handler(req, { userId, role, permissions: [] })),
   };
 }
 


### PR DESCRIPTION
## Summary
- implement unified withRouteAuth supporting roles and permissions
- adapt withAuthRequest to reuse new middleware
- update permissions middleware and API route handlers
- update tests and add new tests for the new middleware

## Testing
- `vitest run --coverage` *(fails: JavaScript heap out of memory)*