### PR TITLE
Implement role hierarchy methods

### DIFF
--- a/src/services/role/__tests__/role.service.test.ts
+++ b/src/services/role/__tests__/role.service.test.ts
@@ -68,4 +68,67 @@ describe('RoleService', () => {
     const service = new RoleService();
     await expect(service.updateRole('r1', { parentRoleId: 'r2' })).rejects.toThrow('Circular role hierarchy');
   });
+
+  it('updates parent role via setParentRole', async () => {
+    const supabase = getServiceSupabase();
+    const from = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnValue({ error: null }),
+    };
+    (supabase.from as any).mockReturnValue(from);
+    vi.spyOn(RoleService.prototype as any, 'hasCircularDependency').mockResolvedValue(false);
+    const service = new RoleService();
+    await service.setParentRole('B', 'A');
+    expect(from.update).toHaveBeenCalledWith({ parent_role_id: 'A', updated_at: expect.any(String) });
+    expect(from.eq).toHaveBeenCalledWith('id', 'B');
+  });
+
+  it('returns ancestor roles in order', async () => {
+    const roles: any = {
+      A: { id: 'A', name: 'A', isSystemRole: false, createdAt: '', updatedAt: '', parentRoleId: null },
+      B: { id: 'B', name: 'B', isSystemRole: false, createdAt: '', updatedAt: '', parentRoleId: 'A' },
+      C: { id: 'C', name: 'C', isSystemRole: false, createdAt: '', updatedAt: '', parentRoleId: 'B' },
+    };
+    const service = new RoleService();
+    vi.spyOn(service, 'getRoleById').mockImplementation(async (id: string) => roles[id] || null);
+    const ancestors = await service.getAncestorRoles('C');
+    expect(ancestors.map(r => r.id)).toEqual(['B', 'A']);
+  });
+
+  it('returns descendant roles', async () => {
+    const roles = [
+      { id: 'A', name: 'A', isSystemRole: false, createdAt: '', updatedAt: '', parentRoleId: null },
+      { id: 'B', name: 'B', isSystemRole: false, createdAt: '', updatedAt: '', parentRoleId: 'A' },
+      { id: 'C', name: 'C', isSystemRole: false, createdAt: '', updatedAt: '', parentRoleId: 'B' },
+    ];
+    const service = new RoleService();
+    vi.spyOn(service, 'getAllRoles').mockResolvedValue(roles as any);
+    const desc = await service.getDescendantRoles('A');
+    expect(desc.map(r => r.id).sort()).toEqual(['B', 'C']);
+  });
+
+  it('calculates effective permissions with inheritance', async () => {
+    const service = new RoleService();
+    vi.spyOn(service, 'getAncestorRoles').mockResolvedValue([
+      { id: 'B', name: 'B', isSystemRole: false, createdAt: '', updatedAt: '', parentRoleId: 'A' },
+      { id: 'A', name: 'A', isSystemRole: false, createdAt: '', updatedAt: '', parentRoleId: null },
+    ] as any);
+    const supabase = getServiceSupabase();
+    const from = {
+      select: vi.fn().mockReturnThis(),
+      in: vi.fn().mockResolvedValue({
+        data: [
+          { permissions: 'p1' },
+          { permissions: 'p2' },
+          { permissions: 'p3' },
+          { permissions: 'p4' },
+          { permissions: 'p3' },
+        ],
+        error: null,
+      }),
+    };
+    (supabase.from as any).mockReturnValue(from);
+    const perms = await service.getEffectivePermissions('C');
+    expect(perms.sort()).toEqual(['p1', 'p2', 'p3', 'p4']);
+  });
 });


### PR DESCRIPTION
## Summary
- add hierarchy support to RoleService with `setParentRole`, `getAncestorRoles`, `getDescendantRoles` and `getEffectivePermissions`
- extend RoleService tests to cover new methods

## Testing
- `npx vitest run --coverage` *(fails: The environment doesn't have network access after setup, so Codex couldn't run certain commands)*

------
https://chatgpt.com/codex/tasks/task_b_683da511c70c8331b5abbf79c1df003f