### PR TITLE
Add role hierarchy service with inheritance

### DIFF
--- a/src/services/permission/permission.service.ts
+++ b/src/services/permission/permission.service.ts
@@ -186,11 +186,11 @@ export class PermissionService {
     if (error) throw error;
   }
 
-  // Grant resource-specific permission to a user
-  async grantResourcePermission(
-    userId: string, 
-    permissionId: string, 
-    resourceType: string, 
+  // Assign resource-specific permission to a user
+  async assignResourcePermission(
+    userId: string,
+    permissionId: string,
+    resourceType: string,
     resourceId: string
   ): Promise<ResourcePermission> {
     const { data, error } = await supabase
@@ -206,6 +206,43 @@ export class PermissionService {
       
     if (error) throw error;
     return data;
+  }
+
+  // Remove a resource-specific permission from a user
+  async removeResourcePermission(
+    userId: string,
+    permissionId: string,
+    resourceType: string,
+    resourceId: string
+  ): Promise<void> {
+    const { error } = await supabase
+      .from('resource_permissions')
+      .delete()
+      .eq('user_id', userId)
+      .eq('permission_id', permissionId)
+      .eq('resource_type', resourceType)
+      .eq('resource_id', resourceId);
+
+    if (error) throw error;
+  }
+
+  // Check if a user has a permission for a specific resource
+  async hasPermissionForResource(
+    userId: string,
+    permissionId: string,
+    resourceType: string,
+    resourceId: string
+  ): Promise<boolean> {
+    const { data, error } = await supabase
+      .from('resource_permissions')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('permission_id', permissionId)
+      .eq('resource_type', resourceType)
+      .eq('resource_id', resourceId)
+      .single();
+
+    return !error && !!data;
   }
 }
 

--- a/src/services/role/__tests__/default-role.service.test.ts
+++ b/src/services/role/__tests__/default-role.service.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DefaultRoleService, type RoleRecord } from '../default-role.service';
+
+describe('DefaultRoleService', () => {
+  let service: DefaultRoleService;
+  let roles: Record<string, RoleRecord>;
+
+  beforeEach(() => {
+    service = new DefaultRoleService();
+    roles = {
+      A: { id: 'A', permissionIds: ['p1', 'p2'] },
+      B: { id: 'B', permissionIds: ['p3'], parentRoleId: 'A' },
+      C: { id: 'C', permissionIds: ['p4'], parentRoleId: 'B' }
+    };
+    Object.values(roles).forEach(r => service.addRole(r));
+  });
+
+  it('returns ancestor roles in order', () => {
+    const ancestors = service.getAncestorRoles('C').map(r => r.id);
+    expect(ancestors).toEqual(['B', 'A']);
+  });
+
+  it('returns descendant roles', () => {
+    const desc = service.getDescendantRoles('A').map(r => r.id);
+    expect(desc.sort()).toEqual(['B', 'C']);
+  });
+
+  it('calculates effective permissions with inheritance', () => {
+    const perms = service.getEffectivePermissions('C');
+    expect(perms.sort()).toEqual(['p1', 'p2', 'p3', 'p4']);
+  });
+
+  it('handles circular references safely', () => {
+    service.setParentRole('A', 'C');
+    const perms = service.getEffectivePermissions('B');
+    expect(perms.sort()).toEqual(['p1', 'p2', 'p3', 'p4']);
+  });
+
+  it('setParentRole ignores unknown role', () => {
+    service.setParentRole('X', 'A');
+    expect(service.getAncestorRoles('X')).toEqual([]);
+  });
+
+  it('returns empty lists for missing relations', () => {
+    expect(service.getAncestorRoles('A')).toEqual([]);
+    expect(service.getDescendantRoles('C')).toEqual([]);
+  });
+
+  it('returns empty permissions for unknown role', () => {
+    expect(service.getEffectivePermissions('missing')).toEqual([]);
+  });
+
+  it('handles missing parent gracefully', () => {
+    service.setParentRole('B', 'X');
+    expect(service.getAncestorRoles('B')).toEqual([]);
+  });
+
+  it('uses cache on subsequent calls', () => {
+    const first = service.getEffectivePermissions('C');
+    service.setParentRole('A', null); // modify hierarchy after caching
+    const second = service.getEffectivePermissions('C');
+    expect(first).toEqual(second);
+  });
+});

