### PR TITLE
Implement standardized auth error responses

### DIFF
--- a/src/middleware/__tests__/auth-errors.test.ts
+++ b/src/middleware/__tests__/auth-errors.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createAuthError, createAuthApiError } from '../auth-errors';
+import { ERROR_CODES } from '@/lib/api/common';
+
+vi.mock('@/lib/audit/auditLogger', () => ({
+  logUserAction: vi.fn().mockResolvedValue(undefined)
+}));
+
+import { logUserAction } from '@/lib/audit/auditLogger';
+
+describe('auth-errors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates error response and logs event', async () => {
+    const res = createAuthError('INVALID_TOKEN');
+    expect(res.status).toBe(401);
+    expect(res.headers.get('content-type')).toBe('application/json');
+    const body = await res.json();
+    expect(body.error.code).toBe(ERROR_CODES.UNAUTHORIZED);
+    expect(body.error.message).toBe('Invalid authentication token');
+    expect(logUserAction).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'AUTH_FAILURE',
+      status: 'FAILURE',
+      details: { type: 'INVALID_TOKEN' }
+    }));
+  });
+
+  it('creates ApiError with details', () => {
+    const err = createAuthApiError('INSUFFICIENT_PERMISSIONS', { foo: 'bar' });
+    expect(err.code).toBe(ERROR_CODES.FORBIDDEN);
+    expect(err.status).toBe(403);
+    expect(err.details).toEqual({ foo: 'bar' });
+  });
+});

