### PR TITLE
Fix login form test

### DIFF
--- a/src/ui/headless/auth/__tests__/login-form.test.tsx
+++ b/src/ui/headless/auth/__tests__/login-form.test.tsx
@@ -91,6 +91,18 @@ function setupAuthStoreMock(authMock: any) {
   (useAuth as any).mockImplementation(() => authMock);
 }
 
+let props: any;
+const renderForm = (p = {}) =>
+  render(
+    <LoginForm
+      {...p}
+      render={(rp) => {
+        props = rp;
+        return <div />;
+      }}
+    />
+  );
+
 describe('LoginForm', () => {
   const mockLogin = vi.fn();
 


### PR DESCRIPTION
## Summary
- restore `renderForm` for login-form.test.tsx
- set up provider render for registration-form test

## Testing
- `npx vitest run src/ui/headless/auth/__tests__/login-form.test.tsx`
- `npx vitest run src/ui/headless/auth/__tests__/registration-form.test.tsx` *(fails: act errors)*

------
https://chatgpt.com/codex/tasks/task_b_683cc5ddb1e88331affe5d0af2dcbed1