### PR TITLE
Implement WebAuthn register and verify routes

### DIFF
--- a/app/api/2fa/webauthn/register/__tests__/route.test.ts
+++ b/app/api/2fa/webauthn/register/__tests__/route.test.ts
@@ -1,9 +1,53 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../route';
+import { generateRegistration, verifyRegistration } from '@/lib/webauthn/webauthn.service';
+import { logUserAction } from '@/lib/audit/auditLogger';
+
+vi.mock('@/lib/webauthn/webauthn.service', () => ({
+  generateRegistration: vi.fn(),
+  verifyRegistration: vi.fn()
+}));
+vi.mock('@/middleware/with-security', () => ({ withSecurity: (h: any) => h }));
+vi.mock('@/middleware/createMiddlewareChain', async () => {
+  const actual = await vi.importActual<any>('@/middleware/createMiddlewareChain');
+  return {
+    ...actual,
+    routeAuthMiddleware: vi.fn(() => (handler: any) =>
+      (req: any, _ctx?: any, data?: any) => handler(req, { userId: 'u1' }, data)
+    ),
+  };
+});
+vi.mock('@/lib/audit/auditLogger', () => ({ logUserAction: vi.fn() }));
+
+const createRequest = (body: any) =>
+  new Request('http://localhost/api/2fa/webauthn/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'User-Agent': 'test' },
+    body: JSON.stringify(body)
+  });
 
 describe('WebAuthn register API', () => {
-  it('returns not implemented', async () => {
-    const res = await POST();
-    expect(res.status).toBe(501);
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns registration options', async () => {
+    vi.mocked(generateRegistration).mockResolvedValue({ challenge: 'c' } as any);
+    const res = await POST(createRequest({ phase: 'options' }) as any);
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.challenge).toBe('c');
+    expect(generateRegistration).toHaveBeenCalledWith('u1');
+  });
+
+  it('verifies registration', async () => {
+    vi.mocked(verifyRegistration).mockResolvedValue({ verified: true } as any);
+    const res = await POST(
+      createRequest({ phase: 'verification', credential: 'cred' }) as any
+    );
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.verified).toBe(true);
+    expect(verifyRegistration).toHaveBeenCalledWith('u1', 'cred');
   });
 });

--- a/app/api/2fa/webauthn/register/route.ts
+++ b/app/api/2fa/webauthn/register/route.ts
@@ -1,5 +1,94 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { generateRegistration, verifyRegistration } from '@/lib/webauthn/webauthn.service';
+import { logUserAction } from '@/lib/audit/auditLogger';
+import { withSecurity } from '@/middleware/with-security';
+import {
+  createMiddlewareChain,
+  errorHandlingMiddleware,
+  routeAuthMiddleware,
+  validationMiddleware
+} from '@/middleware/createMiddlewareChain';
+import { z } from 'zod';
 
-export async function POST(): Promise<NextResponse> {
-  return NextResponse.json({ error: 'WebAuthn registration not implemented' }, { status: 501 });
+// Schema for registration request
+const registerRequestSchema = z.object({
+  phase: z.enum(['options', 'verification']),
+  credential: z.any().optional(),
+});
+
+async function handleRegister(
+  request: NextRequest,
+  auth: any,
+  data: z.infer<typeof registerRequestSchema>
+) {
+  const userId = auth.userId;
+  if (!userId) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+  const ipAddress = request.ip || request.headers.get('x-forwarded-for') || 'unknown';
+  const userAgent = request.headers.get('user-agent') || 'unknown';
+
+  try {
+    if (data.phase === 'options') {
+      const options = await generateRegistration(userId);
+
+      await logUserAction({
+        userId,
+        action: 'WEBAUTHN_REGISTRATION_INITIATED',
+        status: 'INITIATED',
+        ipAddress,
+        userAgent,
+        targetResourceType: 'auth_method',
+        targetResourceId: userId
+      });
+
+      return NextResponse.json(options);
+    } else {
+      // Verify registration
+      if (!data.credential) {
+        return NextResponse.json({ error: 'Missing credential' }, { status: 400 });
+      }
+
+      const verification = await verifyRegistration(userId, data.credential);
+
+      await logUserAction({
+        userId,
+        action: 'WEBAUTHN_REGISTRATION_COMPLETED',
+        status: 'SUCCESS',
+        ipAddress,
+        userAgent,
+        targetResourceType: 'auth_method',
+        targetResourceId: userId
+      });
+
+      return NextResponse.json(verification);
+    }
+  } catch (error) {
+    console.error('WebAuthn registration error:', error);
+
+    await logUserAction({
+      userId,
+      action: 'WEBAUTHN_REGISTRATION_FAILED',
+      status: 'FAILURE',
+      ipAddress,
+      userAgent,
+      targetResourceType: 'auth_method',
+      targetResourceId: userId,
+      details: { error: error instanceof Error ? error.message : String(error) }
+    });
+
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'An unexpected error occurred' },
+      { status: 400 }
+    );
+  }
 }
+
+const middleware = createMiddlewareChain([
+  errorHandlingMiddleware(),
+  routeAuthMiddleware(),
+  validationMiddleware(registerRequestSchema)
+]);
+
+export const POST = withSecurity((request: NextRequest) =>
+  middleware(handleRegister)(request));

