### PR TITLE
Refactor team routes to unified middleware

### DIFF
--- a/app/api/team/[teamId]/route.ts
+++ b/app/api/team/[teamId]/route.ts
@@ -1,14 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getApiTeamService } from '@/services/team/factory';
-import { withErrorHandling } from '@/middleware/error-handling';
+import {
+  createMiddlewareChain,
+  errorHandlingMiddleware,
+  routeAuthMiddleware,
+  validationMiddleware
+} from '@/middleware/createMiddlewareChain';
+import type { RouteAuthContext } from '@/middleware/auth';
 
 const UpdateTeamSchema = z.object({
   name: z.string().optional(),
   description: z.string().optional()
 });
 
-async function handleGet(req: NextRequest, { params }: { params: { teamId: string } }) {
+async function handleGet(
+  _req: NextRequest,
+  _auth: RouteAuthContext,
+  _data: unknown,
+  { params }: { params: { teamId: string } }
+) {
   const service = getApiTeamService();
   const team = await service.getTeam(params.teamId);
   if (!team) {
@@ -17,25 +28,25 @@ async function handleGet(req: NextRequest, { params }: { params: { teamId: strin
   return NextResponse.json({ team });
 }
 
-async function handlePatch(req: NextRequest, { params }: { params: { teamId: string } }) {
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
-  }
-  const parsed = UpdateTeamSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.message }, { status: 400 });
-  }
-  const result = await getApiTeamService().updateTeam(params.teamId, parsed.data);
+async function handlePatch(
+  _req: NextRequest,
+  _auth: RouteAuthContext,
+  data: z.infer<typeof UpdateTeamSchema>,
+  { params }: { params: { teamId: string } }
+) {
+  const result = await getApiTeamService().updateTeam(params.teamId, data);
   if (!result.success || !result.team) {
     return NextResponse.json({ error: result.error || 'Failed to update team' }, { status: 400 });
   }
   return NextResponse.json({ team: result.team });
 }
 
-async function handleDelete(req: NextRequest, { params }: { params: { teamId: string } }) {
+async function handleDelete(
+  _req: NextRequest,
+  _auth: RouteAuthContext,
+  _data: unknown,
+  { params }: { params: { teamId: string } }
+) {
   const result = await getApiTeamService().deleteTeam(params.teamId);
   if (!result.success) {
     return NextResponse.json({ error: result.error || 'Failed to delete team' }, { status: 400 });
@@ -43,6 +54,22 @@ async function handleDelete(req: NextRequest, { params }: { params: { teamId: st
   return NextResponse.json({ success: true });
 }
 
-export const GET = (req: NextRequest, ctx: { params: { teamId: string } }) => withErrorHandling((r) => handleGet(r, ctx), req);
-export const PATCH = (req: NextRequest, ctx: { params: { teamId: string } }) => withErrorHandling((r) => handlePatch(r, ctx), req);
-export const DELETE = (req: NextRequest, ctx: { params: { teamId: string } }) => withErrorHandling((r) => handleDelete(r, ctx), req);
+const baseMiddleware = createMiddlewareChain([
+  errorHandlingMiddleware(),
+  routeAuthMiddleware()
+]);
+
+const patchMiddleware = createMiddlewareChain([
+  errorHandlingMiddleware(),
+  routeAuthMiddleware(),
+  validationMiddleware(UpdateTeamSchema)
+]);
+
+export const GET = (req: NextRequest, ctx: { params: { teamId: string } }) =>
+  baseMiddleware((r, auth) => handleGet(r, auth, undefined, ctx))(req);
+
+export const PATCH = (req: NextRequest, ctx: { params: { teamId: string } }) =>
+  patchMiddleware((r, auth, data) => handlePatch(r, auth, data, ctx))(req);
+
+export const DELETE = (req: NextRequest, ctx: { params: { teamId: string } }) =>
+  baseMiddleware((r, auth) => handleDelete(r, auth, undefined, ctx))(req);

--- a/app/api/team/__tests__/route.test.ts
+++ b/app/api/team/__tests__/route.test.ts
@@ -2,9 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import { GET, POST } from '../route';
 import { getApiTeamService } from '@/services/team/factory';
+import { withRouteAuth } from '@/middleware/auth';
 
 vi.mock('@/services/team/factory', () => ({
   getApiTeamService: vi.fn()
+}));
+vi.mock('@/middleware/auth', () => ({
+  withRouteAuth: vi.fn((handler: any) => async (req: any) => handler(req, { userId: 'u1', role: 'user' }))
 }));
 
 describe('team API', () => {
@@ -20,7 +24,6 @@ describe('team API', () => {
 
   it('GET returns teams', async () => {
     const req = new NextRequest('http://test');
-    req.headers.set('x-user-id', 'u1');
     const res = await GET(req as any);
     expect(res.status).toBe(200);
     expect(service.getUserTeams).toHaveBeenCalledWith('u1');
@@ -28,7 +31,6 @@ describe('team API', () => {
 
   it('POST creates team', async () => {
     const req = new NextRequest('http://test', { method: 'POST', body: JSON.stringify({ name: 'My Team' }) });
-    req.headers.set('x-user-id', 'u1');
     (req as any).json = async () => ({ name: 'My Team' });
     const res = await POST(req as any);
     expect(res.status).toBe(201);

--- a/app/api/team/invites/accept/route.ts
+++ b/app/api/team/invites/accept/route.ts
@@ -1,19 +1,24 @@
 import { type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { prisma } from '@/lib/database/prisma';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth/index';
 import { createSuccessResponse, ApiError, ERROR_CODES } from '@/lib/api/common';
-import { withErrorHandling } from '@/middleware/error-handling';
-import { withValidation } from '@/middleware/validation';
 import { createTeamMemberNotFoundError } from '@/lib/api/team/error-handler';
-import { withSecurity } from '@/middleware/with-security';
+import {
+  createMiddlewareChain,
+  errorHandlingMiddleware,
+  routeAuthMiddleware,
+  validationMiddleware
+} from '@/middleware/createMiddlewareChain';
+import type { RouteAuthContext } from '@/middleware/auth';
 
 const acceptInviteSchema = z.object({ token: z.string() });
 
-async function handleAccept(req: NextRequest, data: z.infer<typeof acceptInviteSchema>) {
-  const session = await getServerSession(authOptions);
-  if (!session?.user) {
+async function handleAccept(
+  _req: NextRequest,
+  auth: RouteAuthContext,
+  data: z.infer<typeof acceptInviteSchema>
+) {
+  if (!auth.userId || !auth.user) {
     throw new ApiError(ERROR_CODES.UNAUTHORIZED, 'Unauthorized', 401);
   }
 
@@ -29,7 +34,7 @@ async function handleAccept(req: NextRequest, data: z.infer<typeof acceptInviteS
     throw new ApiError(ERROR_CODES.INVALID_REQUEST, 'Invitation has expired', 400);
   }
 
-  if (invite.invitedEmail !== session.user.email) {
+  if (invite.invitedEmail !== auth.user.email) {
     throw new ApiError(ERROR_CODES.FORBIDDEN, 'This invitation was sent to a different email address', 403);
   }
 
@@ -37,7 +42,7 @@ async function handleAccept(req: NextRequest, data: z.infer<typeof acceptInviteS
     const updated = await prisma.teamMember.update({
       where: { id: invite.id },
       data: {
-        userId: session.user.id,
+        userId: auth.userId,
         status: 'active',
         inviteToken: null,
         inviteExpires: null,
@@ -49,10 +54,10 @@ async function handleAccept(req: NextRequest, data: z.infer<typeof acceptInviteS
   }
 }
 
-async function handler(req: NextRequest) {
-  const body = await req.json();
-  return withValidation(acceptInviteSchema, handleAccept, req, body);
-}
+const middleware = createMiddlewareChain([
+  errorHandlingMiddleware(),
+  routeAuthMiddleware(),
+  validationMiddleware(acceptInviteSchema)
+]);
 
-export const POST = (req: NextRequest) =>
-  withSecurity((r) => withErrorHandling(handler, r))(req);
+export const POST = middleware(handleAccept);

--- a/app/api/team/members/__tests__/route.test.ts
+++ b/app/api/team/members/__tests__/route.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { NextRequest } from 'next/server';
-import { getServerSession } from 'next-auth';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/database/prisma';
 import { GET, POST } from '../route';
 import { ERROR_CODES } from '@/lib/api/common';
 import { getApiAuthService } from '@/services/auth/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
+import { withRouteAuth } from '@/middleware/auth';
 
 // Mocks
-vi.mock('next-auth', () => ({
-  getServerSession: vi.fn(),
+vi.mock('@/middleware/auth', () => ({
+  withRouteAuth: vi.fn((handler: any) => async (req: any) => handler(req, { userId: 'user1', role: 'user', user: { id: 'user1', email: 'test@example.com' } }))
 }));
 
 vi.mock('@/services/auth/factory', () => ({ getApiAuthService: vi.fn() }));
@@ -92,7 +92,6 @@ describe('Team Members API', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(getServerSession).mockResolvedValue(mockSession as any);
     vi.mocked(getApiAuthService).mockReturnValue({
       getSession: vi.fn().mockResolvedValue({ user: { id: 'user1' } }),
     } as any);
@@ -105,10 +104,7 @@ describe('Team Members API', () => {
   });
 
   it('returns 401 when no session exists', async () => {
-    vi.mocked(getServerSession).mockResolvedValueOnce(null);
-    vi.mocked(getApiAuthService).mockReturnValueOnce({
-      getSession: vi.fn().mockResolvedValue(null),
-    } as any);
+    vi.mocked(withRouteAuth).mockResolvedValueOnce(new NextResponse('unauth', { status: 401 }));
 
     const request = new NextRequest('http://localhost:3000/api/team/members');
     const response = await GET(request);

--- a/app/api/team/roles/route.ts
+++ b/app/api/team/roles/route.ts
@@ -1,13 +1,17 @@
-import { NextRequest } from 'next/server';
 import { createSuccessResponse } from '@/lib/api/common';
 import { getAllRoles } from '@/lib/rbac/roles';
-import { withErrorHandling } from '@/middleware/error-handling';
+import {
+  createMiddlewareChain,
+  errorHandlingMiddleware
+} from '@/middleware/createMiddlewareChain';
 
 async function handleGet() {
   const roles = getAllRoles();
   return createSuccessResponse({ roles });
 }
 
-export async function GET(req: NextRequest) {
-  return withErrorHandling(() => handleGet(), req);
-}
+const middleware = createMiddlewareChain([
+  errorHandlingMiddleware()
+]);
+
+export const GET = middleware(() => handleGet());


### PR DESCRIPTION
## Summary
- refactor team route handlers to use the middleware chain factory
- adapt tests to mock `withRouteAuth`
- ensure validation and permission checks use the new chain

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'pathname'))*