### PR TITLE
Standardize API responses

### DIFF
--- a/app/api/subscriptions/portal/route.ts
+++ b/app/api/subscriptions/portal/route.ts
@@ -1,6 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { z } from 'zod';
 import { createBillingPortalSession } from '@/lib/payments/stripe';
+import {
+  createSuccessResponse,
+  createValidationError,
+  createServerError,
+} from '@/lib/api/common';
 
 const bodySchema = z.object({ customerId: z.string() });
 
@@ -12,11 +17,11 @@ export async function POST(req: NextRequest) {
   try {
     body = await req.json();
   } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+    throw createValidationError('Invalid JSON');
   }
   const parse = bodySchema.safeParse(body);
   if (!parse.success) {
-    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    throw createValidationError('Invalid payload', parse.error.flatten());
   }
 
   try {
@@ -24,8 +29,8 @@ export async function POST(req: NextRequest) {
       customer: parse.data.customerId,
       return_url: `${process.env.NEXT_PUBLIC_APP_URL}/billing`,
     });
-    return NextResponse.json({ url: session.url });
+    return createSuccessResponse({ url: session.url });
   } catch (err: any) {
-    return NextResponse.json({ error: err.message }, { status: 500 });
+    throw createServerError(err.message);
   }
 }


### PR DESCRIPTION
## Summary
- use response helpers in company notification recipient endpoint
- use response helpers in company documents API
- unify response structure for subscription checkout and portal routes
- standardize webhook API responses

## Testing
- `npm run test:coverage` *(fails: API tests require network access)*