### PR TITLE
Refactor company routes to use middleware chain

### DIFF
--- a/app/api/company/documents/[documentId]/route.ts
+++ b/app/api/company/documents/[documentId]/route.ts
@@ -2,8 +2,17 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServiceSupabase } from '@/lib/database/supabase';
 import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
-import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
-import { withErrorHandling } from '@/middleware/error-handling';
+import { type RouteAuthContext } from '@/middleware/auth';
+import {
+  createMiddlewareChain,
+  errorHandlingMiddleware,
+  routeAuthMiddleware,
+} from '@/middleware/createMiddlewareChain';
+
+const middleware = createMiddlewareChain([
+  errorHandlingMiddleware(),
+  routeAuthMiddleware(),
+]);
 
 // --- DELETE Handler for removing company documents ---
 async function handleDelete(
@@ -73,8 +82,4 @@ async function handleDelete(
 export const DELETE = (
   req: NextRequest,
   ctx: { params: { documentId: string } }
-) =>
-  withErrorHandling(
-    (r) => withRouteAuth((r2, auth) => handleDelete(r2, ctx.params, auth), r),
-    req
-  );
+) => middleware((r, auth) => handleDelete(r, ctx.params, auth))(req);

--- a/app/api/company/domains/[id]/verify-check/route.ts
+++ b/app/api/company/domains/[id]/verify-check/route.ts
@@ -2,11 +2,20 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServiceSupabase } from '@/lib/database/supabase';
 import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
-import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
-import { withErrorHandling } from '@/middleware/error-handling';
+import { type RouteAuthContext } from '@/middleware/auth';
+import {
+  createMiddlewareChain,
+  errorHandlingMiddleware,
+  routeAuthMiddleware,
+} from '@/middleware/createMiddlewareChain';
 import dns from 'dns/promises';
 
 const supabaseService = getServiceSupabase();
+
+const middleware = createMiddlewareChain([
+  errorHandlingMiddleware(),
+  routeAuthMiddleware(),
+]);
 
 async function handlePost(
   request: NextRequest,
@@ -108,6 +117,5 @@ async function handlePost(
 export const POST = (
   req: NextRequest,
   ctx: { params: { id: string } }
-) =>
-  withErrorHandling((r) => withRouteAuth((r2, auth) => handlePost(r2, ctx.params, auth), r), req);
+) => middleware((r, auth) => handlePost(r, ctx.params, auth))(req);
 

--- a/app/api/company/profile/route.ts
+++ b/app/api/company/profile/route.ts
@@ -43,7 +43,8 @@ const CompanyProfileUpdateSchema = z.object({
 });
 
 type CompanyProfileUpdateRequest = z.infer<typeof CompanyProfileUpdateSchema>;
-const middleware = createMiddlewareChain([
+
+const baseMiddleware = createMiddlewareChain([
   errorHandlingMiddleware(),
   routeAuthMiddleware(),
 ]);
@@ -150,13 +151,13 @@ async function handlePost(
   }
 }
 // Update middleware chain to include validation
-const middleware = createMiddlewareChain([
+const postMiddleware = createMiddlewareChain([
   errorHandlingMiddleware(),
   routeAuthMiddleware(),
   validationMiddleware(CompanyProfileSchema)
 ]);
 
-export const POST = middleware(handlePost);
+export const POST = postMiddleware(handlePost);
 
 
 async function handleGet(request: NextRequest, auth: RouteAuthContext) {
@@ -184,7 +185,7 @@ async function handleGet(request: NextRequest, auth: RouteAuthContext) {
   }
 }
 
-export const GET = middleware(handleGet);
+export const GET = baseMiddleware(handleGet);
 
 async function handlePut(
   request: NextRequest,
@@ -424,4 +425,4 @@ async function handleDelete(request: NextRequest, auth: RouteAuthContext) {
   }
 }
 
-export const DELETE = middleware(handleDelete);
+export const DELETE = baseMiddleware(handleDelete);


### PR DESCRIPTION
## Summary
- refactor company profile API to use middleware chain consistently
- update company domains API and ID endpoints to apply middleware chain
- switch domain verification routes to middleware chain
- apply middleware chain to company address endpoints
- unify documents routes with middleware chain

## Testing
- `npm run test:coverage` *(fails: JavaScript heap out of memory)*