### PR TITLE
Use withErrorHandling across API routes

### DIFF
--- a/app/api/admin/dashboard/route.ts
+++ b/app/api/admin/dashboard/route.ts
@@ -1,11 +1,12 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, NextRequest } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth/index';
 import { prisma } from '@/lib/database/prisma';
 import { checkRolePermission } from '@/lib/rbac/roleService';
 import { Role } from '@/types/rbac';
+import { withErrorHandling } from '@/middleware/error-handling';
 
-export async function GET() {
+async function handleGet() {
   try {
     // Get the current session
     const session = await getServerSession(authOptions);
@@ -116,3 +117,4 @@ export async function GET() {
     );
   }
 }
+export const GET = (req: NextRequest) => withErrorHandling(() => handleGet(), req);

--- a/app/api/admin/export/route.ts
+++ b/app/api/admin/export/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { supabase } from '@/lib/supabase';
 import { middleware } from '@/middleware';
 import { logUserAction } from '@/lib/audit/auditLogger';
+import { withErrorHandling } from '@/middleware/error-handling';
 
 // Helper to fetch all relevant company data for export
 async function getCompanyExportData(companyId: string) {
@@ -45,7 +46,7 @@ async function getCompanyExportData(companyId: string) {
   };
 }
 
-export const GET = middleware(['cors', 'csrf', 'rateLimit'], async (req: NextRequest) => {
+async function handleGet(req: NextRequest) {
   const user = (req as any).user;
   if (!user) {
     return new NextResponse(JSON.stringify({ error: 'Unauthorized' }), {
@@ -137,4 +138,9 @@ export const GET = middleware(['cors', 'csrf', 'rateLimit'], async (req: NextReq
       'Content-Disposition': `attachment; filename="${filename}"`,
     },
   });
-});
+}
+
+export const GET = middleware(
+  ['cors', 'csrf', 'rateLimit'],
+  (req: NextRequest) => withErrorHandling(handleGet, req)
+);

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import { withErrorHandling } from '@/middleware/error-handling';
 import { z } from 'zod';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
@@ -12,7 +13,7 @@ const querySchema = z.object({
 
 type QueryParams = z.infer<typeof querySchema>;
 
-export async function GET(req: NextRequest) {
+async function handleGet(req: NextRequest) {
   const url = new URL(req.url);
   const parseResult = querySchema.safeParse(Object.fromEntries(url.searchParams.entries()));
   if (!parseResult.success) {
@@ -73,3 +74,5 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: message }, { status });
   }
 }
+
+export const GET = (req: NextRequest) => withErrorHandling(handleGet, req);

--- a/app/api/company/addresses/[addressId]/route.ts
+++ b/app/api/company/addresses/[addressId]/route.ts
@@ -4,6 +4,7 @@ import { getServiceSupabase } from '@/lib/database/supabase';
 import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
+import { withErrorHandling } from '@/middleware/error-handling';
 import { addressUpdateSchema } from '@/core/address/models';
 import { createSupabaseAddressProvider } from '@/adapters/address/factory';
 
@@ -120,9 +121,17 @@ async function handleDelete(
 export const PUT = (
   req: NextRequest,
   ctx: { params: { addressId: string } }
-) => withRouteAuth((r, auth) => handlePut(r, ctx.params, auth), req);
+) =>
+  withErrorHandling(
+    (r) => withRouteAuth((r2, auth) => handlePut(r2, ctx.params, auth), r),
+    req
+  );
 
 export const DELETE = (
   req: NextRequest,
   ctx: { params: { addressId: string } }
-) => withRouteAuth((r, auth) => handleDelete(r, ctx.params, auth), req);
+) =>
+  withErrorHandling(
+    (r) => withRouteAuth((r2, auth) => handleDelete(r2, ctx.params, auth), r),
+    req
+  );

--- a/app/api/company/addresses/route.ts
+++ b/app/api/company/addresses/route.ts
@@ -3,6 +3,7 @@ import { getServiceSupabase } from '@/lib/database/supabase';
 import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
+import { withErrorHandling } from '@/middleware/error-handling';
 import { addressCreateSchema } from '@/core/address/models';
 import { createSupabaseAddressProvider } from '@/adapters/address/factory';
 
@@ -99,5 +100,7 @@ async function handleGet(request: NextRequest, auth: RouteAuthContext) {
   }
 }
 
-export const POST = (req: NextRequest) => withRouteAuth(handlePost, req);
-export const GET = (req: NextRequest) => withRouteAuth(handleGet, req);
+export const POST = (req: NextRequest) =>
+  withErrorHandling((r) => withRouteAuth(handlePost, r), req);
+export const GET = (req: NextRequest) =>
+  withErrorHandling((r) => withRouteAuth(handleGet, r), req);

--- a/app/api/company/documents/[documentId]/route.ts
+++ b/app/api/company/documents/[documentId]/route.ts
@@ -3,6 +3,7 @@ import { getServiceSupabase } from '@/lib/database/supabase';
 import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
+import { withErrorHandling } from '@/middleware/error-handling';
 
 // --- DELETE Handler for removing company documents ---
 async function handleDelete(
@@ -72,4 +73,8 @@ async function handleDelete(
 export const DELETE = (
   req: NextRequest,
   ctx: { params: { documentId: string } }
-) => withRouteAuth((r, auth) => handleDelete(r, ctx.params, auth), req);
+) =>
+  withErrorHandling(
+    (r) => withRouteAuth((r2, auth) => handleDelete(r2, ctx.params, auth), r),
+    req
+  );

--- a/app/api/company/documents/route.ts
+++ b/app/api/company/documents/route.ts
@@ -4,6 +4,7 @@ import { getServiceSupabase } from '@/lib/database/supabase';
 import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
+import { withErrorHandling } from '@/middleware/error-handling';
 
 // Document upload schema
 const DocumentUploadSchema = z.object({
@@ -228,5 +229,7 @@ async function handleGet(request: NextRequest, auth: RouteAuthContext) {
   }
 }
 
-export const POST = (req: NextRequest) => withRouteAuth(handlePost, req);
-export const GET = (req: NextRequest) => withRouteAuth(handleGet, req);
+export const POST = (req: NextRequest) =>
+  withErrorHandling((r) => withRouteAuth(handlePost, r), req);
+export const GET = (req: NextRequest) =>
+  withErrorHandling((r) => withRouteAuth(handleGet, r), req);

--- a/app/api/company/domains/[id]/route.ts
+++ b/app/api/company/domains/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServiceSupabase } from '@/lib/database/supabase';
 import { checkRateLimit } from '@/middleware/rate-limit';
+import { withErrorHandling } from '@/middleware/error-handling';
 import { z } from 'zod';
 
 // Validation schema for updating a domain
@@ -9,7 +10,7 @@ const domainUpdateSchema = z.object({
 });
 
 // DELETE /api/company/domains/[id] - Delete a domain
-export async function DELETE(
+async function handleDelete(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
@@ -83,7 +84,7 @@ export async function DELETE(
 }
 
 // PATCH /api/company/domains/[id] - Update a domain (currently just primary status)
-export async function PATCH(
+async function handlePatch(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
@@ -181,4 +182,14 @@ export async function PATCH(
     console.error(`Unexpected error in PATCH /api/company/domains/${params.id}:`, error);
     return NextResponse.json({ error: 'An internal server error occurred.' }, { status: 500 });
   }
-} 
+}
+
+export const DELETE = (
+  req: NextRequest,
+  ctx: { params: { id: string } }
+) => withErrorHandling((r) => handleDelete(r, ctx), req);
+
+export const PATCH = (
+  req: NextRequest,
+  ctx: { params: { id: string } }
+) => withErrorHandling((r) => handlePatch(r, ctx), req);

--- a/app/api/company/domains/[id]/verify-check/route.ts
+++ b/app/api/company/domains/[id]/verify-check/route.ts
@@ -3,6 +3,7 @@ import { getServiceSupabase } from '@/lib/database/supabase';
 import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
+import { withErrorHandling } from '@/middleware/error-handling';
 import dns from 'dns/promises';
 
 const supabaseService = getServiceSupabase();
@@ -107,5 +108,6 @@ async function handlePost(
 export const POST = (
   req: NextRequest,
   ctx: { params: { id: string } }
-) => withRouteAuth((r, auth) => handlePost(r, ctx.params, auth), req);
+) =>
+  withErrorHandling((r) => withRouteAuth((r2, auth) => handlePost(r2, ctx.params, auth), r), req);
 

--- a/app/api/company/domains/[id]/verify-initiate/route.ts
+++ b/app/api/company/domains/[id]/verify-initiate/route.ts
@@ -3,6 +3,7 @@ import { getServiceSupabase } from '@/lib/database/supabase';
 import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
+import { withErrorHandling } from '@/middleware/error-handling';
 import { v4 as uuidv4 } from 'uuid';
 
 const VERIFICATION_PREFIX = 'user-management-verification=';
@@ -74,5 +75,6 @@ async function handlePost(
 export const POST = (
   req: NextRequest,
   ctx: { params: { id: string } }
-) => withRouteAuth((r, auth) => handlePost(r, ctx.params, auth), req);
+) =>
+  withErrorHandling((r) => withRouteAuth((r2, auth) => handlePost(r2, ctx.params, auth), r), req);
 

--- a/app/api/company/domains/route.ts
+++ b/app/api/company/domains/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServiceSupabase } from '@/lib/database/supabase';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
+import { withErrorHandling } from '@/middleware/error-handling';
 import { z } from 'zod';
 
 // Validation schema for adding a new domain
@@ -135,5 +136,7 @@ async function handlePost(request: NextRequest, auth: RouteAuthContext) {
   }
 }
 
-export const GET = (req: NextRequest) => withRouteAuth(handleGet, req);
-export const POST = (req: NextRequest) => withRouteAuth(handlePost, req);
+export const GET = (req: NextRequest) =>
+  withErrorHandling((r) => withRouteAuth(handleGet, r), req);
+export const POST = (req: NextRequest) =>
+  withErrorHandling((r) => withRouteAuth(handlePost, r), req);

--- a/app/api/company/notifications/preferences/[id]/route.ts
+++ b/app/api/company/notifications/preferences/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServiceSupabase } from '@/lib/database/supabase';
 import { checkRateLimit } from '@/middleware/rate-limit';
+import { withErrorHandling } from '@/middleware/error-handling';
 import { z } from 'zod';
 
 // Validation schema for updating a notification preference
@@ -10,7 +11,7 @@ const updateSchema = z.object({
 });
 
 // PATCH /api/company/notifications/preferences/[id] - Update a notification preference
-export async function PATCH(
+async function handlePatch(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
@@ -109,3 +110,4 @@ export async function PATCH(
     return NextResponse.json({ error: 'An internal server error occurred.' }, { status: 500 });
   }
 } 
+export const PATCH = (req: NextRequest, ctx: { params: { id: string } }) => withErrorHandling((r) => handlePatch(r, ctx), req);

--- a/app/api/company/notifications/preferences/route.ts
+++ b/app/api/company/notifications/preferences/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServiceSupabase } from '@/lib/database/supabase';
 import { checkRateLimit } from '@/middleware/rate-limit';
+import { withErrorHandling } from '@/middleware/error-handling';
 import { z } from 'zod';
 
 // Validation schema for creating a new notification preference
@@ -12,7 +13,7 @@ const preferenceSchema = z.object({
 });
 
 // GET /api/company/notifications/preferences - Get all notification preferences for the current user's company
-export async function GET(request: NextRequest) {
+async function handleGet(request: NextRequest) {
   // 1. Rate Limiting
   const isRateLimited = await checkRateLimit(request);
   if (isRateLimited) {
@@ -73,7 +74,7 @@ export async function GET(request: NextRequest) {
 }
 
 // POST /api/company/notifications/preferences - Create a new notification preference
-export async function POST(request: NextRequest) {
+async function handlePost(request: NextRequest) {
   // 1. Rate Limiting
   const isRateLimited = await checkRateLimit(request);
   if (isRateLimited) {
@@ -197,3 +198,5 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'An internal server error occurred.' }, { status: 500 });
   }
 } 
+export const GET = (req: NextRequest) => withErrorHandling(handleGet, req);
+export const POST = (req: NextRequest) => withErrorHandling(handlePost, req);

--- a/app/api/company/notifications/recipients/[id]/route.ts
+++ b/app/api/company/notifications/recipients/[id]/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServiceSupabase } from '@/lib/database/supabase';
 import { checkRateLimit } from '@/middleware/rate-limit';
+import { withErrorHandling } from '@/middleware/error-handling';
 
 // DELETE /api/company/notifications/recipients/[id] - Delete a notification recipient
-export async function DELETE(
+async function handleDelete(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
@@ -101,3 +102,4 @@ export async function DELETE(
     return NextResponse.json({ error: 'An internal server error occurred.' }, { status: 500 });
   }
 } 
+export const DELETE = (req: NextRequest, ctx: { params: { id: string } }) => withErrorHandling((r) => handleDelete(r, ctx), req);

--- a/app/api/company/notifications/recipients/route.ts
+++ b/app/api/company/notifications/recipients/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServiceSupabase } from '@/lib/database/supabase';
 import { checkRateLimit } from '@/middleware/rate-limit';
+import { withErrorHandling } from '@/middleware/error-handling';
 import { z } from 'zod';
 
 // Validation schema for adding a new recipient
@@ -12,7 +13,7 @@ const recipientSchema = z.object({
 });
 
 // POST /api/company/notifications/recipients - Add a new notification recipient
-export async function POST(request: NextRequest) {
+async function handlePost(request: NextRequest) {
   // 1. Rate Limiting
   const isRateLimited = await checkRateLimit(request);
   if (isRateLimited) {
@@ -152,3 +153,4 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'An internal server error occurred.' }, { status: 500 });
   }
 } 
+export const POST = (req: NextRequest) => withErrorHandling(handlePost, req);

--- a/app/api/company/profile/route.ts
+++ b/app/api/company/profile/route.ts
@@ -5,6 +5,7 @@ import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { logUserAction } from '@/lib/audit/auditLogger';
 import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
+import { withErrorHandling } from '@/middleware/error-handling';
 
 // Company Profile Schema
 const CompanyProfileSchema = z.object({
@@ -150,7 +151,8 @@ async function handlePost(request: NextRequest, auth: RouteAuthContext) {
   }
 }
 
-export const POST = (req: NextRequest) => withRouteAuth(handlePost, req);
+export const POST = (req: NextRequest) =>
+  withErrorHandling((r) => withRouteAuth(handlePost, r), req);
 
 
 async function handleGet(request: NextRequest, auth: RouteAuthContext) {
@@ -178,7 +180,8 @@ async function handleGet(request: NextRequest, auth: RouteAuthContext) {
   }
 }
 
-export const GET = (req: NextRequest) => withRouteAuth(handleGet, req);
+export const GET = (req: NextRequest) =>
+  withErrorHandling((r) => withRouteAuth(handleGet, r), req);
 
 async function handlePut(request: NextRequest, auth: RouteAuthContext) {
   // Get IP and User Agent early
@@ -294,7 +297,8 @@ async function handlePut(request: NextRequest, auth: RouteAuthContext) {
   }
 }
 
-export const PUT = (req: NextRequest) => withRouteAuth(handlePut, req);
+export const PUT = (req: NextRequest) =>
+  withErrorHandling((r) => withRouteAuth(handlePut, r), req);
 
 async function handleDelete(request: NextRequest, auth: RouteAuthContext) {
   // Get IP and User Agent early
@@ -420,4 +424,5 @@ async function handleDelete(request: NextRequest, auth: RouteAuthContext) {
   }
 }
 
-export const DELETE = (req: NextRequest) => withRouteAuth(handleDelete, req);
+export const DELETE = (req: NextRequest) =>
+  withErrorHandling((r) => withRouteAuth(handleDelete, r), req);

--- a/app/api/company/validate/registration/route.ts
+++ b/app/api/company/validate/registration/route.ts
@@ -4,6 +4,7 @@ import { getServiceSupabase } from '@/lib/database/supabase';
 import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
+import { withErrorHandling } from '@/middleware/error-handling';
 
 const ValidationRequestSchema = z.object({
   registrationNumber: z.string().min(1),
@@ -116,4 +117,5 @@ async function handlePost(request: NextRequest, auth: RouteAuthContext) {
   }
 }
 
-export const POST = (req: NextRequest) => withRouteAuth(handlePost, req);
+export const POST = (req: NextRequest) =>
+  withErrorHandling((r) => withRouteAuth(handlePost, r), req);

--- a/app/api/company/validate/tax/route.ts
+++ b/app/api/company/validate/tax/route.ts
@@ -4,6 +4,7 @@ import { getServiceSupabase } from '@/lib/database/supabase';
 import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
+import { withErrorHandling } from '@/middleware/error-handling';
 
 const ValidationRequestSchema = z.object({
   taxId: z.string().min(1),
@@ -110,4 +111,5 @@ async function handlePost(request: NextRequest, auth: RouteAuthContext) {
   }
 }
 
-export const POST = (req: NextRequest) => withRouteAuth(handlePost, req);
+export const POST = (req: NextRequest) =>
+  withErrorHandling((r) => withRouteAuth(handlePost, r), req);

--- a/app/api/team/route.ts
+++ b/app/api/team/route.ts
@@ -1,13 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getApiTeamService } from '@/services/team/factory';
+import { withErrorHandling } from '@/middleware/error-handling';
 
 const CreateTeamSchema = z.object({
   name: z.string().min(1),
   description: z.string().optional()
 });
 
-export async function GET(req: NextRequest) {
+async function handleGet(req: NextRequest) {
   const userId = req.headers.get('x-user-id');
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -17,7 +18,7 @@ export async function GET(req: NextRequest) {
   return NextResponse.json({ teams });
 }
 
-export async function POST(req: NextRequest) {
+async function handlePost(req: NextRequest) {
   const userId = req.headers.get('x-user-id');
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -38,3 +39,6 @@ export async function POST(req: NextRequest) {
   }
   return NextResponse.json({ team: result.team }, { status: 201 });
 }
+
+export const GET = (req: NextRequest) => withErrorHandling(handleGet, req);
+export const POST = (req: NextRequest) => withErrorHandling(handlePost, req);

--- a/src/middleware/error-handling.ts
+++ b/src/middleware/error-handling.ts
@@ -22,6 +22,9 @@ export async function withErrorHandling(
             500
           );
 
+    // Log to console for easier debugging during development/testing
+    console.error('API error:', apiError);
+
     await logApiError(apiError, {
       ipAddress: req.headers.get('x-forwarded-for') || 'unknown',
       userAgent: req.headers.get('user-agent') || 'unknown',


### PR DESCRIPTION
## Summary
- log API errors to console in withErrorHandling
- wrap company, team and admin API routes with withErrorHandling middleware for consistent error handling

## Testing
- `npx vitest run --coverage` *(fails: various tests fail)*