### PR TITLE
Create withProtectedRoute middleware

### DIFF
--- a/docs/middleware/README.md
+++ b/docs/middleware/README.md
@@ -21,5 +21,6 @@ Each middleware lives in `src/middleware` and can be imported individually or vi
 | `validation.ts` | Validates request bodies using Zod schemas. | `zod`, `ApiError` utilities. |
 | `with-auth-rate-limit.ts` | Convenience wrapper applying strict rate limits to auth endpoints. | `createRateLimit` from `rate-limit.ts`. |
 | `with-security.ts` | Middleware for App Router route handlers adding security headers and CSRF protection. | None |
+| `protected-route.ts` | Combines rate limiting, authentication and optional permission checks. | `checkRateLimit`, `withRouteAuth` |
 
 Importing from `registry.ts` ensures a consistent entry point and avoids duplicate imports.

--- a/src/middleware/__tests__/protected-route.test.ts
+++ b/src/middleware/__tests__/protected-route.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+import { withProtectedRoute } from '../protected-route';
+import { checkRateLimit } from '../rate-limit';
+import { withRouteAuth } from '../auth';
+
+vi.mock('../rate-limit');
+vi.mock('../auth');
+
+const mockReq = new NextRequest('http://test');
+
+describe('withProtectedRoute', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns 429 when rate limited', async () => {
+    vi.mocked(checkRateLimit).mockResolvedValue(true);
+    const handler = vi.fn();
+    const res = await withProtectedRoute(handler)(mockReq);
+    expect(res.status).toBe(429);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('skips rate limiting when option set', async () => {
+    vi.mocked(checkRateLimit).mockResolvedValue(true);
+    const handler = vi.fn().mockResolvedValue(new NextResponse('ok'));
+    const authCtx = { userId: '1', role: 'user', permissions: [] } as any;
+    vi.mocked(withRouteAuth).mockImplementation(async (h, req) => h(req, authCtx));
+    const res = await withProtectedRoute(handler, { skipRateLimit: true })(mockReq);
+    expect(checkRateLimit).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(handler).toHaveBeenCalledWith(mockReq, authCtx, undefined);
+  });
+
+  it('calls handler with auth context', async () => {
+    vi.mocked(checkRateLimit).mockResolvedValue(false);
+    const authCtx = { userId: '1', role: 'user', permissions: [] } as any;
+    vi.mocked(withRouteAuth).mockImplementation(async (h, req) => h(req, authCtx));
+    const handler = vi.fn().mockResolvedValue(new NextResponse('ok'));
+    const res = await withProtectedRoute(handler)(mockReq);
+    expect(withRouteAuth).toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledWith(mockReq, authCtx, undefined);
+    expect(res.status).toBe(200);
+  });
+
+  it('passes permission option to withRouteAuth', async () => {
+    vi.mocked(checkRateLimit).mockResolvedValue(false);
+    vi.mocked(withRouteAuth).mockResolvedValue(new NextResponse('forbidden', { status: 403 }));
+    const res = await withProtectedRoute(() => Promise.resolve(new NextResponse('ok')), { requiredPermission: 'edit' })(mockReq);
+    expect(withRouteAuth).toHaveBeenCalledWith(expect.any(Function), mockReq, { requiredPermissions: ['edit'] });
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/middleware/protected-route.ts
+++ b/src/middleware/protected-route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withRouteAuth, type RouteAuthContext } from './auth';
+import { checkRateLimit } from './rate-limit';
+import { ApiError, ERROR_CODES } from '@/lib/api/common';
+import { createErrorResponse } from '@/lib/api/common/response-formatter';
+
+export interface ProtectedRouteOptions {
+  skipRateLimit?: boolean;
+  requiredPermission?: string;
+}
+
+export type ProtectedRouteHandler = (
+  req: NextRequest,
+  auth: RouteAuthContext,
+  ctx?: any
+) => Promise<NextResponse>;
+
+export function withProtectedRoute(
+  handler: ProtectedRouteHandler,
+  options: ProtectedRouteOptions = {}
+) {
+  return async (req: NextRequest, ctx?: any): Promise<NextResponse> => {
+    try {
+      if (!options.skipRateLimit) {
+        const limited = await checkRateLimit(req);
+        if (limited) {
+          const err = new ApiError(
+            ERROR_CODES.OPERATION_FAILED,
+            'Too many requests, please try again later.',
+            429
+          );
+          return createErrorResponse(err);
+        }
+      }
+
+      return withRouteAuth(
+        (r, auth) => handler(r, auth, ctx),
+        req,
+        options.requiredPermission
+          ? { requiredPermissions: [options.requiredPermission] }
+          : {}
+      );
+    } catch (error) {
+      const apiError =
+        error instanceof ApiError
+          ? error
+          : new ApiError(
+              'server/internal_error',
+              error instanceof Error ? error.message : 'An unexpected error occurred',
+              500
+            );
+      return createErrorResponse(apiError);
+    }
+  };
+}

--- a/src/middleware/registry.ts
+++ b/src/middleware/registry.ts
@@ -14,3 +14,4 @@ export * from './security-headers';
 export * from './validation';
 export * from './with-auth-rate-limit';
 export * from './with-security';
+export * from './protected-route';


### PR DESCRIPTION
## Summary
- add `withProtectedRoute` middleware
- export from registry and document in README
- test new middleware

## Testing
- `npx vitest run --coverage` *(fails: Test suite execution exceeded available resources)*