### PR TITLE
Update middleware chain tests

### DIFF
--- a/app/api/company/domains/[id]/__tests__/route.test.ts
+++ b/app/api/company/domains/[id]/__tests__/route.test.ts
@@ -1,23 +1,57 @@
-import { it, expect, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { DELETE, PATCH } from '../route';
-import { withResourcePermission } from '@/middleware/withResourcePermission';
+import { getServiceSupabase } from '@/lib/database/supabase';
+import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
 
-vi.mock('@/middleware/withResourcePermission');
-vi.mock('@/middleware/error-handling', () => ({ withErrorHandling: (fn: any) => fn }));
 vi.mock('@/middleware/rate-limit', () => ({ checkRateLimit: vi.fn().mockResolvedValue(false) }));
-vi.mock('@/lib/database/supabase', () => ({ getServiceSupabase: () => ({ from: vi.fn().mockReturnThis(), select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), single: vi.fn().mockResolvedValue({ data: { is_primary: false, company_profiles: { id: 'c', user_id: '1' } }, error: null }), update: vi.fn().mockReturnThis(), delete: vi.fn().mockReturnThis() }) }));
-
-const req = {} as any;
-const ctx = { params: { id: '1' } } as any;
-
-it('uses withResourcePermission for DELETE', async () => {
-  vi.mocked(withResourcePermission).mockImplementation((h) => async () => { await h(req as any, {} as any, ctx.params); return new Response('ok'); });
-  await DELETE(req, ctx);
-  expect(withResourcePermission).toHaveBeenCalled();
+vi.mock('@/lib/database/supabase', () => {
+  const client = {
+    from: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn(),
+  };
+  return { getServiceSupabase: vi.fn(() => client) };
 });
+vi.mock("@/middleware/auth", () => ({ withRouteAuth: vi.fn((h: any, r: any) => h(r, { userId: "user-1" })) }));
 
-it('uses withResourcePermission for PATCH', async () => {
-  vi.mocked(withResourcePermission).mockImplementation((h) => async () => { await h(req as any, {} as any, ctx.params); return new Response('ok'); });
-  await PATCH(req, ctx);
-  expect(withResourcePermission).toHaveBeenCalled();
+describe('Company Domain By ID API', () => {
+  const id = 'domain-1';
+  const ctx = { params: { id } } as any;
+  let supabase: any;
+
+  beforeEach(() => {
+    supabase = getServiceSupabase();
+    vi.resetAllMocks();
+
+    supabase.from.mockReturnThis();
+    supabase.select.mockReturnThis();
+    supabase.update.mockReturnThis();
+    supabase.delete.mockReturnThis();
+    supabase.eq.mockReturnThis();
+    supabase.single.mockResolvedValue({
+      data: { id, is_primary: false, company_profiles: { id: 'c', user_id: 'user-1' } },
+      error: null
+    });
+  });
+
+  it('deletes a domain successfully', async () => {
+    supabase.delete.mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+
+    const request = createAuthenticatedRequest('DELETE', `http://localhost/${id}`);
+    const res = await DELETE(request, ctx);
+
+    expect(res.status).toBe(200);
+  });
+
+  it('updates a domain successfully', async () => {
+    supabase.update.mockImplementation(() => ({ eq: vi.fn().mockReturnThis(), select: vi.fn().mockReturnThis(), single: vi.fn().mockResolvedValue({ data: { id, is_primary: true }, error: null }) }));
+
+    const request = createAuthenticatedRequest('PATCH', `http://localhost/${id}`, { is_primary: true });
+    const res = await PATCH(request, ctx);
+
+    expect(res.status).toBe(200);
+  });
 });

--- a/tests/utils/middleware-test-helpers.ts
+++ b/tests/utils/middleware-test-helpers.ts
@@ -1,0 +1,29 @@
+import type { RouteMiddleware, RouteHandler } from '@/middleware/createMiddlewareChain';
+import { createMiddlewareChain } from '@/middleware/createMiddlewareChain';
+import { NextRequest } from 'next/server';
+
+/**
+ * Helper to execute a set of middlewares with a handler for testing.
+ * @param middlewares Middleware functions to run.
+ * @param handler Final route handler.
+ * @param req Request to pass to the chain.
+ * @param ctx Optional context passed to the handler.
+ */
+export async function runMiddlewareChain(
+  middlewares: RouteMiddleware[],
+  handler: RouteHandler,
+  req: NextRequest,
+  ctx?: any
+) {
+  const chain = createMiddlewareChain(middlewares);
+  return chain(handler)(req, ctx);
+}
+
+/**
+ * Creates a mock handler that resolves with a JSON response.
+ * @param status HTTP status to return.
+ * @param body Optional JSON body.
+ */
+export function createJsonHandler(status = 200, body: unknown = null): RouteHandler {
+  return async () => new Response(body ? JSON.stringify(body) : null, { status });
+}


### PR DESCRIPTION
## Summary
- add helper to run middleware chains in tests
- update domain-by-id route tests for middleware chain

## Testing
- `npx vitest run app/api/company/domains/[id]/__tests__/route.test.ts`
- `npx vitest run --coverage app/api/company/domains/[id]/__tests__/route.test.ts`
