### PR TITLE
Introduce CompanyService and refactor company routes

### DIFF
--- a/app/api/company/addresses/[addressId]/route.ts
+++ b/app/api/company/addresses/[addressId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getServiceSupabase } from '@/lib/database/supabase';
+import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
 import { addressUpdateSchema } from '@/core/address/models';
@@ -24,14 +25,10 @@ async function handlePut(
     const supabaseService = getServiceSupabase();
     const userId = auth.userId!;
 
-    // 3. Get Company Profile
-    const { data: companyProfile, error: companyError } = await supabaseService
-      .from('company_profiles')
-      .select('id')
-      .eq('user_id', userId)
-      .single();
+    const companyService = getApiCompanyService();
+    const companyProfile = await companyService.getProfileByUserId(userId);
 
-    if (companyError || !companyProfile) {
+    if (!companyProfile) {
       return NextResponse.json({ error: 'Company profile not found' }, { status: 404 });
     }
 
@@ -90,14 +87,10 @@ async function handleDelete(
     const supabaseService = getServiceSupabase();
     const userId = auth.userId!;
 
-    // 3. Get Company Profile
-    const { data: companyProfile, error: companyError } = await supabaseService
-      .from('company_profiles')
-      .select('id')
-      .eq('user_id', userId)
-      .single();
+    const companyService = getApiCompanyService();
+    const companyProfile = await companyService.getProfileByUserId(userId);
 
-    if (companyError || !companyProfile) {
+    if (!companyProfile) {
       return NextResponse.json({ error: 'Company profile not found' }, { status: 404 });
     }
 

--- a/app/api/company/addresses/route.ts
+++ b/app/api/company/addresses/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServiceSupabase } from '@/lib/database/supabase';
+import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
 import { addressCreateSchema } from '@/core/address/models';
@@ -19,14 +20,10 @@ async function handlePost(request: NextRequest, auth: RouteAuthContext) {
     const supabaseService = getServiceSupabase();
     const userId = auth.userId!;
 
-    // 3. Get Company Profile
-    const { data: companyProfile, error: companyError } = await supabaseService
-      .from('company_profiles')
-      .select('id')
-      .eq('user_id', userId)
-      .single();
+    const companyService = getApiCompanyService();
+    const companyProfile = await companyService.getProfileByUserId(userId);
 
-    if (companyError || !companyProfile) {
+    if (!companyProfile) {
       return NextResponse.json({ error: 'Company profile not found' }, { status: 404 });
     }
 
@@ -80,14 +77,10 @@ async function handleGet(request: NextRequest, auth: RouteAuthContext) {
     const supabaseService = getServiceSupabase();
     const userId = auth.userId!;
 
-    // 3. Get Company Profile
-    const { data: companyProfile, error: companyError } = await supabaseService
-      .from('company_profiles')
-      .select('id')
-      .eq('user_id', userId)
-      .single();
+    const companyService = getApiCompanyService();
+    const companyProfile = await companyService.getProfileByUserId(userId);
 
-    if (companyError || !companyProfile) {
+    if (!companyProfile) {
       return NextResponse.json({ error: 'Company profile not found' }, { status: 404 });
     }
 

--- a/app/api/company/documents/[documentId]/route.ts
+++ b/app/api/company/documents/[documentId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServiceSupabase } from '@/lib/database/supabase';
+import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
 
@@ -19,14 +20,10 @@ async function handleDelete(
     const supabaseService = getServiceSupabase();
     const userId = auth.userId!;
 
-    // 3. Get Company Profile
-    const { data: companyProfile, error: companyError } = await supabaseService
-      .from('company_profiles')
-      .select('id')
-      .eq('user_id', userId)
-      .single();
+    const companyService = getApiCompanyService();
+    const companyProfile = await companyService.getProfileByUserId(userId);
 
-    if (companyError || !companyProfile) {
+    if (!companyProfile) {
       return NextResponse.json({ error: 'Company profile not found' }, { status: 404 });
     }
 

--- a/app/api/company/documents/route.ts
+++ b/app/api/company/documents/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getServiceSupabase } from '@/lib/database/supabase';
+import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
 
@@ -38,14 +39,10 @@ async function handlePost(request: NextRequest, auth: RouteAuthContext) {
     const supabaseService = getServiceSupabase();
     const userId = auth.userId!;
 
-    // 3. Get Company Profile
-    const { data: companyProfile, error: companyError } = await supabaseService
-      .from('company_profiles')
-      .select('id')
-      .eq('user_id', userId)
-      .single();
+    const companyService = getApiCompanyService();
+    const companyProfile = await companyService.getProfileByUserId(userId);
 
-    if (companyError || !companyProfile) {
+    if (!companyProfile) {
       return NextResponse.json({ error: 'Company profile not found' }, { status: 404 });
     }
 
@@ -136,13 +133,10 @@ async function handleGet(request: NextRequest, auth: RouteAuthContext) {
     const userId = auth.userId!;
 
     // 3. Get Company Profile
-    const { data: companyProfile, error: companyError } = await supabaseService
-      .from('company_profiles')
-      .select('id')
-      .eq('user_id', userId)
-      .single();
+    const companyService = getApiCompanyService();
+    const companyProfile = await companyService.getProfileByUserId(userId);
 
-    if (companyError || !companyProfile) {
+    if (!companyProfile) {
       return NextResponse.json({ error: 'Company profile not found' }, { status: 404 });
     }
 

--- a/app/api/company/validate/registration/route.ts
+++ b/app/api/company/validate/registration/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getServiceSupabase } from '@/lib/database/supabase';
+import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
 
@@ -59,6 +60,11 @@ async function handlePost(request: NextRequest, auth: RouteAuthContext) {
   try {
     const supabaseService = getServiceSupabase();
     const userId = auth.userId!;
+    const companyService = getApiCompanyService();
+    const companyProfile = await companyService.getProfileByUserId(userId);
+    if (!companyProfile) {
+      return NextResponse.json({ error: 'Company profile not found' }, { status: 404 });
+    }
 
     // 3. Parse and Validate Body
     let body: ValidationRequest;

--- a/app/api/company/validate/tax/route.ts
+++ b/app/api/company/validate/tax/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getServiceSupabase } from '@/lib/database/supabase';
+import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
 
@@ -53,6 +54,11 @@ async function handlePost(request: NextRequest, auth: RouteAuthContext) {
   try {
     const supabaseService = getServiceSupabase();
     const userId = auth.userId!;
+    const companyService = getApiCompanyService();
+    const companyProfile = await companyService.getProfileByUserId(userId);
+    if (!companyProfile) {
+      return NextResponse.json({ error: 'Company profile not found' }, { status: 404 });
+    }
 
     // 3. Parse and Validate Body
     let body: ValidationRequest;

--- a/src/services/company/__tests__/companyService.test.ts
+++ b/src/services/company/__tests__/companyService.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DefaultCompanyService } from '../companyService';
+import { getServiceSupabase } from '@/lib/database/supabase';
+
+vi.mock('@/lib/database/supabase', () => ({
+  getServiceSupabase: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn()
+        }))
+      }))
+    }))
+  }))
+}));
+
+describe('DefaultCompanyService.getProfileByUserId', () => {
+  it('returns profile when found', async () => {
+    const supabase = getServiceSupabase();
+    (supabase.from('company_profiles').select('*').eq as any).mockReturnValue({
+      single: vi.fn().mockResolvedValue({ data: { id: 'c1' }, error: null })
+    });
+    const service = new DefaultCompanyService();
+    const result = await service.getProfileByUserId('u1');
+    expect(result).toEqual({ id: 'c1' });
+  });
+
+  it('returns null when not found', async () => {
+    const supabase = getServiceSupabase();
+    (supabase.from('company_profiles').select('*').eq as any).mockReturnValue({
+      single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } })
+    });
+    const service = new DefaultCompanyService();
+    const result = await service.getProfileByUserId('u1');
+    expect(result).toBeNull();
+  });
+
+  it('throws for other errors', async () => {
+    const supabase = getServiceSupabase();
+    (supabase.from('company_profiles').select('*').eq as any).mockReturnValue({
+      single: vi.fn().mockResolvedValue({ data: null, error: { code: '123', message: 'db error' } })
+    });
+    const service = new DefaultCompanyService();
+    await expect(service.getProfileByUserId('u1')).rejects.toThrow('Failed to fetch company profile');
+  });
+});

