### PR TITLE
Fix i18n defaults in tests

### DIFF
--- a/src/tests/i18nTestSetup.ts
+++ b/src/tests/i18nTestSetup.ts
@@ -56,7 +56,30 @@ function resolveKey(key: string, obj: any): string {
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => resolveKey(key, en),
+    t: (key: string, options?: any) => {
+      let defaultValue: string | undefined;
+      let params: Record<string, string> | undefined;
+
+      if (typeof options === 'string') {
+        defaultValue = options;
+      } else if (options) {
+        ({ defaultValue, ...params } = options);
+      }
+
+      let value = resolveKey(key, en);
+
+      if (value === key && defaultValue) {
+        value = defaultValue;
+      }
+
+      if (params) {
+        Object.entries(params).forEach(([k, v]) => {
+          value = value.replace(new RegExp(`{{${k}}}`, 'g'), String(v));
+        });
+      }
+
+      return value;
+    },
   }),
   Trans: ({ i18nKey }: { i18nKey: string }) => resolveKey(i18nKey, en),
   initReactI18next: {

--- a/src/ui/styled/profile/DataExport.tsx
+++ b/src/ui/styled/profile/DataExport.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/ui/primitives/card';
 import { Button } from '@/ui/primitives/button';
@@ -6,9 +7,18 @@ import { DataExport as DataExportHeadless } from '@/ui/headless/settings/DataExp
 
 export default function DataExport() {
   const { t } = useTranslation();
+  const [success, setSuccess] = useState<string | null>(null);
 
   return (
     <DataExportHeadless
+      onComplete={() =>
+        setSuccess(
+          t(
+            'profile.dataExport.success',
+            'Your data export has been downloaded successfully.'
+          )
+        )
+      }
       render={({ isLoading, error, handleExport }) => (
         <Card className="rounded border p-4 max-w-lg mx-auto bg-white shadow mt-6">
           <CardHeader>
@@ -20,7 +30,16 @@ export default function DataExport() {
           {error && (
             <CardContent>
               <Alert variant="destructive" role="alert">
-                <AlertDescription>{error}</AlertDescription>
+                <AlertDescription>
+                  {t('profile.dataExport.error', error)}
+                </AlertDescription>
+              </Alert>
+            </CardContent>
+          )}
+          {success && (
+            <CardContent>
+              <Alert role="status">
+                <AlertDescription>{success}</AlertDescription>
               </Alert>
             </CardContent>
           )}


### PR DESCRIPTION
## Summary
- improve `react-i18next` mocks so that default strings passed to `t` are returned when no translation exists
- update headless i18n test setup
- show success message in `DataExport` styled component

## Testing
- `npx vitest run src/ui/styled/profile/__tests__/DataExport.test.tsx` *(fails: Your data export has been downloaded successfully not found)*
- `npx vitest run src/ui/styled/profile/__tests__/NotificationPreferences.test.tsx` *(fails: multiple expectations)*
- `npx vitest run src/ui/styled/profile/__tests__/CompanyLogoUpload.test.tsx` *(fails: missing alert)*


------
https://chatgpt.com/codex/tasks/task_b_683d45eb488c8331bd1b92a6ff9be28b