### PR TITLE
Add WebAuthn service and tests

### DIFF
--- a/src/lib/webauthn/__tests__/webauthn.service.test.ts
+++ b/src/lib/webauthn/__tests__/webauthn.service.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock(
+  '@simplewebauthn/server',
+  () => ({
+    generateRegistrationOptions: vi.fn(async () => ({ challenge: 'reg-chal' })),
+    verifyRegistrationResponse: vi.fn(async () => ({
+      verified: true,
+      registrationInfo: {
+        credentialID: Buffer.from('cred').toString('base64'),
+        credentialPublicKey: Buffer.from('pk').toString('base64'),
+        counter: 0,
+      },
+    })),
+    generateAuthenticationOptions: vi.fn(async () => ({ challenge: 'auth-chal' })),
+    verifyAuthenticationResponse: vi.fn(async () => ({
+      verified: true,
+      authenticationInfo: { newCounter: 2 },
+    })),
+  }),
+  { virtual: true },
+);
+
+import {
+  generateRegistration,
+  verifyRegistration,
+  generateAuthentication,
+  verifyAuthentication,
+} from '../webauthn.service';
+import {
+  setTableMockData,
+  resetSupabaseMock,
+  supabase,
+} from '@/tests/mocks/supabase';
+
+describe('webauthn.service', () => {
+  beforeEach(() => {
+    resetSupabaseMock();
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'key');
+    vi.stubEnv('NEXT_PUBLIC_RP_ID', 'example.com');
+    vi.stubEnv('NEXT_PUBLIC_ORIGIN', 'https://example.com');
+    setTableMockData('webauthn_credentials', { data: [], error: null });
+    setTableMockData('webauthn_challenges', { data: [], error: null });
+  });
+
+  it('generates registration options and stores challenge', async () => {
+    const opts = await generateRegistration('user1');
+    expect(opts.challenge).toBe('reg-chal');
+    const builder = (supabase.from as any).mock.results[1].value;
+    expect(builder.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: 'user1', challenge: 'reg-chal', type: 'registration' })
+    );
+  });
+
+  it('verifies registration and saves credential', async () => {
+    setTableMockData('webauthn_challenges', {
+      data: [{ user_id: 'user1', challenge: 'reg-chal', type: 'registration' }],
+      error: null,
+    });
+    const res = await verifyRegistration('user1', {} as any);
+    expect(res.verified).toBe(true);
+  });
+
+  it('generates authentication options', async () => {
+    setTableMockData('webauthn_credentials', {
+      data: [{ credential_id: Buffer.from('cred').toString('base64'), user_id: 'user1' }],
+      error: null,
+    });
+    const opts = await generateAuthentication('user1');
+    expect(opts.challenge).toBe('auth-chal');
+  });
+
+  it('throws when no credentials for authentication', async () => {
+    await expect(generateAuthentication('user1')).rejects.toThrow('No credentials found for this user');
+  });
+
+  it('verifies authentication and updates counter', async () => {
+    setTableMockData('webauthn_challenges', {
+      data: [{ user_id: 'user1', challenge: 'auth-chal', type: 'authentication' }],
+      error: null,
+    });
+    setTableMockData('webauthn_credentials', {
+      data: {
+        credential_id: Buffer.from('cred').toString('base64'),
+        public_key: Buffer.from('pk').toString('base64'),
+        counter: 1,
+        user_id: 'user1',
+      },
+      error: null,
+    });
+    const res = await verifyAuthentication('user1', { id: 'cred' } as any);
+    expect(res.verified).toBe(true);
+  });
+});

