### PR TITLE
Implement comprehensive middleware chain

### DIFF
--- a/src/middleware/createMiddlewareChain.ts
+++ b/src/middleware/createMiddlewareChain.ts
@@ -1,8 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withErrorHandling } from './error-handling';
 import { withRouteAuth, type RouteAuthOptions } from './auth';
+import { withValidation } from './validation';
+import type { ZodSchema } from 'zod';
+import { createRateLimit, type RateLimitOptions } from './rate-limit';
 
-export type RouteHandler = (req: NextRequest, ctx?: any) => Promise<NextResponse>;
+export type RouteHandler = (
+  req: NextRequest,
+  ctx?: any,
+  data?: any
+) => Promise<NextResponse>;
 export type RouteMiddleware = (handler: RouteHandler) => RouteHandler;
 
 /**
@@ -18,12 +25,31 @@ export function createMiddlewareChain(middlewares: RouteMiddleware[]): RouteMidd
 
 /** Adapts `withErrorHandling` to {@link RouteMiddleware}. */
 export function errorHandlingMiddleware(): RouteMiddleware {
-  return (handler: RouteHandler): RouteHandler => (req: NextRequest) =>
-    withErrorHandling((r) => handler(r), req);
+  return (handler: RouteHandler): RouteHandler =>
+    (req: NextRequest, ctx?: any, data?: any) =>
+      withErrorHandling((r) => handler(r, ctx, data), req);
 }
 
 /** Adapts `withRouteAuth` to {@link RouteMiddleware}. */
 export function routeAuthMiddleware(options?: RouteAuthOptions): RouteMiddleware {
-  return (handler: RouteHandler): RouteHandler => (req: NextRequest) =>
-    withRouteAuth((r, ctx) => handler(r, ctx), req, options);
+  return (handler: RouteHandler): RouteHandler =>
+    (req: NextRequest, _ctx?: any, data?: any) =>
+      withRouteAuth((r, authCtx) => handler(r, authCtx, data), req, options);
+}
+
+/** Adapts `withValidation` to {@link RouteMiddleware}. */
+export function validationMiddleware<T>(schema: ZodSchema<T>): RouteMiddleware {
+  return (handler: RouteHandler): RouteHandler =>
+    (req: NextRequest, ctx?: any) =>
+      withValidation(schema, (r, data) => handler(r, ctx, data), req);
+}
+
+/** Adapts `createRateLimit` to {@link RouteMiddleware}. */
+export function rateLimitMiddleware(
+  options?: RateLimitOptions
+): RouteMiddleware {
+  const limiter = createRateLimit(options);
+  return (handler: RouteHandler): RouteHandler =>
+    (req: NextRequest, ctx?: any, data?: any) =>
+      limiter(req, (r) => handler(r, ctx, data));
 }


### PR DESCRIPTION
## Summary
- extend `createMiddlewareChain` types to support context and data
- add built-in middleware adapters for validation and rate limiting
- update tests for new middleware chain behaviour and add coverage

## Testing
- `npm run test:coverage` *(fails: Cannot read properties of undefined (reading 'findUnique'))*