### PR TITLE
Add auth permission check endpoints

### DIFF
--- a/app/api/auth/check-permission/__tests__/route.test.ts
+++ b/app/api/auth/check-permission/__tests__/route.test.ts
@@ -30,11 +30,19 @@ function createRequest(body: any) {
 
 describe('POST /api/auth/check-permission', () => {
   it('returns permission result', async () => {
-    const res = await POST(createRequest({ permission: 'ADMIN_ACCESS' }) as any);
+    const res = await POST(
+      createRequest({ permission: 'ADMIN_ACCESS' }) as any
+    );
     const data = await res.json();
     expect(res.status).toBe(200);
     expect(data.data.hasPermission).toBe(true);
     expect(mockService.hasPermission).toHaveBeenCalledWith('user-1', 'ADMIN_ACCESS');
+  });
+
+  it('caches permission checks', async () => {
+    await POST(createRequest({ permission: 'ADMIN_ACCESS' }) as any);
+    await POST(createRequest({ permission: 'ADMIN_ACCESS' }) as any);
+    expect(mockService.hasPermission).toHaveBeenCalledTimes(1);
   });
 
   it('validates request body', async () => {

--- a/app/api/auth/check-permissions/__tests__/route.test.ts
+++ b/app/api/auth/check-permissions/__tests__/route.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+import { getApiPermissionService } from '@/services/permission/factory';
+
+vi.mock('@/middleware/with-security', () => ({ withSecurity: (h: any) => h }));
+vi.mock('@/services/permission/factory', () => ({ getApiPermissionService: vi.fn() }));
+vi.mock('@/middleware/createMiddlewareChain', async () => {
+  const actual = await vi.importActual<any>('@/middleware/createMiddlewareChain');
+  return {
+    ...actual,
+    routeAuthMiddleware: vi.fn(() => (handler: any) => (req: any, _ctx?: any, data?: any) => handler(req, { userId: 'u1' }, data)),
+  };
+});
+
+const mockService = { hasPermission: vi.fn() };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (getApiPermissionService as unknown as vi.Mock).mockReturnValue(mockService);
+  mockService.hasPermission.mockResolvedValue(true);
+});
+
+function createReq(body: any) {
+  return new Request('http://test/api/auth/check-permissions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+}
+
+describe('POST /api/auth/check-permissions', () => {
+  it('returns results for checks', async () => {
+    const res = await POST(createReq({ checks: [{ permission: 'VIEW_PROJECTS' }] }) as any);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.data.results[0].hasPermission).toBe(true);
+    expect(mockService.hasPermission).toHaveBeenCalledWith('u1', 'VIEW_PROJECTS');
+  });
+
+  it('validates body', async () => {
+    const res = await POST(createReq({}) as any);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/auth/check-permissions/route.ts
+++ b/app/api/auth/check-permissions/route.ts
@@ -12,38 +12,47 @@ import { getApiPermissionService } from '@/services/permission/factory';
 import { permissionCheckCache } from '@/lib/auth/permission-cache';
 import type { RouteAuthContext } from '@/middleware/auth';
 
-const CheckPermissionSchema = z.object({
+const CheckSchema = z.object({
   permission: z.string().min(1),
   resourceType: z.string().optional(),
   resourceId: z.string().optional()
 });
 
-async function handleCheckPermission(
+const BatchSchema = z.object({
+  checks: z.array(CheckSchema).min(1)
+});
+
+async function handleCheckPermissions(
   _req: NextRequest,
   auth: RouteAuthContext,
-  data: z.infer<typeof CheckPermissionSchema>
+  data: z.infer<typeof BatchSchema>
 ) {
   if (!auth.userId) {
-    return createSuccessResponse({ hasPermission: false });
+    return createSuccessResponse({
+      results: data.checks.map(c => ({ permission: c.permission, hasPermission: false }))
+    });
   }
 
-  const key = `${auth.userId}:${data.permission}:${data.resourceType ?? ''}:${
-    data.resourceId ?? ''}`;
-
   const service = getApiPermissionService();
-  const allowed = await permissionCheckCache.getOrCreate(key, () =>
-    service.hasPermission(auth.userId!, data.permission as any)
+  const results = await Promise.all(
+    data.checks.map(async (c) => {
+      const key = `${auth.userId}:${c.permission}:${c.resourceType ?? ''}:${c.resourceId ?? ''}`;
+      const allowed = await permissionCheckCache.getOrCreate(key, () =>
+        service.hasPermission(auth.userId!, c.permission as any)
+      );
+      return { permission: c.permission, hasPermission: allowed };
+    })
   );
 
-  return createSuccessResponse({ hasPermission: allowed });
+  return createSuccessResponse({ results });
 }
 
 const middleware = createMiddlewareChain([
   errorHandlingMiddleware(),
   routeAuthMiddleware(),
-  validationMiddleware(CheckPermissionSchema)
+  validationMiddleware(BatchSchema)
 ]);
 
 export const POST = withSecurity((req: NextRequest) =>
-  middleware((r, auth, data) => handleCheckPermission(r, auth, data))(req)
+  middleware((r, auth, data) => handleCheckPermissions(r, auth, data))(req)
 );

--- a/app/api/auth/check-role/__tests__/route.test.ts
+++ b/app/api/auth/check-role/__tests__/route.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+import { getApiPermissionService } from '@/services/permission/factory';
+
+vi.mock('@/middleware/with-security', () => ({ withSecurity: (h: any) => h }));
+vi.mock('@/services/permission/factory', () => ({ getApiPermissionService: vi.fn() }));
+vi.mock('@/middleware/createMiddlewareChain', async () => {
+  const actual = await vi.importActual<any>('@/middleware/createMiddlewareChain');
+  return {
+    ...actual,
+    routeAuthMiddleware: vi.fn(() => (handler: any) => (req: any, _ctx?: any, data?: any) => handler(req, { userId: 'u1' }, data)),
+  };
+});
+
+const mockService = { hasRole: vi.fn() };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (getApiPermissionService as unknown as vi.Mock).mockReturnValue(mockService);
+  mockService.hasRole.mockResolvedValue(true);
+});
+
+function makeReq(body: any) {
+  return new Request('http://test/api/auth/check-role', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+}
+
+describe('POST /api/auth/check-role', () => {
+  it('returns role result', async () => {
+    const res = await POST(makeReq({ role: 'ADMIN' }) as any);
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.data.hasRole).toBe(true);
+    expect(mockService.hasRole).toHaveBeenCalledWith('u1', 'ADMIN');
+  });
+
+  it('validates body', async () => {
+    const res = await POST(makeReq({}) as any);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/auth/check-role/route.ts
+++ b/app/api/auth/check-role/route.ts
@@ -1,0 +1,40 @@
+import { type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { withSecurity } from '@/middleware/with-security';
+import {
+  createMiddlewareChain,
+  errorHandlingMiddleware,
+  routeAuthMiddleware,
+  validationMiddleware
+} from '@/middleware/createMiddlewareChain';
+import { createSuccessResponse } from '@/lib/api/common';
+import { getApiPermissionService } from '@/services/permission/factory';
+import type { RouteAuthContext } from '@/middleware/auth';
+
+const CheckRoleSchema = z.object({
+  role: z.string().min(1),
+  includeHierarchy: z.boolean().optional()
+});
+
+async function handleCheckRole(
+  _req: NextRequest,
+  auth: RouteAuthContext,
+  data: z.infer<typeof CheckRoleSchema>
+) {
+  if (!auth.userId) {
+    return createSuccessResponse({ hasRole: false });
+  }
+  const service = getApiPermissionService();
+  const hasRole = await service.hasRole(auth.userId, data.role as any);
+  return createSuccessResponse({ hasRole, effectiveRole: hasRole ? data.role : undefined });
+}
+
+const middleware = createMiddlewareChain([
+  errorHandlingMiddleware(),
+  routeAuthMiddleware(),
+  validationMiddleware(CheckRoleSchema)
+]);
+
+export const POST = withSecurity((req: NextRequest) =>
+  middleware((r, auth, data) => handleCheckRole(r, auth, data))(req)
+);

--- a/app/api/auth/my-permissions/__tests__/route.test.ts
+++ b/app/api/auth/my-permissions/__tests__/route.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from '../route';
+import { getApiPermissionService } from '@/services/permission/factory';
+
+vi.mock('@/middleware/with-security', () => ({ withSecurity: (h: any) => h }));
+vi.mock('@/services/permission/factory', () => ({ getApiPermissionService: vi.fn() }));
+vi.mock('@/middleware/createMiddlewareChain', async () => {
+  const actual = await vi.importActual<any>('@/middleware/createMiddlewareChain');
+  return {
+    ...actual,
+    routeAuthMiddleware: vi.fn(() => (handler: any) => (req: any, _ctx?: any, data?: any) => handler(req, { userId: 'u1' }, data)),
+  };
+});
+
+const mockService = {
+  getUserRoles: vi.fn(),
+  getRoleById: vi.fn()
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (getApiPermissionService as unknown as vi.Mock).mockReturnValue(mockService);
+  mockService.getUserRoles.mockResolvedValue([{ roleId: 'r1' }]);
+  mockService.getRoleById.mockResolvedValue({ name: 'ADMIN', permissions: ['P1'] });
+});
+
+describe('GET /api/auth/my-permissions', () => {
+  it('returns aggregated permissions', async () => {
+    const res = await GET(new Request('http://test') as any);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.data.roles[0]).toBe('ADMIN');
+    expect(body.data.permissions).toContain('P1');
+  });
+});

--- a/app/api/auth/my-permissions/route.ts
+++ b/app/api/auth/my-permissions/route.ts
@@ -1,0 +1,40 @@
+import { type NextRequest } from 'next/server';
+import { withSecurity } from '@/middleware/with-security';
+import {
+  createMiddlewareChain,
+  errorHandlingMiddleware,
+  routeAuthMiddleware
+} from '@/middleware/createMiddlewareChain';
+import { createSuccessResponse } from '@/lib/api/common';
+import { getApiPermissionService } from '@/services/permission/factory';
+import type { RouteAuthContext } from '@/middleware/auth';
+
+async function handleMyPermissions(
+  _req: NextRequest,
+  auth: RouteAuthContext
+) {
+  if (!auth.userId) {
+    return createSuccessResponse({ roles: [], permissions: [], resourcePermissions: [] });
+  }
+
+  const service = getApiPermissionService();
+  const assignments = await service.getUserRoles(auth.userId);
+  const roleEntities = await Promise.all(assignments.map(r => service.getRoleById(r.roleId)));
+  const roles = roleEntities.filter(Boolean).map(r => r!.name);
+  const permissions = new Set<string>();
+  roleEntities.forEach(r => r?.permissions.forEach(p => permissions.add(p)));
+  return createSuccessResponse({
+    roles,
+    permissions: Array.from(permissions),
+    resourcePermissions: []
+  });
+}
+
+const middleware = createMiddlewareChain([
+  errorHandlingMiddleware(),
+  routeAuthMiddleware()
+]);
+
+export const GET = withSecurity((req: NextRequest) =>
+  middleware((r, auth) => handleMyPermissions(r, auth))(req)
+);

--- a/src/lib/auth/permission-cache.ts
+++ b/src/lib/auth/permission-cache.ts
@@ -1,0 +1,7 @@
+import { MemoryCache } from '@/lib/cache';
+
+/**
+ * Cache for permission checks keyed by user and permission parameters.
+ * TTL is short to avoid stale permissions.
+ */
+export const permissionCheckCache = new MemoryCache<string, boolean>({ ttl: 5000 });


### PR DESCRIPTION
## Summary
- extend check-permission route with caching and resource args
- add batch permission check endpoint
- expose user permissions endpoint
- add role check endpoint
- share in-memory permission cache
- test coverage for new endpoints

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683dae5fb14c8331a6041bbd3dfbc9c7