### PR TITLE
Switch admin pages to Supabase auth

### DIFF
--- a/app/admin/audit-logs/page.tsx
+++ b/app/admin/audit-logs/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { getUser } from '@/lib/auth/getUser';
+import { getSupabaseServerClient } from '@/lib/auth';
+import type { User as SupabaseUser } from '@supabase/supabase-js';
 import { hasPermission } from '@/lib/auth/hasPermission';
 import { AdminAuditLogs } from '@/ui/styled/admin/audit-logs/AdminAuditLogs';
 
@@ -11,9 +12,11 @@ export const metadata: Metadata = {
 
 export default async function AdminAuditLogsPage(): Promise<JSX.Element> {
   // Get current user and check permissions
-  const user = await getUser();
-  
-  if (!user) {
+  const supabase = getSupabaseServerClient();
+  const { data, error } = await supabase.auth.getUser();
+  const user: SupabaseUser | null = data.user;
+
+  if (error || !user) {
     redirect('/auth/login');
   }
   

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import { redirect } from 'next/navigation';
-import { getUser } from '@/lib/auth/getUser';
+import { getSupabaseServerClient } from '@/lib/auth';
+import type { User as SupabaseUser } from '@supabase/supabase-js';
 import { hasPermission } from '@/lib/auth/hasPermission';
 import Link from 'next/link';
 import { Button } from '@/ui/primitives/button';
@@ -11,13 +12,15 @@ interface AdminLayoutProps {
 }
 
 export default async function AdminLayout({ children }: AdminLayoutProps): Promise<JSX.Element> {
-  // Get current user and check permissions
-  const user = await getUser();
-  
-  if (!user) {
+  // Create a Supabase client tied to the server session
+  const supabase = getSupabaseServerClient();
+  const { data, error } = await supabase.auth.getUser();
+  const user: SupabaseUser | null = data.user;
+
+  if (error || !user) {
     redirect('/auth/login');
   }
-  
+
   // Check if user has admin access
   const isAdmin = await hasPermission(user.id, 'ADMIN_ACCESS');
   


### PR DESCRIPTION
## Summary
- update admin layout to use Supabase client to fetch user
- fetch authenticated user in admin audit log page with Supabase

## Testing
- `npx vitest run --coverage` *(fails: JavaScript heap out of memory)*