### PR TITLE
Refactor admin routes with middleware chain

### DIFF
--- a/app/api/admin/users/[id]/__tests__/route.test.ts
+++ b/app/api/admin/users/[id]/__tests__/route.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 import { GET, PUT, DELETE } from '../route';
-import { withResourcePermission } from '@/middleware/withResourcePermission';
 
-vi.mock('@/middleware/withResourcePermission');
+vi.mock('@/middleware/createMiddlewareChain', async () => {
+  const actual = await vi.importActual<any>('@/middleware/createMiddlewareChain');
+  return {
+    ...actual,
+    routeAuthMiddleware: () => (handler: any) =>
+      (req: any, ctx?: any, data?: any) =>
+        handler(req, { userId: 'u1', role: 'admin', permissions: ['admin.users.view','admin.users.update','admin.users.delete','admin.users.list'] }, data),
+  };
+});
 vi.mock('@/middleware/with-security', () => ({ withSecurity: (fn: any) => fn }));
 vi.mock('@/middleware/error-handling', () => ({ withErrorHandling: (fn: any) => fn }));
 vi.mock('@/middleware/validation', () => ({ withValidation: (_s: any, fn: any) => fn }));
@@ -13,20 +20,17 @@ vi.mock('@/lib/realtime/notifyUserChanges', () => ({ notifyUserChanges: vi.fn() 
 const req = new NextRequest('http://localhost');
 const ctx = { params: { id: '1' } } as any;
 
-it('uses withResourcePermission for GET', async () => {
-  vi.mocked(withResourcePermission).mockImplementation((h) => async () => { await h(req as any, {} as any, ctx.params); return new Response('ok'); });
+it('calls auth middleware for GET', async () => {
   await GET(req, ctx);
-  expect(withResourcePermission).toHaveBeenCalled();
+  expect(authMw).toHaveBeenCalled();
 });
 
-it('uses withResourcePermission for PUT', async () => {
-  vi.mocked(withResourcePermission).mockImplementation(() => async () => new Response('ok'));
+it('calls auth middleware for PUT', async () => {
   await PUT(req, ctx);
-  expect(withResourcePermission).toHaveBeenCalled();
+  expect(authMw).toHaveBeenCalled();
 });
 
-it('uses withResourcePermission for DELETE', async () => {
-  vi.mocked(withResourcePermission).mockImplementation((h) => async () => { await h(req as any, {} as any, ctx.params); return new Response('ok'); });
+it('calls auth middleware for DELETE', async () => {
   await DELETE(req, ctx);
-  expect(withResourcePermission).toHaveBeenCalled();
+  expect(authMw).toHaveBeenCalled();
 });

--- a/app/api/admin/users/__tests__/route.test.ts
+++ b/app/api/admin/users/__tests__/route.test.ts
@@ -5,6 +5,15 @@ import { GET } from '../route';
 vi.mock('@/lib/database/supabase', () => ({
   getServiceSupabase: vi.fn(),
 }));
+vi.mock('@/middleware/createMiddlewareChain', async () => {
+  const actual = await vi.importActual<any>('@/middleware/createMiddlewareChain');
+  return {
+    ...actual,
+    routeAuthMiddleware: () => (handler: any) =>
+      (req: any, ctx?: any, data?: any) =>
+        handler(req, { userId: 'u1', role: 'admin', permissions: ['admin.users.list'] }, data),
+  };
+});
 
 import { getServiceSupabase } from '@/lib/database/supabase';
 


### PR DESCRIPTION
## Summary
- standardize admin routes to use `createMiddlewareChain`
- switch to routeAuthMiddleware for permission checks
- update related tests

## Testing
- `npm run test:coverage` *(fails: many tests report errors)*