### PR TITLE
Clean up auth adapter mocks in route tests

### DIFF
--- a/app/api/team/invites/__tests__/route.test.ts
+++ b/app/api/team/invites/__tests__/route.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../route';
 import { prisma } from '@/lib/database/prisma';
 import { withRouteAuth } from '@/middleware/auth';
-import { getServerSession } from '@/middleware/auth-adapter';
 import { sendTeamInviteEmail } from '@/lib/email/teamInvite';
 import { generateInviteToken } from '@/lib/utils/token';
 import { ERROR_CODES } from '@/lib/api/common';
@@ -16,10 +15,7 @@ vi.mock('@/middleware/auth', () => ({
   }))
 }));
 
-vi.mock('@/middleware/auth-adapter', () => ({
-  getServerSession: vi.fn()
-}));
-}));
+vi.mock('@/middleware/auth-adapter', () => ({}));
 
 vi.mock('@/lib/prisma', () => ({
   prisma: {

--- a/app/api/team/invites/accept/__tests__/route.test.ts
+++ b/app/api/team/invites/accept/__tests__/route.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../route';
 import { prisma } from '@/lib/prisma';
 import { withRouteAuth } from '@/middleware/auth';
-import { getServerSession } from '@/middleware/auth-adapter';
 import { NextResponse } from 'next/server';
 import { ERROR_CODES } from '@/lib/api/common';
 
@@ -15,10 +14,7 @@ vi.mock('@/middleware/auth', () => ({
   }))
 }));
 
-vi.mock('@/middleware/auth-adapter', () => ({
-  getServerSession: vi.fn()
-}));
-}));
+vi.mock('@/middleware/auth-adapter', () => ({}));
 
 vi.mock('@/lib/prisma', () => ({
   prisma: {

--- a/app/api/team/members/[memberId]/__tests__/route.test.ts
+++ b/app/api/team/members/[memberId]/__tests__/route.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DELETE } from '../route';
 // RESOLVED VERSION
-import { getServerSession } from '@/middleware/auth-adapter';
 import { prisma } from '@/lib/database/prisma';
 import { withRouteAuth } from '@/middleware/auth';
 


### PR DESCRIPTION
## Summary
- remove unused `getServerSession` imports from team route tests
- clean up auth adapter mocks in invite route tests

## Testing
- `npx vitest run --coverage` *(fails: No "Circle" export is defined on the "lucide-react" mock)*