### PR TITLE
Add Supabase auth test utilities

### DIFF
--- a/docs/Testing documentation/supabase-auth-test-utils.md
+++ b/docs/Testing documentation/supabase-auth-test-utils.md
@@ -1,0 +1,58 @@
+# Supabase Auth Test Utilities
+
+This document explains the helper functions in
+`src/tests/utils/supabase-auth-utils.ts` used for testing
+Supabase authentication logic.
+
+## Overview
+
+The utilities provide a lightweight way to generate tokens, create mock
+Supabase users and sessions, and simulate common authentication states or
+errors. They are designed to work with the global Supabase mock defined in
+`src/tests/mocks/supabase.ts`.
+
+## API
+
+### `generateTestJwt(payload?: Record<string, unknown>): string`
+Returns a base64 encoded string representing a simple JWT payload. It is
+**not** cryptographically signed and should only be used in tests.
+
+### `createMockSupabaseUser(overrides?: Partial<User>): User`
+Creates a mock `User` object with sensible defaults. Pass an object to
+`overrides` to customise specific fields, such as the custom role stored in
+`app_metadata`.
+
+### `createMockSupabaseSession(user?: User, overrides?: Partial<Session>): Session`
+Generates a mock `Session` for the supplied user. You can override any of the
+session fields if needed.
+
+### `mockSupabaseUserRole(role: string, overrides?: Partial<User>): User`
+Configures the Supabase client mock so that `supabase.auth.getUser` resolves to a
+user with the specified role. Returns the generated user for convenience.
+
+### `mockAuthError(message?: string): AuthError`
+Forces `supabase.auth.getUser` to reject with an authentication error. Useful for
+error and edge case tests.
+
+### `mockExpiredToken()`
+Convenience wrapper around `mockAuthError('Token expired')`.
+
+## Example
+
+```ts
+import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
+import {
+  mockSupabaseUserRole,
+  generateTestJwt,
+} from '@/tests/utils/supabase-auth-utils';
+
+// Mock an admin user
+const admin = mockSupabaseUserRole('admin');
+
+// Create a request with a matching token
+const token = generateTestJwt({ sub: admin.id });
+const req = createAuthenticatedRequest('GET', '/api/admin', undefined, token);
+```
+
+These helpers should make it straightforward to cover any authentication
+scenario in your tests.

--- a/src/tests/utils/request-helpers.ts
+++ b/src/tests/utils/request-helpers.ts
@@ -1,7 +1,16 @@
 import { NextRequest } from 'next/server';
+import { generateTestJwt } from '@/tests/utils/supabase-auth-utils';
 
-export function createAuthenticatedRequest(method: string, url: string, body?: any) {
-  const init: RequestInit = { method };
+export function createAuthenticatedRequest(
+  method: string,
+  url: string,
+  body?: any,
+  token: string = generateTestJwt()
+) {
+  const init: RequestInit = {
+    method,
+    headers: { Authorization: `Bearer ${token}` },
+  };
   if (body !== undefined) {
     init.body = JSON.stringify(body);
   }

--- a/src/tests/utils/supabase-auth-utils.ts
+++ b/src/tests/utils/supabase-auth-utils.ts
@@ -1,0 +1,82 @@
+// src/tests/utils/supabase-auth-utils.ts
+// Utility helpers for Supabase authentication in tests
+
+import { vi, Mock } from 'vitest';
+import type { User, Session, AuthError } from '@supabase/supabase-js';
+import { supabase } from '@/tests/mocks/supabase';
+
+/**
+ * Generate a lightweight JWT-like string for tests.
+ * This does not perform real signing and should NEVER be used in production.
+ */
+export function generateTestJwt(payload: Record<string, unknown> = {}): string {
+  const base = {
+    sub: 'test-user',
+    exp: Math.floor(Date.now() / 1000) + 60 * 60,
+    ...payload,
+  };
+  return Buffer.from(JSON.stringify(base)).toString('base64');
+}
+
+/**
+ * Create a mock Supabase user with optional overrides.
+ */
+export function createMockSupabaseUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 'user-123',
+    email: 'user@example.com',
+    role: 'authenticated',
+    app_metadata: { role: 'user' },
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: new Date().toISOString(),
+    ...overrides,
+  } as User;
+}
+
+/**
+ * Create a mock Supabase session for the given user.
+ */
+export function createMockSupabaseSession(
+  user: User = createMockSupabaseUser(),
+  overrides: Partial<Session> = {}
+): Session {
+  return {
+    access_token: 'test-token',
+    token_type: 'bearer',
+    user,
+    refresh_token: 'refresh-token',
+    expires_in: 3600,
+    provider_token: null,
+    provider_refresh_token: null,
+    ...overrides,
+  } as Session;
+}
+
+/**
+ * Mock the Supabase client to return a user with the given role.
+ */
+export function mockSupabaseUserRole(
+  role: string,
+  overrides: Partial<User> = {}
+): User {
+  const user = createMockSupabaseUser({ app_metadata: { role }, ...overrides });
+  (supabase.auth.getUser as Mock).mockResolvedValue({ data: { user }, error: null });
+  return user;
+}
+
+/**
+ * Force `supabase.auth.getUser` to return an authentication error.
+ */
+export function mockAuthError(message = 'Invalid token'): AuthError {
+  const error: AuthError = { name: 'AuthError', message };
+  (supabase.auth.getUser as Mock).mockResolvedValue({ data: { user: null }, error });
+  return error;
+}
+
+/**
+ * Shortcut for simulating an expired token error.
+ */
+export function mockExpiredToken() {
+  return mockAuthError('Token expired');
+}


### PR DESCRIPTION
## Summary
- extend `createAuthenticatedRequest` to attach Bearer token
- add `supabase-auth-utils` with factories for tokens, users, sessions and error helpers
- document Supabase auth testing utilities

## Testing
- `npx vitest run --coverage` *(fails: JavaScript heap out of memory)*