### PR TITLE
Refactor tests to use new auth mocks

### DIFF
--- a/app/api/company/domains/__tests__/route.test.ts
+++ b/app/api/company/domains/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import { GET, POST, DELETE, PATCH } from '../route';
 import { getServiceSupabase } from '@/lib/database/supabase';
 import { withRouteAuth } from '@/middleware/auth';
 import { z } from 'zod';
+import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
 
 // Mock dependencies
 vi.mock('@/middleware/rate-limit', () => ({
@@ -166,8 +167,9 @@ describe('Company Domains API', () => {
         })
       }));
 
-      const request = new NextRequest(
-        new URL('http://localhost/api/company/domains?companyId=' + mockCompanyId)
+      const request = createAuthenticatedRequest(
+        'GET',
+        'http://localhost/api/company/domains?companyId=' + mockCompanyId
       );
 
       const response = await GET(request);
@@ -190,8 +192,9 @@ describe('Company Domains API', () => {
         )
       );
 
-      const request = new NextRequest(
-        new URL('http://localhost/api/company/domains?companyId=' + mockCompanyId)
+      const request = createAuthenticatedRequest(
+        'GET',
+        'http://localhost/api/company/domains?companyId=' + mockCompanyId
       );
 
       const response = await GET(request);
@@ -202,9 +205,7 @@ describe('Company Domains API', () => {
     });
     
     test('returns 400 if companyId is missing', async () => {
-      const request = new NextRequest(
-        new URL('http://localhost/api/company/domains')
-      );
+      const request = createAuthenticatedRequest('GET', 'http://localhost/api/company/domains');
       
       const response = await GET(request);
       expect(response.status).toBe(400);
@@ -224,8 +225,9 @@ describe('Company Domains API', () => {
         })
       }));
       
-      const request = new NextRequest(
-        new URL('http://localhost/api/company/domains?companyId=' + mockCompanyId)
+      const request = createAuthenticatedRequest(
+        'GET',
+        'http://localhost/api/company/domains?companyId=' + mockCompanyId
       );
       
       const response = await GET(request);
@@ -241,12 +243,10 @@ describe('Company Domains API', () => {
     test('adds a new domain successfully', async () => {
       const requestBody = { domain: mockDomain, companyId: mockCompanyId };
       
-      const request = new NextRequest(
-        new URL('http://localhost/api/company/domains'),
-        {
-          method: 'POST',
-          body: JSON.stringify(requestBody)
-        }
+      const request = createAuthenticatedRequest(
+        'POST',
+        'http://localhost/api/company/domains',
+        requestBody
       );
       
       const response = await POST(request);
@@ -276,12 +276,10 @@ describe('Company Domains API', () => {
       
       const requestBody = { domain: 'invalid-domain', companyId: mockCompanyId };
       
-      const request = new NextRequest(
-        new URL('http://localhost/api/company/domains'),
-        {
-          method: 'POST',
-          body: JSON.stringify(requestBody)
-        }
+      const request = createAuthenticatedRequest(
+        'POST',
+        'http://localhost/api/company/domains',
+        requestBody
       );
       
       const response = await POST(request);
@@ -301,12 +299,10 @@ describe('Company Domains API', () => {
       
       const requestBody = { domain: mockDomain, companyId: mockCompanyId };
       
-      const request = new NextRequest(
-        new URL('http://localhost/api/company/domains'),
-        {
-          method: 'POST',
-          body: JSON.stringify(requestBody)
-        }
+      const request = createAuthenticatedRequest(
+        'POST',
+        'http://localhost/api/company/domains',
+        requestBody
       );
       
       const response = await POST(request);
@@ -325,12 +321,10 @@ describe('Company Domains API', () => {
       
       const requestBody = { domain: mockDomain, companyId: mockCompanyId };
       
-      const request = new NextRequest(
-        new URL('http://localhost/api/company/domains'),
-        {
-          method: 'POST',
-          body: JSON.stringify(requestBody)
-        }
+      const request = createAuthenticatedRequest(
+        'POST',
+        'http://localhost/api/company/domains',
+        requestBody
       );
       
       const response = await POST(request);
@@ -351,8 +345,9 @@ describe('Company Domains API', () => {
         })
       }));
       
-      const request = new NextRequest(
-        new URL(`http://localhost/api/company/domains/${mockDomainId}`)
+      const request = createAuthenticatedRequest(
+        'DELETE',
+        `http://localhost/api/company/domains/${mockDomainId}`
       );
       
       const response = await DELETE(request, { params: { id: mockDomainId } });
@@ -374,8 +369,9 @@ describe('Company Domains API', () => {
         })
       }));
       
-      const request = new NextRequest(
-        new URL(`http://localhost/api/company/domains/${mockDomainId}`)
+      const request = createAuthenticatedRequest(
+        'DELETE',
+        `http://localhost/api/company/domains/${mockDomainId}`
       );
       
       const response = await DELETE(request, { params: { id: mockDomainId } });
@@ -398,12 +394,10 @@ describe('Company Domains API', () => {
       
       const requestBody = { is_primary: true };
       
-      const request = new NextRequest(
-        new URL(`http://localhost/api/company/domains/${mockDomainId}`),
-        {
-          method: 'PATCH',
-          body: JSON.stringify(requestBody)
-        }
+      const request = createAuthenticatedRequest(
+        'PATCH',
+        `http://localhost/api/company/domains/${mockDomainId}`,
+        requestBody
       );
       
       const response = await PATCH(request, { params: { id: mockDomainId } });
@@ -446,12 +440,10 @@ describe('Company Domains API', () => {
       
       const requestBody = { is_primary: true };
       
-      const request = new NextRequest(
-        new URL(`http://localhost/api/company/domains/${mockDomainId}`),
-        {
-          method: 'PATCH',
-          body: JSON.stringify(requestBody)
-        }
+      const request = createAuthenticatedRequest(
+        'PATCH',
+        `http://localhost/api/company/domains/${mockDomainId}`,
+        requestBody
       );
       
       const response = await PATCH(request, { params: { id: mockDomainId } });
@@ -473,12 +465,10 @@ describe('Company Domains API', () => {
       
       const requestBody = { is_primary: true };
       
-      const request = new NextRequest(
-        new URL(`http://localhost/api/company/domains/${mockDomainId}`),
-        {
-          method: 'PATCH',
-          body: JSON.stringify(requestBody)
-        }
+      const request = createAuthenticatedRequest(
+        'PATCH',
+        `http://localhost/api/company/domains/${mockDomainId}`,
+        requestBody
       );
       
       const response = await PATCH(request, { params: { id: mockDomainId } });

--- a/app/api/user/avatar/__tests__/route.test.ts
+++ b/app/api/user/avatar/__tests__/route.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { NextRequest } from 'next/server';
 import { GET, POST, DELETE } from '../route';
 import { getApiUserService } from '@/services/user/factory';
-import { withAuthRequest } from '@/middleware/auth';
+import { withRouteAuth } from '@/middleware/auth';
 import createMockUserService from '@/tests/mocks/user.service.mock';
+import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
 
 vi.mock('@/services/user/factory', () => ({ getApiUserService: vi.fn() }));
 vi.mock('@/middleware/auth', () => ({
-  withAuthRequest: vi.fn((req: any, handler: any) => handler(req, { userId: 'user-1', role: 'user', permissions: [] })),
+  withRouteAuth: vi.fn((handler: any) => async (req: any) => handler(req, { userId: 'user-1', role: 'user', permissions: [] })),
 }));
 
 const service = createMockUserService();
@@ -19,39 +19,33 @@ beforeEach(() => {
 
 describe('/api/user/avatar alias', () => {
   it('returns predefined avatars', async () => {
-    const req = new NextRequest('http://localhost/api/user/avatar');
-    const res = await GET(req as any);
+    const req = createAuthenticatedRequest('GET', 'http://localhost/api/user/avatar');
+    const res = await GET(req);
     const body = await res.json();
     expect(res.status).toBe(200);
     expect(Array.isArray(body.data.avatars)).toBe(true);
   });
 
   it('updates avatar using predefined id', async () => {
-    const req = new NextRequest('http://localhost/api/user/avatar', {
-      method: 'POST',
-      body: JSON.stringify({ avatarId: 'avatar1' }),
-    });
+    const req = createAuthenticatedRequest('POST', 'http://localhost/api/user/avatar', { avatarId: 'avatar1' });
     (req as any).json = async () => ({ avatarId: 'avatar1' });
-    const res = await POST(req as any);
+    const res = await POST(req);
     expect(res.status).toBe(200);
     expect(service.updateUserProfile).toHaveBeenCalled();
   });
 
   it('uploads custom avatar', async () => {
     const data = 'data:image/png;base64,aGVsbG8=';
-    const req = new NextRequest('http://localhost/api/user/avatar', {
-      method: 'POST',
-      body: JSON.stringify({ avatar: data }),
-    });
+    const req = createAuthenticatedRequest('POST', 'http://localhost/api/user/avatar', { avatar: data });
     (req as any).json = async () => ({ avatar: data });
-    const res = await POST(req as any);
+    const res = await POST(req);
     expect(res.status).toBe(200);
     expect(service.uploadProfilePicture).toHaveBeenCalled();
   });
 
   it('deletes avatar', async () => {
-    const req = new NextRequest('http://localhost/api/user/avatar', { method: 'DELETE' });
-    const res = await DELETE(req as any);
+    const req = createAuthenticatedRequest('DELETE', 'http://localhost/api/user/avatar');
+    const res = await DELETE(req);
     expect(res.status).toBe(204);
     expect(service.deleteProfilePicture).toHaveBeenCalled();
   });

--- a/src/tests/utils/request-helpers.ts
+++ b/src/tests/utils/request-helpers.ts
@@ -1,0 +1,9 @@
+import { NextRequest } from 'next/server';
+
+export function createAuthenticatedRequest(method: string, url: string, body?: any) {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+  return new NextRequest(new URL(url), init);
+}


### PR DESCRIPTION
## Summary
- update route tests to mock `withRouteAuth` instead of old auth utils
- add `createAuthenticatedRequest` helper for API tests
- adjust tests for company profile, domains, session and user APIs

## Testing
- `npx vitest run --coverage` *(fails: useSubscriptionStore.getState is not a function)*