### PR TITLE
Implement basic centralized error handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,6 @@ TOKEN_EXPIRY_DAYS=7
 # Environment
 # Next.js automatically sets NODE_ENV to 'development' or 'production'
 E2E_USE_SUPABASE=false
+
+# Error logging configuration
+ERROR_LOG_LEVEL=info

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -5,12 +5,8 @@ import { withSecurity } from '@/middleware/with-security';
 import { logUserAction } from '@/lib/audit/auditLogger';
 import { getApiAuthService } from '@/services/auth/factory';
 import { LoginPayload } from '@/core/auth/models';
-import {
-  createSuccessResponse,
-  ApiError,
-  ERROR_CODES
-} from '@/lib/api/common';
-import { withErrorHandling } from '@/middleware/error-handling';
+import { createSuccessResponse, ApiError, ERROR_CODES } from '@/lib/api';
+import { createErrorHandledRoute } from '@/middleware/with-error-handling';
 import { withValidation } from '@/middleware/validation';
 import { createInvalidCredentialsError, createEmailNotVerifiedError } from '@/lib/api/auth/error-handler';
 
@@ -113,9 +109,6 @@ async function handleLogin(req: NextRequest, validatedData: z.infer<typeof Login
  */
 export const POST = withSecurity(async (request: NextRequest) =>
   withAuthRateLimit(request, (req) =>
-    withErrorHandling(
-      async (r) => withValidation(LoginSchema, handleLogin, r),
-      req
-    )
+    createErrorHandledRoute((r) => withValidation(LoginSchema, handleLogin, r))(req)
   )
 );

--- a/src/core/config/AppInitializer.tsx
+++ b/src/core/config/AppInitializer.tsx
@@ -21,6 +21,11 @@ export function AppInitializer({ children }: { children: React.ReactNode }) {
       console.log('[AppInitializer] Initializing application...');
       // Initialize the application and get the service instances
       const services = initializeApp();
+
+      // Example: register global error handler for API calls
+      window.addEventListener('unhandledrejection', (e) => {
+        console.error('[AppInitializer] Unhandled promise rejection', e.reason);
+      });
       
       // Ensure services are properly registered with UserManagementConfiguration
       UserManagementConfiguration.configureServiceProviders({

--- a/src/lib/api/error-handler.ts
+++ b/src/lib/api/error-handler.ts
@@ -1,0 +1,25 @@
+import { ApiError, ERROR_STATUS_MAP, ERROR_CODES, ErrorCode } from './common';
+
+/**
+ * Normalize unknown errors into ApiError instances.
+ */
+export function toApiError(err: unknown, fallbackCode: ErrorCode = ERROR_CODES.INTERNAL_ERROR) {
+  if (err instanceof ApiError) return err;
+  const message = err instanceof Error ? err.message : 'Unexpected error';
+  const status = ERROR_STATUS_MAP[fallbackCode] ?? 500;
+  return new ApiError(fallbackCode, message, status);
+}
+
+/**
+ * Utility to map a list of known Error instances to ApiErrors.
+ */
+export type ErrorMap = [RegExp, () => ApiError][];
+export function mapError(err: unknown, mappings: ErrorMap, fallbackCode: ErrorCode = ERROR_CODES.INTERNAL_ERROR) {
+  const msg = err instanceof Error ? err.message : String(err);
+  for (const [pattern, factory] of mappings) {
+    if (pattern.test(msg)) {
+      return factory();
+    }
+  }
+  return toApiError(err, fallbackCode);
+}

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,0 +1,2 @@
+export * from './common';
+export * from './error-handler';

--- a/src/lib/audit/auditLogger.ts
+++ b/src/lib/audit/auditLogger.ts
@@ -12,6 +12,7 @@ export interface LogUserActionParams {
   userId?: string | null; // Nullable for system actions or unauthenticated attempts
   action: string; // e.g., 'LOGIN_SUCCESS', 'PROFILE_UPDATE'
   status: 'SUCCESS' | 'FAILURE' | 'INITIATED' | 'COMPLETED';
+  severity?: 'info' | 'warn' | 'error';
   ipAddress?: string | null;
   userAgent?: string | null;
   targetResourceType?: string | null;
@@ -47,6 +48,7 @@ export async function logUserAction(params: LogUserActionParams): Promise<void> 
         user_id: userId,
         action: action,
         status: status,
+        severity: params.severity ?? 'info',
         ip_address: ipAddress, // Assumes INET type in DB can handle string representation
         user_agent: userAgent,
         target_resource_type: targetResourceType,

--- a/src/lib/audit/error-logger.ts
+++ b/src/lib/audit/error-logger.ts
@@ -1,0 +1,15 @@
+import { logUserAction } from './auditLogger';
+import { ApiError } from '@/lib/api/common';
+
+export async function logError(error: ApiError, req?: { ip?: string; ua?: string }) {
+  await logUserAction({
+    action: 'API_ERROR',
+    status: 'FAILURE',
+    severity: 'error',
+    ipAddress: req?.ip ?? null,
+    userAgent: req?.ua ?? null,
+    targetResourceType: 'api',
+    targetResourceId: '',
+    details: { code: error.code, message: error.message }
+  });
+}

--- a/src/middleware/error-handling.ts
+++ b/src/middleware/error-handling.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { ApiError } from '@/lib/api/common/api-error';
+import { ApiError, toApiError } from '@/lib/api';
 import { createErrorResponse } from '@/lib/api/common/response-formatter';
-import { logUserAction } from '@/lib/audit/auditLogger';
+import { logError } from '@/lib/audit/error-logger';
 
 /**
  * Middleware to handle API errors for route handlers.
@@ -13,30 +13,12 @@ export async function withErrorHandling(
   try {
     return await handler(req);
   } catch (error) {
-    console.error('API Error:', error);
-    const apiError =
-      error instanceof ApiError
-        ? error
-        : new ApiError(
-            'server/internal_error',
-            error instanceof Error ? error.message : 'An unexpected error occurred',
-            500
-          );
-
-    try {
-      await logUserAction({
-        action: 'API_ERROR',
-        status: 'FAILURE',
-        ipAddress: req.headers.get('x-forwarded-for') || 'unknown',
-        userAgent: req.headers.get('user-agent') || 'unknown',
-        targetResourceType: 'api',
-        targetResourceId: req.nextUrl.pathname,
-        details: { code: apiError.code, message: apiError.message }
-      });
-    } catch (logErr) {
-      console.error('Failed to log API error:', logErr);
-    }
-
+    const apiError = toApiError(error);
+    await logError(apiError, {
+      ip: req.headers.get('x-forwarded-for') || undefined,
+      ua: req.headers.get('user-agent') || undefined,
+    });
     return createErrorResponse(apiError);
   }
 }
+

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -140,5 +140,7 @@ export function withSecurity(
         res.status(500).json({ error: 'Internal server error' });
       }
     }
-  };
-} 
+  }; 
+}
+
+export * from './with-error-handling';

--- a/src/middleware/with-error-handling.ts
+++ b/src/middleware/with-error-handling.ts
@@ -1,0 +1,6 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withErrorHandling } from './error-handling';
+
+export function createErrorHandledRoute(handler: (req: NextRequest) => Promise<NextResponse>) {
+  return (req: NextRequest) => withErrorHandling(handler, req);
+}

--- a/tests/errors/index.ts
+++ b/tests/errors/index.ts
@@ -1,0 +1,3 @@
+export const sampleError = () => {
+  throw new Error('sample');
+};


### PR DESCRIPTION
## Summary
- introduce general error utilities and export via `src/lib/api`
- log audit entries with severity
- centralize error handling middleware
- wrap login endpoint with new error middleware
- add environment variable example for error logging

## Testing
- `npx vitest run src/middleware/__tests__/error-handling.test.ts`
- `npm run lint`