### PR TITLE
Add centralized Supabase auth helpers

### DIFF
--- a/src/lib/auth/__tests__/index.test.ts
+++ b/src/lib/auth/__tests__/index.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../session', () => {
+  return {
+    getCurrentSession: vi.fn(),
+    getCurrentUser: vi.fn(),
+    getSessionFromRequest: vi.fn(),
+    isSessionValid: vi.fn(),
+    refreshSession: vi.fn(),
+    handleSessionTimeout: vi.fn(),
+    persistSession: vi.fn(),
+  };
+});
+
+vi.mock('../utils', () => {
+  return {
+    extractAuthToken: vi.fn(),
+    validateAuthToken: vi.fn(),
+    verifyEmailToken: vi.fn(),
+    getUserFromRequest: vi.fn(),
+  };
+});
+
+// Import after mocks
+import {
+  getSession,
+  getCurrentUser,
+  getUserId,
+  extractAuthToken,
+  validateAuthToken,
+  verifyEmailToken,
+  getUserFromRequest,
+} from '../index';
+import * as sessionModule from '../session';
+import * as utilsModule from '../utils';
+
+describe('auth index utilities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getSession returns session from session module', async () => {
+    const mockSession = { userId: 'abc' } as any;
+    (sessionModule.getCurrentSession as any).mockResolvedValue(mockSession);
+    const result = await getSession();
+    expect(sessionModule.getCurrentSession).toHaveBeenCalled();
+    expect(result).toBe(mockSession);
+  });
+
+  it('getCurrentUser returns user from session module', async () => {
+    const mockUser = { id: 'u1' } as any;
+    (sessionModule.getCurrentUser as any).mockResolvedValue(mockUser);
+    const result = await getCurrentUser();
+    expect(sessionModule.getCurrentUser).toHaveBeenCalled();
+    expect(result).toBe(mockUser);
+  });
+
+  it('getUserId resolves id from session module', async () => {
+    const mockUser = { id: 'u2' } as any;
+    (sessionModule.getCurrentUser as any).mockResolvedValue(mockUser);
+    const id = await getUserId();
+    expect(id).toBe('u2');
+  });
+
+  it('re-exports token utilities', () => {
+    expect(extractAuthToken).toBe(utilsModule.extractAuthToken);
+    expect(validateAuthToken).toBe(utilsModule.validateAuthToken);
+    expect(verifyEmailToken).toBe(utilsModule.verifyEmailToken);
+    expect(getUserFromRequest).toBe(utilsModule.getUserFromRequest);
+  });
+});

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -2,6 +2,24 @@ import { cookies } from 'next/headers';
 import { createServerClient } from '@supabase/ssr';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
+import type { CurrentSession } from './session';
+import {
+  getCurrentSession,
+  getCurrentUser as sessionGetCurrentUser,
+  getSessionFromRequest,
+  isSessionValid,
+  refreshSession,
+  handleSessionTimeout,
+  persistSession,
+} from './session';
+import {
+  extractAuthToken,
+  validateAuthToken,
+  verifyEmailToken,
+  getUserFromRequest,
+  type AuthenticatedUser,
+} from './utils';
+
 // Export an empty object to satisfy existing imports while the codebase
 // migrates away from NextAuth. Supabase is now used for authentication.
 /**
@@ -35,6 +53,45 @@ export async function signOut(): Promise<void> {
   const supabase = getSupabaseServerClient();
   await supabase.auth.signOut();
 }
+
+/**
+ * Retrieve the current authentication session.
+ */
+export async function getSession(): Promise<CurrentSession | null> {
+  return getCurrentSession();
+}
+
+/**
+ * Resolve the authenticated user from the current session.
+ */
+export async function getCurrentUser() {
+  return sessionGetCurrentUser();
+}
+
+/**
+ * Convenience helper that returns only the authenticated user id.
+ */
+export async function getUserId(): Promise<string | null> {
+  const user = await sessionGetCurrentUser();
+  return user?.id ?? null;
+}
+
+export {
+  // Session helpers
+  getCurrentSession,
+  getSessionFromRequest,
+  isSessionValid,
+  refreshSession,
+  handleSessionTimeout,
+  persistSession,
+  // Token utilities
+  extractAuthToken,
+  validateAuthToken,
+  verifyEmailToken,
+  getUserFromRequest,
+};
+
+export type { CurrentSession, AuthenticatedUser };
 
 export * from './supabase-auth.config';
 export { initializeSupabaseAuth } from './initialize-supabase-auth';


### PR DESCRIPTION
## Summary
- expose Supabase session helpers and token utilities from `src/lib/auth`
- add tests for the new helpers

## Testing
- `vitest run --coverage` *(fails: No "Circle" export is defined on the "lucide-react" mock)*