### PR TITLE
Add configurable rate limiting

### DIFF
--- a/app/api/admin/dashboard/__tests__/route.test.ts
+++ b/app/api/admin/dashboard/__tests__/route.test.ts
@@ -20,6 +20,8 @@ vi.mock('@/middleware/createMiddlewareChain', async () => {
             user_metadata: { role: 'ADMIN', teamId: '1' }
           }
         }, data)),
+    rateLimitMiddleware: vi.fn(() => (handler: any) =>
+      (req: any, ctx?: any, data?: any) => handler(req, ctx, data)),
   };
 });
 

--- a/app/api/admin/dashboard/route.ts
+++ b/app/api/admin/dashboard/route.ts
@@ -6,6 +6,7 @@ import {
   createMiddlewareChain,
   errorHandlingMiddleware,
   routeAuthMiddleware,
+  rateLimitMiddleware,
   type RouteAuthContext,
 } from '@/middleware/createMiddlewareChain';
 
@@ -124,6 +125,7 @@ async function handleGet(_req: NextRequest, auth: RouteAuthContext) {
   }
 }
 const getMiddleware = createMiddlewareChain([
+  rateLimitMiddleware(),
   errorHandlingMiddleware(),
   routeAuthMiddleware({ includeUser: true }),
 ]);

--- a/app/api/admin/export/route.ts
+++ b/app/api/admin/export/route.ts
@@ -5,6 +5,7 @@ import {
   createMiddlewareChain,
   errorHandlingMiddleware,
   routeAuthMiddleware,
+  rateLimitMiddleware,
   type RouteAuthContext,
 } from '@/middleware/createMiddlewareChain';
 import { withSecurity } from '@/middleware/with-security';
@@ -146,6 +147,7 @@ async function handleGet(req: NextRequest, auth: RouteAuthContext) {
 }
 
 const getMiddleware = createMiddlewareChain([
+  rateLimitMiddleware(),
   errorHandlingMiddleware(),
   routeAuthMiddleware({ includeUser: true }),
 ]);

--- a/src/lib/auth/config.tsx
+++ b/src/lib/auth/config.tsx
@@ -35,8 +35,12 @@ export const authConfig = {
 
 // Rate Limiting Configuration
 export const rateLimitConfig = {
-  windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS || (15 * 60 * 1000).toString(), 10), // 15 minutes
+  windowMs: parseInt(
+    process.env.RATE_LIMIT_WINDOW_MS || (15 * 60 * 1000).toString(),
+    10
+  ), // 15 minutes
   max: parseInt(process.env.RATE_LIMIT_MAX || '100', 10), // limit each IP to 100 requests per windowMs
+  enabled: process.env.RATE_LIMIT_ENABLED !== 'false',
 };
 
 // Environment validation - check required variables

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -39,8 +39,12 @@ export const authConfig = {
 
 // Rate Limiting Configuration (used by rate-limit middleware/helper)
 export const rateLimitConfig = {
-  windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS || (15 * 60 * 1000).toString(), 10), // 15 minutes
+  windowMs: parseInt(
+    process.env.RATE_LIMIT_WINDOW_MS || (15 * 60 * 1000).toString(),
+    10
+  ), // 15 minutes
   max: parseInt(process.env.RATE_LIMIT_MAX || '100', 10), // limit each IP to 100 requests per windowMs
+  enabled: process.env.RATE_LIMIT_ENABLED !== 'false',
 };
 
 // Environment validation - check required variables for the project


### PR DESCRIPTION
## Summary
- extend rate-limit middleware to support enabled flag and merge default options with config
- expose `RATE_LIMIT_ENABLED` via config files
- apply rate limiting to admin dashboard and export API routes
- mock the new middleware in dashboard route test

## Testing
- `npx vitest run --coverage` *(fails: The environment doesn't have network access after setup)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: TS1128 errors)*