--- a/src/lib/webauthn/webauthn.service.ts
+++ b/src/lib/webauthn/webauthn.service.ts
@@ -1,0 +1,201 @@
+import {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+} from '@simplewebauthn/server';
+import type {
+  RegistrationCredentialJSON,
+  AuthenticationCredentialJSON,
+} from '@simplewebauthn/typescript-types';
+import { getServiceSupabase } from '@/lib/database/supabase';
+
+const rpName = 'User Management System';
+const rpID = process.env.NEXT_PUBLIC_RP_ID || 'localhost';
+const origin = process.env.NEXT_PUBLIC_ORIGIN || `https://${rpID}`;
+
+export async function generateRegistration(userId: string) {
+  const supabase = getServiceSupabase();
+
+  const { data: existingCredentials } = await supabase
+    .from('webauthn_credentials')
+    .select('credential_id, public_key')
+    .eq('user_id', userId);
+
+  const excludeCredentials =
+    existingCredentials?.map((cred: any) => ({
+      id: Buffer.from(cred.credential_id, 'base64'),
+      type: 'public-key',
+    })) || [];
+
+  const options = await generateRegistrationOptions({
+    rpName,
+    rpID,
+    userID: userId,
+    attestationType: 'none',
+    excludeCredentials,
+    authenticatorSelection: {
+      userVerification: 'preferred',
+      residentKey: 'preferred',
+    },
+  });
+
+  await supabase.from('webauthn_challenges').upsert({
+    user_id: userId,
+    challenge: options.challenge,
+    expires_at: new Date(Date.now() + 5 * 60 * 1000),
+    type: 'registration',
+  });
+
+  return options;
+}
+
+export async function verifyRegistration(
+  userId: string,
+  credential: RegistrationCredentialJSON,
+) {
+  const supabase = getServiceSupabase();
+
+  const { data: challengeData, error: challengeError } = await supabase
+    .from('webauthn_challenges')
+    .select('challenge')
+    .eq('user_id', userId)
+    .eq('type', 'registration')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (challengeError || !challengeData) {
+    throw new Error('Challenge not found or expired');
+  }
+
+  const verification = await verifyRegistrationResponse({
+    credential,
+    expectedChallenge: challengeData.challenge,
+    expectedOrigin: origin,
+    expectedRPID: rpID,
+  });
+
+  if (!verification.verified || !verification.registrationInfo) {
+    throw new Error('Verification failed');
+  }
+
+  const { error: credError } = await supabase.from('webauthn_credentials').insert({
+    user_id: userId,
+    credential_id: Buffer.from(
+      verification.registrationInfo.credentialID,
+    ).toString('base64'),
+    public_key: Buffer.from(
+      verification.registrationInfo.credentialPublicKey,
+    ).toString('base64'),
+    counter: verification.registrationInfo.counter,
+    created_at: new Date().toISOString(),
+  });
+
+  if (credError) {
+    throw new Error(`Failed to store credential: ${credError.message}`);
+  }
+
+  await supabase
+    .from('webauthn_challenges')
+    .delete()
+    .eq('user_id', userId)
+    .eq('type', 'registration');
+
+  return { verified: true };
+}
+
+export async function generateAuthentication(userId: string) {
+  const supabase = getServiceSupabase();
+
+  const { data: existingCredentials } = await supabase
+    .from('webauthn_credentials')
+    .select('credential_id')
+    .eq('user_id', userId);
+
+  const allowCredentials =
+    existingCredentials?.map((cred: any) => ({
+      id: Buffer.from(cred.credential_id, 'base64'),
+      type: 'public-key',
+    })) || [];
+
+  if (allowCredentials.length === 0) {
+    throw new Error('No credentials found for this user');
+  }
+
+  const options = await generateAuthenticationOptions({
+    rpID,
+    allowCredentials,
+    userVerification: 'preferred',
+  });
+
+  await supabase.from('webauthn_challenges').upsert({
+    user_id: userId,
+    challenge: options.challenge,
+    expires_at: new Date(Date.now() + 5 * 60 * 1000),
+    type: 'authentication',
+  });
+
+  return options;
+}
+
+export async function verifyAuthentication(
+  userId: string,
+  credential: AuthenticationCredentialJSON,
+) {
+  const supabase = getServiceSupabase();
+
+  const { data: challengeData, error: challengeError } = await supabase
+    .from('webauthn_challenges')
+    .select('challenge')
+    .eq('user_id', userId)
+    .eq('type', 'authentication')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (challengeError || !challengeData) {
+    throw new Error('Challenge not found or expired');
+  }
+
+  const credentialId = Buffer.from(credential.id, 'base64').toString('base64');
+  const { data: credentialData, error: credentialError } = await supabase
+    .from('webauthn_credentials')
+    .select('credential_id, public_key, counter')
+    .eq('credential_id', credentialId)
+    .eq('user_id', userId)
+    .single();
+
+  if (credentialError || !credentialData) {
+    throw new Error('Credential not found');
+  }
+
+  const verification = await verifyAuthenticationResponse({
+    credential,
+    expectedChallenge: challengeData.challenge,
+    expectedOrigin: origin,
+    expectedRPID: rpID,
+    authenticator: {
+      credentialID: Buffer.from(credentialData.credential_id, 'base64'),
+      credentialPublicKey: Buffer.from(credentialData.public_key, 'base64'),
+      counter: credentialData.counter,
+    },
+  });
+
+  if (!verification.verified) {
+    throw new Error('Verification failed');
+  }
+
+  await supabase
+    .from('webauthn_credentials')
+    .update({ counter: verification.authenticationInfo.newCounter })
+    .eq('credential_id', credentialId);
+
+  await supabase
+    .from('webauthn_challenges')
+    .delete()
+    .eq('user_id', userId)
+    .eq('type', 'authentication');
+
+  return { verified: true };
+}

--- a/src/tests/mocks/simplewebauthn-server.ts
+++ b/src/tests/mocks/simplewebauthn-server.ts
@@ -1,0 +1,12 @@
+export function generateRegistrationOptions() {
+  throw new Error('not implemented');
+}
+export function verifyRegistrationResponse() {
+  throw new Error('not implemented');
+}
+export function generateAuthenticationOptions() {
+  throw new Error('not implemented');
+}
+export function verifyAuthenticationResponse() {
+  throw new Error('not implemented');
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
+      '@simplewebauthn/server': path.resolve(
+        __dirname,
+        'src/tests/mocks/simplewebauthn-server.ts'
+      ),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- implement WebAuthn service with registration and authentication helpers
- add Vitest coverage alias and stub for `@simplewebauthn/server`
- provide tests for the new service

## Testing
- `npx vitest run src/lib/webauthn/__tests__/webauthn.service.test.ts --coverage`