--- a/app/api/2fa/webauthn/verify/__tests__/route.test.ts
+++ b/app/api/2fa/webauthn/verify/__tests__/route.test.ts
@@ -1,9 +1,57 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../route';
+import { generateAuthentication, verifyAuthentication } from '@/lib/webauthn/webauthn.service';
+import { logUserAction } from '@/lib/audit/auditLogger';
+
+vi.mock('@/lib/webauthn/webauthn.service', () => ({
+  generateAuthentication: vi.fn(),
+  verifyAuthentication: vi.fn()
+}));
+vi.mock('@/middleware/with-security', () => ({ withSecurity: (h: any) => h }));
+vi.mock('@/middleware/createMiddlewareChain', async () => {
+  const actual = await vi.importActual<any>('@/middleware/createMiddlewareChain');
+  return {
+    ...actual,
+    // Pass-through validation middleware using actual schema parsing
+    validationMiddleware: (schema: any) => (handler: any) => async (req: any, ctx?: any) => {
+      const body = await req.json();
+      const parsed = schema.parse(body);
+      return handler(req, ctx, parsed);
+    },
+  };
+});
+vi.mock('@/lib/audit/auditLogger', () => ({ logUserAction: vi.fn() }));
+
+const createRequest = (body: any) =>
+  new Request('http://localhost/api/2fa/webauthn/verify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'User-Agent': 'test' },
+    body: JSON.stringify(body)
+  });
 
 describe('WebAuthn verify API', () => {
-  it('returns not implemented', async () => {
-    const res = await POST();
-    expect(res.status).toBe(501);
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns authentication options', async () => {
+    vi.mocked(generateAuthentication).mockResolvedValue({ challenge: 'c' } as any);
+    const res = await POST(createRequest({ phase: 'options', userId: 'u1' }) as any);
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.challenge).toBe('c');
+    expect(generateAuthentication).toHaveBeenCalledWith('u1');
+  });
+
+  it('verifies authentication', async () => {
+    vi.mocked(verifyAuthentication).mockResolvedValue({ verified: true } as any);
+    const res = await POST(
+      createRequest({ phase: 'verification', userId: 'u1', credential: 'cred' }) as any
+    );
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.verified).toBe(true);
+    expect(data.user.id).toBe('u1');
+    expect(verifyAuthentication).toHaveBeenCalledWith('u1', 'cred');
   });
 });

--- a/app/api/2fa/webauthn/verify/route.ts
+++ b/app/api/2fa/webauthn/verify/route.ts
@@ -1,5 +1,95 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { generateAuthentication, verifyAuthentication } from '@/lib/webauthn/webauthn.service';
+import { logUserAction } from '@/lib/audit/auditLogger';
+import { withSecurity } from '@/middleware/with-security';
+import {
+  createMiddlewareChain,
+  errorHandlingMiddleware,
+  validationMiddleware
+} from '@/middleware/createMiddlewareChain';
+import { z } from 'zod';
 
-export async function POST(): Promise<NextResponse> {
-  return NextResponse.json({ error: 'WebAuthn verification not implemented' }, { status: 501 });
+// Schema for verification request
+const verifyRequestSchema = z.object({
+  phase: z.enum(['options', 'verification']),
+  credential: z.any().optional(),
+  userId: z.string(),
+});
+
+async function handleVerify(
+  request: NextRequest,
+  _auth: any,
+  data: z.infer<typeof verifyRequestSchema>
+) {
+  const ipAddress = request.ip || request.headers.get('x-forwarded-for') || 'unknown';
+  const userAgent = request.headers.get('user-agent') || 'unknown';
+  const userId = data.userId;
+
+  try {
+    if (data.phase === 'options') {
+      const options = await generateAuthentication(userId);
+
+      await logUserAction({
+        action: 'WEBAUTHN_VERIFICATION_INITIATED',
+        status: 'INITIATED',
+        ipAddress,
+        userAgent,
+        targetResourceType: 'auth_method',
+        targetResourceId: userId
+      });
+
+      return NextResponse.json(options);
+    } else {
+      // Verify authentication
+      if (!data.credential) {
+        return NextResponse.json({ error: 'Missing credential' }, { status: 400 });
+      }
+
+      const verification = await verifyAuthentication(userId, data.credential);
+
+      if (verification.verified) {
+        await logUserAction({
+          action: 'WEBAUTHN_VERIFICATION_COMPLETED',
+          status: 'SUCCESS',
+          ipAddress,
+          userAgent,
+          targetResourceType: 'auth_method',
+          targetResourceId: userId
+        });
+
+        return NextResponse.json({
+          verified: true,
+          user: { id: userId }
+        });
+      } else {
+        throw new Error('Verification failed');
+      }
+    }
+  } catch (error) {
+    console.error('WebAuthn verification error:', error);
+
+    await logUserAction({
+      action: 'WEBAUTHN_VERIFICATION_FAILED',
+      status: 'FAILURE',
+      ipAddress,
+      userAgent,
+      targetResourceType: 'auth_method',
+      targetResourceId: userId,
+      details: { error: error instanceof Error ? error.message : String(error) }
+    });
+
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'An unexpected error occurred' },
+      { status: 400 }
+    );
+  }
 }
+
+const middleware = createMiddlewareChain([
+  errorHandlingMiddleware(),
+  validationMiddleware(verifyRequestSchema)
+]);
+
+// Note: Not using auth middleware because this can be called during login
+export const POST = withSecurity((request: NextRequest) =>
+  middleware(handleVerify)(request));


### PR DESCRIPTION
## Summary
- add real implementation for WebAuthn register route
- add real implementation for WebAuthn verify route
- test register route for options and verification phases
- test verify route for options and verification phases

## Testing
- `npx vitest run --coverage` *(fails: JavaScript heap out of memory)*
- `npx vitest run app/api/2fa/webauthn/register/__tests__/route.test.ts app/api/2fa/webauthn/verify/__tests__/route.test.ts --coverage` *(fails: TypeError: loginWithProvider is not a function)*