--- a/src/services/role/default-role.service.ts
+++ b/src/services/role/default-role.service.ts
@@ -1,0 +1,79 @@
+export interface RoleRecord {
+  id: string;
+  permissionIds: string[];
+  parentRoleId?: string | null;
+}
+
+/**
+ * Simple in-memory role service supporting hierarchy and permission inheritance.
+ */
+export class DefaultRoleService {
+  private roles = new Map<string, RoleRecord>();
+  private permissionCache = new Map<string, string[]>();
+
+  addRole(role: RoleRecord): void {
+    this.roles.set(role.id, { ...role });
+    this.permissionCache.clear();
+  }
+
+  setParentRole(roleId: string, parentRoleId: string | null): void {
+    const role = this.roles.get(roleId);
+    if (role) {
+      role.parentRoleId = parentRoleId;
+      this.permissionCache.clear();
+    }
+  }
+
+  getAncestorRoles(roleId: string): RoleRecord[] {
+    const ancestors: RoleRecord[] = [];
+    const visited = new Set<string>();
+    let current = this.roles.get(roleId);
+    while (current?.parentRoleId) {
+      const parentId = current.parentRoleId;
+      if (!parentId || visited.has(parentId)) break;
+      visited.add(parentId);
+      const parent = this.roles.get(parentId);
+      if (!parent) break;
+      ancestors.push(parent);
+      current = parent;
+    }
+    return ancestors;
+  }
+
+  getDescendantRoles(roleId: string): RoleRecord[] {
+    const descendants: RoleRecord[] = [];
+    const visited = new Set<string>();
+    const traverse = (id: string) => {
+      for (const role of this.roles.values()) {
+        if (role.parentRoleId === id && !visited.has(role.id)) {
+          visited.add(role.id);
+          descendants.push(role);
+          traverse(role.id);
+        }
+      }
+    };
+    traverse(roleId);
+    return descendants;
+  }
+
+  getEffectivePermissions(roleId: string): string[] {
+    const resolve = (id: string, stack: Set<string>): string[] => {
+      if (this.permissionCache.has(id)) return this.permissionCache.get(id)!;
+      if (stack.has(id)) return [];
+      const role = this.roles.get(id);
+      if (!role) return [];
+      stack.add(id);
+      const perms = new Set(role.permissionIds);
+      if (role.parentRoleId) {
+        for (const p of resolve(role.parentRoleId, stack)) {
+          perms.add(p);
+        }
+      }
+      stack.delete(id);
+      const arr = Array.from(perms);
+      this.permissionCache.set(id, arr);
+      return arr;
+    };
+    return resolve(roleId, new Set());
+  }
+}

--- a/src/services/role/index.ts
+++ b/src/services/role/index.ts
@@ -1,0 +1,2 @@
+export { DefaultRoleService } from './default-role.service';
+export type { RoleRecord } from './default-role.service';

--- a/src/types/rbac.ts
+++ b/src/types/rbac.ts
@@ -124,4 +124,14 @@ export interface RoleFeatures {
     permissions: Permission[];
     description: string;
   };
-} 
+}
+
+// Resource-specific permission assignment
+export interface ResourcePermission {
+  id: string;
+  userId: string;
+  permissionId: string;
+  resourceType: string;
+  resourceId: string;
+  createdAt?: string | Date;
+}


### PR DESCRIPTION
## Summary
- implement DefaultRoleService with parent/child management and permission inheritance
- add resource permission helpers to PermissionService
- define `ResourcePermission` type
- test role service logic

## Testing
- `npx vitest run src/services/role/__tests__/default-role.service.test.ts --coverage`

------
https://chatgpt.com/codex/tasks/task_b_683d9d312e0483319333f81bb42234ac