### PR TITLE
Add auth permission check endpoint

### DIFF
--- a/app/api/auth/check-permission/__tests__/route.test.ts
+++ b/app/api/auth/check-permission/__tests__/route.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+import { getApiPermissionService } from '@/services/permission/factory';
+
+vi.mock('@/middleware/with-security', () => ({ withSecurity: (h: any) => h }));
+vi.mock('@/services/permission/factory', () => ({ getApiPermissionService: vi.fn() }));
+vi.mock('@/middleware/createMiddlewareChain', async () => {
+  const actual = await vi.importActual<any>('@/middleware/createMiddlewareChain');
+  return {
+    ...actual,
+    routeAuthMiddleware: vi.fn(() => (handler: any) => (req: any, _ctx?: any, data?: any) => handler(req, { userId: 'user-1' }, data)),
+  };
+});
+
+const mockService = { hasPermission: vi.fn() };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (getApiPermissionService as unknown as vi.Mock).mockReturnValue(mockService);
+  mockService.hasPermission.mockResolvedValue(true);
+});
+
+function createRequest(body: any) {
+  return new Request('http://localhost/api/auth/check-permission', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+}
+
+describe('POST /api/auth/check-permission', () => {
+  it('returns permission result', async () => {
+    const res = await POST(createRequest({ permission: 'ADMIN_ACCESS' }) as any);
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.data.hasPermission).toBe(true);
+    expect(mockService.hasPermission).toHaveBeenCalledWith('user-1', 'ADMIN_ACCESS');
+  });
+
+  it('validates request body', async () => {
+    const res = await POST(createRequest({}) as any);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/auth/check-permission/route.ts
+++ b/app/api/auth/check-permission/route.ts
@@ -1,0 +1,39 @@
+import { type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { withSecurity } from '@/middleware/with-security';
+import {
+  createMiddlewareChain,
+  errorHandlingMiddleware,
+  routeAuthMiddleware,
+  validationMiddleware
+} from '@/middleware/createMiddlewareChain';
+import { createSuccessResponse } from '@/lib/api/common';
+import { getApiPermissionService } from '@/services/permission/factory';
+import type { RouteAuthContext } from '@/middleware/auth';
+
+const CheckPermissionSchema = z.object({
+  permission: z.string().min(1)
+});
+
+async function handleCheckPermission(
+  _req: NextRequest,
+  auth: RouteAuthContext,
+  data: z.infer<typeof CheckPermissionSchema>
+) {
+  if (!auth.userId) {
+    return createSuccessResponse({ hasPermission: false });
+  }
+  const service = getApiPermissionService();
+  const allowed = await service.hasPermission(auth.userId, data.permission as any);
+  return createSuccessResponse({ hasPermission: allowed });
+}
+
+const middleware = createMiddlewareChain([
+  errorHandlingMiddleware(),
+  routeAuthMiddleware(),
+  validationMiddleware(CheckPermissionSchema)
+]);
+
+export const POST = withSecurity((req: NextRequest) =>
+  middleware((r, auth, data) => handleCheckPermission(r, auth, data))(req)
+);


### PR DESCRIPTION
## Summary
- add /api/auth/check-permission API route
- implement POST endpoint to verify current user's permission
- include tests for new endpoint

## Testing
- `npm run test:coverage` *(fails: Rate limiting is disabled: Redis URL or Token not configured in environment variables)*

------
https://chatgpt.com/codex/tasks/task_b_683daa8297cc83319da8801fcc0bec11