### PR TITLE
Add Supabase auth middleware adapter

### DIFF
--- a/app/api/admin/dashboard/__tests__/route.test.ts
+++ b/app/api/admin/dashboard/__tests__/route.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GET } from '../route';
-import { getServerSession } from 'next-auth';
+import { getServerSession } from '@/middleware/auth-adapter';
 import { prisma } from '@/lib/database/prisma';
 import { checkRolePermission } from '@/lib/rbac/roleService';
 
 // Mock dependencies
-vi.mock('next-auth', () => ({
-  getServerSession: vi.fn()
+vi.mock('@/middleware/auth-adapter', () => ({
+  getServerSession: vi.fn(),
 }));
 
 vi.mock('@/lib/prisma', () => ({

--- a/app/api/admin/dashboard/route.ts
+++ b/app/api/admin/dashboard/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse, NextRequest } from 'next/server';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth/index';
+import { getServerSession } from '@/middleware/auth-adapter';
 import { prisma } from '@/lib/database/prisma';
 import { checkRolePermission } from '@/lib/rbac/roleService';
 import { Role } from '@/types/rbac';
@@ -9,7 +8,7 @@ import { withErrorHandling } from '@/middleware/error-handling';
 async function handleGet() {
   try {
     // Get the current session
-    const session = await getServerSession(authOptions);
+    const session = await getServerSession();
     if (!session?.user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/api/team/invites/__tests__/route.test.ts
+++ b/app/api/team/invites/__tests__/route.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../route';
 import { prisma } from '@/lib/database/prisma';
-import { getServerSession } from 'next-auth';
+import { getServerSession } from '@/middleware/auth-adapter';
 import { sendTeamInviteEmail } from '@/lib/email/teamInvite';
 import { generateInviteToken } from '@/lib/utils/token';
 import { ERROR_CODES } from '@/lib/api/common';
 
 // Mock dependencies
-vi.mock('next-auth', () => ({
+vi.mock('@/middleware/auth-adapter', () => ({
   getServerSession: vi.fn(),
 }));
 

--- a/app/api/team/invites/accept/__tests__/route.test.ts
+++ b/app/api/team/invites/accept/__tests__/route.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../route';
 import { prisma } from '@/lib/prisma';
-import { getServerSession } from 'next-auth';
+import { getServerSession } from '@/middleware/auth-adapter';
 import { ERROR_CODES } from '@/lib/api/common';
 
 // Mock dependencies
-vi.mock('next-auth', () => ({
+vi.mock('@/middleware/auth-adapter', () => ({
   getServerSession: vi.fn(),
 }));
 

--- a/app/api/team/invites/accept/route.ts
+++ b/app/api/team/invites/accept/route.ts
@@ -1,8 +1,7 @@
 import { type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { prisma } from '@/lib/database/prisma';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth/index';
+import { getServerSession } from '@/middleware/auth-adapter';
 import { createSuccessResponse, ApiError, ERROR_CODES } from '@/lib/api/common';
 import { withErrorHandling } from '@/middleware/error-handling';
 import { withValidation } from '@/middleware/validation';
@@ -12,7 +11,7 @@ import { withSecurity } from '@/middleware/with-security';
 const acceptInviteSchema = z.object({ token: z.string() });
 
 async function handleAccept(req: NextRequest, data: z.infer<typeof acceptInviteSchema>) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user) {
     throw new ApiError(ERROR_CODES.UNAUTHORIZED, 'Unauthorized', 401);
   }

--- a/app/api/team/invites/route.ts
+++ b/app/api/team/invites/route.ts
@@ -5,8 +5,7 @@ import { generateInviteToken } from '@/lib/utils/token';
 import { sendTeamInviteEmail } from '@/lib/email/teamInvite';
 import { createProtectedHandler } from '@/middleware/permissions';
 import { Permission } from '@/lib/rbac/roles';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth/index';
+import { getServerSession } from '@/middleware/auth-adapter';
 import { createSuccessResponse, ApiError, ERROR_CODES } from '@/lib/api/common';
 import { withErrorHandling } from '@/middleware/error-handling';
 import { withValidation } from '@/middleware/validation';
@@ -35,7 +34,7 @@ async function listInvites(req: NextRequest) {
 }
 
 async function handleInvite(req: NextRequest, data: z.infer<typeof inviteSchema>) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user?.email || !session?.user?.id) {
     throw new ApiError(ERROR_CODES.UNAUTHORIZED, 'Unauthorized', 401);
   }

--- a/app/api/team/members/[memberId]/__tests__/route.test.ts
+++ b/app/api/team/members/[memberId]/__tests__/route.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DELETE } from '../route';
-import { getServerSession } from 'next-auth';
+import { getServerSession } from '@/middleware/auth-adapter';
 import { prisma } from '@/lib/database/prisma';
 import { hasPermission } from '@/lib/auth/hasPermission';
 
-vi.mock('next-auth');
+vi.mock('@/middleware/auth-adapter');
 vi.mock('@/lib/database/prisma');
 vi.mock('@/lib/auth/hasPermission');
 

--- a/app/api/team/members/[memberId]/role/__tests__/route.test.ts
+++ b/app/api/team/members/[memberId]/role/__tests__/route.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PATCH } from '../route';
 import { prisma } from '@/lib/database/prisma';
-import { getServerSession } from 'next-auth';
+import { getServerSession } from '@/middleware/auth-adapter';
 import { NextResponse } from 'next/server';
 
 // Mock dependencies
-vi.mock('next-auth', () => ({
+vi.mock('@/middleware/auth-adapter', () => ({
   getServerSession: vi.fn(),
 }));
 

--- a/app/api/team/members/[memberId]/role/route.ts
+++ b/app/api/team/members/[memberId]/role/route.ts
@@ -1,8 +1,7 @@
 import { type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { prisma } from '@/lib/database/prisma';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
+import { getServerSession } from '@/middleware/auth-adapter';
 import { logUserAction } from '@/lib/audit/auditLogger';
 import { createSuccessResponse, ApiError, ERROR_CODES } from '@/lib/api/common';
 import { withErrorHandling } from '@/middleware/error-handling';
@@ -19,7 +18,7 @@ async function handlePatch(
   data: z.infer<typeof updateRoleSchema>,
   memberId: string
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user) {
     await logUserAction({
       action: 'TEAM_ROLE_UPDATE_ATTEMPT',

--- a/app/api/team/members/[memberId]/route.ts
+++ b/app/api/team/members/[memberId]/route.ts
@@ -1,6 +1,5 @@
 import { type NextRequest } from 'next/server';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
+import { getServerSession } from '@/middleware/auth-adapter';
 import { prisma } from '@/lib/database/prisma';
 import { hasPermission } from '@/lib/auth/hasPermission';
 import { z } from 'zod';
@@ -16,7 +15,7 @@ async function handleDelete(
   req: NextRequest,
   params: z.infer<typeof paramSchema>
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user) {
     throw new ApiError(ERROR_CODES.UNAUTHORIZED, 'Authentication required', 401);
   }

--- a/app/api/team/members/__tests__/route.test.ts
+++ b/app/api/team/members/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
-import { getServerSession } from 'next-auth';
+import { getServerSession } from '@/middleware/auth-adapter';
 import { prisma } from '@/lib/database/prisma';
 import { GET, POST } from '../route';
 import { ERROR_CODES } from '@/lib/api/common';
@@ -8,7 +8,7 @@ import { getApiAuthService } from '@/services/auth/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
 
 // Mocks
-vi.mock('next-auth', () => ({
+vi.mock('@/middleware/auth-adapter', () => ({
   getServerSession: vi.fn(),
 }));
 

--- a/app/api/team/members/route.ts
+++ b/app/api/team/members/route.ts
@@ -1,6 +1,5 @@
 import { type NextRequest } from 'next/server';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth/index';
+import { getServerSession } from '@/middleware/auth-adapter';
 import { prisma } from '@/lib/database/prisma';
 import { z } from 'zod';
 import { createSuccessResponse, ApiError, ERROR_CODES } from '@/lib/api/common';
@@ -27,7 +26,7 @@ async function handleTeamMembers(
   _ctx: any,
   data: z.infer<typeof querySchema>
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user) {
     throw new ApiError(ERROR_CODES.UNAUTHORIZED, 'Authentication required', 401);
   }
@@ -147,7 +146,7 @@ async function handleAddMember(
   _ctx: any,
   data: z.infer<typeof addMemberSchema>
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user) {
     throw new ApiError(ERROR_CODES.UNAUTHORIZED, 'Authentication required', 401);
   }

--- a/src/middleware/__tests__/auth-adapter.test.ts
+++ b/src/middleware/__tests__/auth-adapter.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getServerSession } from '../auth-adapter';
+import { getCurrentSession, getSessionFromRequest } from '@/lib/auth/session';
+import { getApiPermissionService } from '@/services/permission/factory';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/auth/session');
+vi.mock('@/services/permission/factory');
+
+const mockPermissionService = {
+  getUserRoles: vi.fn(),
+  getRoleById: vi.fn(),
+};
+
+describe('auth-adapter', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getApiPermissionService).mockReturnValue(mockPermissionService as any);
+  });
+
+  it('returns session with user data', async () => {
+    vi.mocked(getCurrentSession).mockResolvedValue({
+      userId: '1',
+      email: 't@example.com',
+      role: 'user',
+      accessToken: 'token',
+      expiresAt: Date.now() + 1000,
+    } as any);
+    mockPermissionService.getUserRoles.mockResolvedValue([{ roleId: 'r1', roleName: 'USER' }]);
+    mockPermissionService.getRoleById.mockResolvedValue({ permissions: ['READ'] });
+
+    const session = await getServerSession();
+    expect(session).toEqual({
+      user: { id: '1', email: 't@example.com', role: 'USER', permissions: ['READ'] },
+    });
+  });
+
+  it('uses request when provided', async () => {
+    const req = new NextRequest('http://localhost');
+    vi.mocked(getSessionFromRequest).mockResolvedValue({
+      userId: '2',
+      email: 'a@b.c',
+      role: 'user',
+      accessToken: 'tok',
+      expiresAt: Date.now() + 1000,
+    } as any);
+    mockPermissionService.getUserRoles.mockResolvedValue([]);
+
+    const session = await getServerSession(req);
+    expect(getSessionFromRequest).toHaveBeenCalledWith(req);
+    expect(session).toEqual({
+      user: { id: '2', email: 'a@b.c', role: undefined, permissions: [] },
+    });
+  });
+
+  it('returns null when session expired', async () => {
+    vi.mocked(getCurrentSession).mockResolvedValue({
+      userId: '1',
+      email: 't@example.com',
+      role: 'user',
+      accessToken: 'token',
+      expiresAt: Date.now() - 1000,
+    } as any);
+
+    const session = await getServerSession();
+    expect(session).toBeNull();
+  });
+});

--- a/src/middleware/auth-adapter.ts
+++ b/src/middleware/auth-adapter.ts
@@ -1,0 +1,56 @@
+import { type NextRequest } from 'next/server';
+import { getApiPermissionService } from '@/services/permission/factory';
+import { getCurrentSession, getSessionFromRequest } from '@/lib/auth/session';
+import type { CurrentSession } from '@/lib/auth/session';
+export type { RouteAuthContext, RouteAuthOptions } from './auth';
+export { withRouteAuth, withAuthRequest } from './auth';
+
+/**
+ * Shape of the session object returned by {@link getServerSession}.
+ */
+export interface AdapterSession {
+  user: {
+    id: string;
+    email: string;
+    role: string | undefined;
+    permissions: string[];
+  };
+}
+
+async function buildSession(session: CurrentSession): Promise<AdapterSession> {
+  const permissionService = getApiPermissionService();
+  const roles = await permissionService.getUserRoles(session.userId);
+  const roleName = roles[0]?.roleName || roles[0]?.role?.name;
+
+  const permissionsSet = new Set<string>();
+  for (const r of roles) {
+    const role = await permissionService.getRoleById(r.roleId);
+    role?.permissions.forEach(p => permissionsSet.add(p));
+  }
+
+  return {
+    user: {
+      id: session.userId,
+      email: session.email,
+      role: roleName,
+      permissions: Array.from(permissionsSet),
+    },
+  };
+}
+
+/**
+ * Replacement for `next-auth`\'s `getServerSession` using Supabase auth.
+ *
+ * The optional parameter is kept for compatibility but ignored.
+ */
+export async function getServerSession(
+  req?: NextRequest | any
+): Promise<AdapterSession | null> {
+  const baseSession: CurrentSession | null = req
+    ? await getSessionFromRequest(req as NextRequest)
+    : await getCurrentSession();
+
+  if (!baseSession) return null;
+  if (baseSession.expiresAt <= Date.now()) return null;
+  return buildSession(baseSession);
+}


### PR DESCRIPTION
## Summary
- create `auth-adapter` for Supabase session handling
- update API routes to use new `getServerSession`
- adapt tests to mock the new adapter
- document usage of the adapter

## Testing
- `npx vitest run --coverage`