### PR TITLE
Migrate permission routes to Supabase auth

### DIFF
--- a/app/api/permissions/check/route.ts
+++ b/app/api/permissions/check/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest } from 'next/server';
+import type { User } from '@supabase/supabase-js';
 import { z } from 'zod';
 
 import { createSuccessResponse } from '@/lib/api/common';
@@ -22,10 +23,9 @@ type QueryParams = z.infer<typeof querySchema>;
 
 async function handlePermissionCheck(
   _req: NextRequest,
-  userId: string,
+  user: User,
   data: QueryParams
 ) {
-  const permissionService = getApiPermissionService();
   const { permission } = data;
 
   if (!isPermission(permission)) {
@@ -33,10 +33,17 @@ async function handlePermissionCheck(
   }
 
   try {
-    const hasPermission = await permissionService.hasPermission(
-      userId,
-      permission as Permission
-    );
+    const metadataPerms: string[] =
+      (user.app_metadata as any)?.permissions ?? [];
+    let hasPermission = metadataPerms.includes(permission);
+
+    if (!hasPermission) {
+      const permissionService = getApiPermissionService();
+      hasPermission = await permissionService.hasPermission(
+        user.id,
+        permission as Permission
+      );
+    }
     return createSuccessResponse({ hasPermission });
   } catch (error) {
     throw mapPermissionServiceError(error as Error);
@@ -46,11 +53,20 @@ async function handlePermissionCheck(
 export async function GET(request: NextRequest) {
   return withErrorHandling(
     (req) =>
-      withRouteAuth((r, ctx) => {
-        const url = new URL(r.url);
-        const params = Object.fromEntries(url.searchParams.entries());
-        return withValidation(querySchema, (r2, data) => handlePermissionCheck(r2, ctx.userId!, data), r, params);
-      }, req),
+      withRouteAuth(
+        (r, ctx) => {
+          const url = new URL(r.url);
+          const params = Object.fromEntries(url.searchParams.entries());
+          return withValidation(
+            querySchema,
+            (r2, data) => handlePermissionCheck(r2, ctx.user!, data),
+            r,
+            params
+          );
+        },
+        req,
+        { includeUser: true }
+      ),
     request
   );
 }

--- a/docs/Product documentation/auth-roles.md
+++ b/docs/Product documentation/auth-roles.md
@@ -17,3 +17,17 @@ Authenticated users have the following structure in our system:
     role: 'admin'            // This is our custom role used for permissions
   }
 }
+```
+
+## Permission Extraction
+
+When routes use `withRouteAuth`, the returned context includes the Supabase user
+object. Custom roles and permissions are stored in `user.app_metadata`.
+
+1. Call `withRouteAuth` with `{ includeUser: true }` to access the full user.
+2. Read `user.app_metadata.permissions` for assigned permissions.
+3. If no permissions are present, fall back to the permission service for a
+   database lookup.
+
+This approach keeps our RBAC service in place while enabling quick checks from
+token metadata.


### PR DESCRIPTION
## Summary
- validate permissions using Supabase user metadata
- drop NextAuth fallbacks from team members endpoint
- document how to read permissions from Supabase user objects

## Testing
- `vitest run --coverage app/api/permissions/check/__tests__/route.test.ts app/api/team/members/__tests__/route.test.ts` *(fails: API error due to mocking and validation issues)*