### PR TITLE
Add Supabase auth test helpers

### DIFF
--- a/src/tests/mocks/supabase-auth-provider.mock.ts
+++ b/src/tests/mocks/supabase-auth-provider.mock.ts
@@ -1,0 +1,95 @@
+import { vi, Mock } from 'vitest';
+import type { AuthDataProvider } from '@/adapters/auth/interfaces';
+import type { User, LoginPayload, RegistrationPayload, AuthResult, MFASetupResponse, MFAVerifyResponse } from '@/core/auth/models';
+
+export interface MockAuthState {
+  user: User | null;
+  token: string | null;
+  role?: string;
+  permissions?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface MockSupabaseAuthProvider extends AuthDataProvider {
+  state: MockAuthState;
+  setUser(user: User | null): void;
+}
+
+/**
+ * Create a mock implementation of {@link SupabaseAuthProvider}.
+ *
+ * The mock exposes a mutable {@link state} object to control authentication
+ * status in tests. All methods are Vitest spies so tests can assert calls.
+ */
+export function createMockSupabaseAuthProvider(
+  initialState: Partial<MockAuthState> = {},
+): MockSupabaseAuthProvider {
+  const state: MockAuthState = {
+    user: null,
+    token: null,
+    role: undefined,
+    permissions: [],
+    metadata: {},
+    ...initialState,
+  };
+
+  const provider: Partial<MockSupabaseAuthProvider> = {
+    state,
+
+    setUser(user: User | null) {
+      state.user = user;
+      state.token = user ? 'mock-token' : null;
+    },
+
+    login: vi.fn(async (_payload: LoginPayload): Promise<AuthResult> => {
+      state.user = {
+        id: 'user-123',
+        email: _payload.email,
+        firstName: '',
+        lastName: '',
+        emailVerified: true,
+        phoneNumber: '',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        lastLoginAt: new Date(),
+        mfaEnabled: false,
+        isActive: true,
+      };
+      state.token = 'mock-token';
+      return { success: true, user: state.user };
+    }),
+
+    register: vi.fn(async (_payload: RegistrationPayload): Promise<AuthResult> => {
+      return provider.login!({ email: _payload.email, password: _payload.password });
+    }),
+
+    logout: vi.fn(async () => {
+      state.user = null;
+      state.token = null;
+    }),
+
+    getCurrentUser: vi.fn(async () => state.user),
+
+    resetPassword: vi.fn(async (_email: string) => ({ success: true })),
+    updatePassword: vi.fn(async (_oldPassword: string, _newPassword: string) => {}),
+    sendVerificationEmail: vi.fn(async (_email: string) => ({ success: true })),
+    verifyEmail: vi.fn(async (_token: string) => {}),
+    sendMagicLink: vi.fn(async (_email: string) => ({ success: true })),
+    verifyMagicLink: vi.fn(async (_token: string) => ({ success: true })),
+    deleteAccount: vi.fn(async (_password?: string) => {}),
+    setupMFA: vi.fn(async (): Promise<MFASetupResponse> => ({ secret: 'secret', qrCode: 'qr' })),
+    verifyMFA: vi.fn(async (_code: string): Promise<MFAVerifyResponse> => ({ success: true, token: 'mock-token' })),
+    disableMFA: vi.fn(async (_code: string) => ({ success: true })),
+    startWebAuthnRegistration: vi.fn(async (): Promise<MFASetupResponse> => ({ secret: 'secret', qrCode: 'qr' })),
+    verifyWebAuthnRegistration: vi.fn(async (_data: unknown): Promise<MFAVerifyResponse> => ({ success: true, token: 'mock-token' })),
+    refreshToken: vi.fn(async () => ({ accessToken: 'refreshed-token', refreshToken: 'refresh', expiresAt: Date.now() + 60_000 })),
+    onAuthStateChanged: vi.fn((cb: (user: User | null) => void) => {
+      cb(state.user);
+      return vi.fn();
+    }),
+    invalidateSessions: vi.fn(async (_userId: string) => {}),
+    handleSessionTimeout: vi.fn(),
+  };
+
+  return provider as MockSupabaseAuthProvider;
+}

--- a/src/tests/utils/request-helpers.ts
+++ b/src/tests/utils/request-helpers.ts
@@ -1,9 +1,27 @@
 import { NextRequest } from 'next/server';
 
-export function createAuthenticatedRequest(method: string, url: string, body?: any) {
-  const init: RequestInit = { method };
+/**
+ * Create a request object with an Authorization header set.
+ *
+ * This helper simplifies testing authenticated API routes by
+ * automatically attaching a bearer token. Pass `null` for `token`
+ * to simulate an unauthenticated request.
+ */
+export function createAuthenticatedRequest(
+  method: string,
+  url: string,
+  body?: any,
+  token: string | null = 'test-token',
+) {
+  const headers: HeadersInit = {};
+  if (token) {
+    headers['authorization'] = `Bearer ${token}`;
+  }
+  const init: RequestInit = { method, headers };
   if (body !== undefined) {
     init.body = JSON.stringify(body);
+    headers['content-type'] = 'application/json';
   }
+
   return new NextRequest(new URL(url), init);
 }


### PR DESCRIPTION
## Summary
- implement `createMockSupabaseAuthProvider` for tests
- enhance `createAuthenticatedRequest` helper to attach bearer token

## Testing
- `npx vitest run --coverage` *(fails: environment not configured for full test run)*