### PR TITLE
Add WebAuthn 2FA option

### DIFF
--- a/src/ui/styled/two-factor/TwoFactorSetup.tsx
+++ b/src/ui/styled/two-factor/TwoFactorSetup.tsx
@@ -6,6 +6,7 @@ import { Card } from '@/ui/primitives/card';
 import { TwoFactorSetup as HeadlessTwoFactorSetup } from '@/ui/headless/two-factor/TwoFactorSetup';
 import QRCodeDisplay from './QRCodeDisplay';
 import BackupCodesList from './BackupCodesList';
+import { WebAuthnRegistration } from './WebAuthnRegistration';
 
 export function TwoFactorSetup() {
   const [code, setCode] = useState('');
@@ -16,9 +17,15 @@ export function TwoFactorSetup() {
       {({ step, secret, qrCode, backupCodes, start, verify, cancel, loading, error }) => (
         <Card className="p-4 space-y-4 w-full max-w-md">
           {step === 'initial' && (
-            <Button onClick={start} disabled={loading} className="w-full">
-              Enable Two-Factor Authentication
-            </Button>
+            <div className="space-y-6">
+              <h2 className="text-xl font-semibold">Choose a 2FA Method</h2>
+              <Button onClick={start} disabled={loading} className="w-full">
+                Enable Two-Factor Authentication
+              </Button>
+              <div className="border p-4 rounded-md">
+                <WebAuthnRegistration />
+              </div>
+            </div>
           )}
           {step === 'verify' && (
             <div className="space-y-4">


### PR DESCRIPTION
## Summary
- integrate hardware key 2FA support
- show WebAuthn registration option in the two-factor setup UI

## Testing
- `npm run test:coverage` *(fails: JavaScript heap out of memory)*