### PR TITLE
Add placeholder permission API endpoints

### DIFF
--- a/app/api/permissions/[id]/route.ts
+++ b/app/api/permissions/[id]/route.ts
@@ -1,0 +1,15 @@
+// GET /api/permissions/[id] - Get permission details
+// PUT /api/permissions/[id] - Update permission
+// DELETE /api/permissions/[id] - Delete permission
+
+export function GET() {
+  return new Response('Not implemented', { status: 501 });
+}
+
+export function PUT() {
+  return new Response('Not implemented', { status: 501 });
+}
+
+export function DELETE() {
+  return new Response('Not implemented', { status: 501 });
+}

--- a/app/api/permissions/categories/route.ts
+++ b/app/api/permissions/categories/route.ts
@@ -1,0 +1,5 @@
+// GET /api/permissions/categories - List all permission categories
+
+export function GET() {
+  return new Response('Not implemented', { status: 501 });
+}

--- a/app/api/permissions/route.ts
+++ b/app/api/permissions/route.ts
@@ -1,3 +1,6 @@
+// GET /api/permissions - List all permissions with optional filtering
+// POST /api/permissions - Create a new permission (admin only)
+
 import { type NextRequest } from 'next/server';
 import { createSuccessResponse } from '@/lib/api/common';
 import { withErrorHandling } from '@/middleware/error-handling';
@@ -11,4 +14,8 @@ async function handleGet() {
 
 export async function GET(req: NextRequest) {
   return withErrorHandling(() => handleGet(), req);
+}
+
+export async function POST() {
+  return new Response('Not implemented', { status: 501 });
 }


### PR DESCRIPTION
## Summary
- add comments and POST stub to `/api/permissions`
- create placeholder endpoints for `/api/permissions/[id]` and `/api/permissions/categories`
- run coverage on permission route tests

## Testing
- `npx vitest run --coverage app/api/permissions/__tests__/route.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_683da5598c5883318492cbb31202a489