--- a/src/services/company/__tests__/factory.test.ts
+++ b/src/services/company/__tests__/factory.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let getApiCompanyService: typeof import('../factory').getApiCompanyService;
+let DefaultCompanyService: typeof import('../companyService').DefaultCompanyService;
+let UserManagementConfiguration: typeof import('@/core/config').UserManagementConfiguration;
+
+describe('getApiCompanyService', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ UserManagementConfiguration } = await import('@/core/config'));
+    UserManagementConfiguration.reset();
+    ({ getApiCompanyService } = await import('../factory'));
+    ({ DefaultCompanyService } = await import('../companyService'));
+  });
+
+  it('returns configured service if registered', () => {
+    const svc = {} as any;
+    UserManagementConfiguration.configureServiceProviders({ companyService: svc });
+    expect(getApiCompanyService()).toBe(svc);
+    expect(getApiCompanyService()).toBe(svc);
+  });
+
+  it('creates default service when not configured', () => {
+    const service = getApiCompanyService();
+    expect(service).toBeInstanceOf(DefaultCompanyService);
+    expect(getApiCompanyService()).toBe(service);
+  });
+});

--- a/src/services/company/companyService.ts
+++ b/src/services/company/companyService.ts
@@ -1,0 +1,28 @@
+import { getServiceSupabase } from '@/lib/database/supabase';
+import type { CompanyProfile } from '@/types/company';
+
+export interface CompanyService {
+  getProfileByUserId(userId: string): Promise<CompanyProfile | null>;
+}
+
+export class DefaultCompanyService implements CompanyService {
+  constructor(private supabase = getServiceSupabase()) {}
+
+  async getProfileByUserId(userId: string): Promise<CompanyProfile | null> {
+    const { data, error } = await this.supabase
+      .from('company_profiles')
+      .select('*')
+      .eq('user_id', userId)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return null;
+      }
+      console.error(`Error fetching company profile for user ${userId}:`, error);
+      throw new Error('Failed to fetch company profile');
+    }
+
+    return data as CompanyProfile;
+  }
+}

--- a/src/services/company/factory.ts
+++ b/src/services/company/factory.ts
@@ -1,0 +1,13 @@
+import { UserManagementConfiguration } from '@/core/config';
+import { DefaultCompanyService, type CompanyService } from './companyService';
+
+let companyServiceInstance: CompanyService | null = null;
+
+export function getApiCompanyService(): CompanyService {
+  if (!companyServiceInstance) {
+    companyServiceInstance =
+      (UserManagementConfiguration.getServiceProvider('companyService') as CompanyService) ||
+      new DefaultCompanyService();
+  }
+  return companyServiceInstance;
+}


### PR DESCRIPTION
## Summary
- add `CompanyService` for retrieving company profiles
- expose service via new factory
- refactor company API routes to use the service
- add unit tests for the service and factory

## Testing
- `npx vitest run --coverage` *(fails: JavaScript heap out of memory)*