--- a/src/middleware/__tests__/auth.test.js
+++ b/src/middleware/__tests__/auth.test.js
@@ -93,8 +93,12 @@ describe('Auth Middleware', () => {
     
     // Check if the response is correct (401 Unauthorized)
     expect(res._getStatusCode()).toBe(401);
-    expect(JSON.parse(res._getData())).toEqual({ 
-      error: 'Unauthorized: Missing authorization header' 
+    expect(JSON.parse(res._getData())).toEqual({
+      error: {
+        code: 'auth/unauthorized',
+        message: 'Authentication required',
+        category: 'auth'
+      }
     });
   });
 
@@ -127,7 +131,11 @@ describe('Auth Middleware', () => {
     // Check if the response is correct (401 Unauthorized)
     expect(res._getStatusCode()).toBe(401);
     expect(JSON.parse(res._getData())).toEqual({
-      error: 'Unauthorized: Invalid token'
+      error: {
+        code: 'auth/unauthorized',
+        message: 'Invalid authentication token',
+        category: 'auth'
+      }
     });
 
     // Verify service was called with the right token
@@ -162,8 +170,12 @@ describe('Auth Middleware', () => {
     
     // Check if the response is correct (500 Server Error)
     expect(res._getStatusCode()).toBe(500);
-    expect(JSON.parse(res._getData())).toEqual({ 
-      error: 'Server error during authentication' 
+    expect(JSON.parse(res._getData())).toEqual({
+      error: {
+        code: 'server/internal_error',
+        message: 'Server error',
+        category: 'server'
+      }
     });
   });
 
@@ -232,8 +244,12 @@ describe('Auth Middleware', () => {
     
     // Check if the response is correct (403 Forbidden)
     expect(res._getStatusCode()).toBe(403);
-    expect(JSON.parse(res._getData())).toEqual({ 
-      error: 'Forbidden: Admin access required' 
+    expect(JSON.parse(res._getData())).toEqual({
+      error: {
+        code: 'auth/forbidden',
+        message: 'Insufficient permissions',
+        category: 'auth'
+      }
     });
   });
   

--- a/src/middleware/__tests__/route-auth.test.ts
+++ b/src/middleware/__tests__/route-auth.test.ts
@@ -25,7 +25,8 @@ describe('withRouteAuth', () => {
   });
 
   it('returns 401 when token missing', async () => {
-    vi.mocked(validateAuthToken).mockResolvedValue({ success: false, error: new Error('unauthorized') } as any);
+    const { createAuthApiError } = await import('../auth-errors');
+    vi.mocked(validateAuthToken).mockResolvedValue({ success: false, error: createAuthApiError('MISSING_TOKEN') } as any);
     const req = new NextRequest('http://test');
     const res = await withRouteAuth(() => Promise.resolve(new NextResponse('ok')), req);
     expect(res.status).toBe(401);

--- a/src/middleware/auth-errors.ts
+++ b/src/middleware/auth-errors.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from 'next/server';
+import { ApiError, ERROR_CODES } from '@/lib/api/common';
+import { logUserAction } from '@/lib/audit/auditLogger';
+
+export type AuthErrorType =
+  | 'MISSING_TOKEN'
+  | 'MALFORMED_TOKEN'
+  | 'INVALID_TOKEN'
+  | 'EXPIRED_TOKEN'
+  | 'INSUFFICIENT_PERMISSIONS'
+  | 'ACCOUNT_SUSPENDED'
+  | 'RATE_LIMITED'
+  | 'MFA_REQUIRED';
+
+interface AuthErrorSpec {
+  code: string;
+  message: string;
+  status: number;
+}
+
+const AUTH_ERROR_MAP: Record<AuthErrorType, AuthErrorSpec> = {
+  MISSING_TOKEN: {
+    code: ERROR_CODES.UNAUTHORIZED,
+    message: 'Authentication required',
+    status: 401,
+  },
+  MALFORMED_TOKEN: {
+    code: ERROR_CODES.UNAUTHORIZED,
+    message: 'Malformed authentication token',
+    status: 401,
+  },
+  INVALID_TOKEN: {
+    code: ERROR_CODES.UNAUTHORIZED,
+    message: 'Invalid authentication token',
+    status: 401,
+  },
+  EXPIRED_TOKEN: {
+    code: ERROR_CODES.SESSION_EXPIRED,
+    message: 'Authentication token expired',
+    status: 401,
+  },
+  INSUFFICIENT_PERMISSIONS: {
+    code: ERROR_CODES.FORBIDDEN,
+    message: 'Insufficient permissions',
+    status: 403,
+  },
+  ACCOUNT_SUSPENDED: {
+    code: ERROR_CODES.ACCOUNT_LOCKED,
+    message: 'Account suspended',
+    status: 403,
+  },
+  RATE_LIMITED: {
+    code: ERROR_CODES.OPERATION_FAILED,
+    message: 'Too many authentication attempts, please try again later.',
+    status: 429,
+  },
+  MFA_REQUIRED: {
+    code: ERROR_CODES.MFA_REQUIRED,
+    message: 'Multi-factor authentication required',
+    status: 403,
+  },
+};
+
+export function createAuthApiError(
+  type: AuthErrorType,
+  details?: Record<string, any>
+): ApiError {
+  const spec = AUTH_ERROR_MAP[type];
+  logUserAction({
+    action: 'AUTH_FAILURE',
+    status: 'FAILURE',
+    targetResourceType: 'auth',
+    details: { type, ...(details || {}) },
+  }).catch((e) => console.error('Failed to log auth error:', e));
+  return new ApiError(spec.code as any, spec.message, spec.status, details);
+}
+
+export function createAuthError(
+  type: AuthErrorType,
+  details?: Record<string, any>
+): NextResponse {
+  const error = createAuthApiError(type, details);
+  return NextResponse.json(error.toResponse(), { status: error.status });
+}
+
+export { AUTH_ERROR_MAP };

--- a/src/middleware/permissions.ts
+++ b/src/middleware/permissions.ts
@@ -3,6 +3,7 @@ import { getApiAuthService } from '@/services/auth/factory';
 import { getApiPermissionService } from '@/services/permission/factory';
 import type { Permission } from '@/lib/rbac/roles';
 import { isPermission } from '@/lib/rbac/roles';
+import { createAuthApiError } from './auth-errors';
 import { withRouteAuth, type RouteAuthContext, type RouteAuthOptions } from './auth';
 
 interface CacheEntry {
@@ -140,7 +141,6 @@ export function createProtectedHandler(
     return withRouteAuth((r, ctx) => handler(r, ctx), req, options);
   };
 }
-import { ApiError } from '@/lib/api/common/api-error';
 import { createErrorResponse } from '@/lib/api/common/response-formatter';
 
 /**
@@ -155,7 +155,7 @@ export async function withPermission(
   return withRouteAuth(
     async (r, ctx) => {
       if (!ctx.userId) {
-        const err = new ApiError('auth/unauthorized', 'Authentication required', 401);
+        const err = createAuthApiError('MISSING_TOKEN');
         return createErrorResponse(err);
       }
 
@@ -169,11 +169,7 @@ export async function withPermission(
       }
 
       if (!hasPermission) {
-        const forbiddenError = new ApiError(
-          'auth/forbidden',
-          `You don't have permission to perform this action`,
-          403
-        );
+        const forbiddenError = createAuthApiError('INSUFFICIENT_PERMISSIONS', { permission });
         return createErrorResponse(forbiddenError);
       }
 

--- a/src/middleware/validate-auth-token.ts
+++ b/src/middleware/validate-auth-token.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import type { User } from '@supabase/supabase-js';
 import { getSessionFromToken } from '@/services/auth/factory';
 import { ApiError } from '@/lib/api/common/api-error';
+import { createAuthApiError } from './auth-errors';
 import { extractAuthToken } from '@/lib/auth/utils';
 
 export interface TokenValidationResult {
@@ -24,7 +25,7 @@ export async function validateAuthToken(req: NextRequest): Promise<TokenValidati
   if (!token) {
     return {
       success: false,
-      error: new ApiError('auth/unauthorized', 'Authentication required', 401),
+      error: createAuthApiError('MISSING_TOKEN'),
     };
   }
 
@@ -33,7 +34,7 @@ export async function validateAuthToken(req: NextRequest): Promise<TokenValidati
     if (!user) {
       return {
         success: false,
-        error: new ApiError('auth/unauthorized', 'Authentication required', 401),
+        error: createAuthApiError('INVALID_TOKEN'),
       };
     }
 


### PR DESCRIPTION
## Summary
- add centralized auth error module with audit logging
- use new errors in authentication middleware
- update token validation logic
- integrate standardized errors in permission checks
- update tests for new error structure and add coverage for auth errors

## Testing
- `npx vitest run src/middleware/__tests__/auth.test.js src/middleware/__tests__/route-auth.test.ts src/middleware/__tests__/protected-route.test.ts src/middleware/__tests__/auth-errors.test.ts --coverage`