### PR TITLE
Add withPermission middleware factory

### DIFF
--- a/src/middleware/__tests__/withPermission.test.ts
+++ b/src/middleware/__tests__/withPermission.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withPermission } from '../withPermission';
+import { getCurrentUser } from '@/lib/auth';
+import { hasPermission } from '@/lib/auth/hasPermission';
+
+vi.mock('@/lib/auth');
+vi.mock('@/lib/auth/hasPermission');
+
+const okHandler = vi.fn(async (_req: NextApiRequest, res: NextApiResponse) => {
+  res.status(200).json({ ok: true });
+});
+
+describe('withPermission middleware', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    okHandler.mockClear();
+  });
+
+  it('returns 401 when user is missing', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(null as any);
+    const middleware = withPermission('TEST')(okHandler);
+    const { req, res } = createMocks({ method: 'GET' });
+
+    await middleware(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(okHandler).not.toHaveBeenCalled();
+  });
+
+  it('allows self access when enabled', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue({ id: '1' } as any);
+    const middleware = withPermission('TEST', { allowSelf: true })(okHandler);
+    const { req, res } = createMocks({ method: 'GET', query: { id: '1' } });
+
+    await middleware(req, res);
+
+    expect(okHandler).toHaveBeenCalled();
+  });
+
+  it('denies when permission check fails', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue({ id: '1' } as any);
+    vi.mocked(hasPermission).mockResolvedValue(false);
+    const middleware = withPermission('TEST')(okHandler);
+    const { req, res } = createMocks({ method: 'GET' });
+
+    await middleware(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(okHandler).not.toHaveBeenCalled();
+  });
+
+  it('executes handler when authorized', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue({ id: '1' } as any);
+    vi.mocked(hasPermission).mockResolvedValue(true);
+    const middleware = withPermission('TEST')(okHandler);
+    const { req, res } = createMocks({ method: 'GET' });
+
+    await middleware(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(okHandler).toHaveBeenCalled();
+  });
+});

--- a/src/middleware/withPermission.ts
+++ b/src/middleware/withPermission.ts
@@ -1,0 +1,31 @@
+import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
+import { getCurrentUser } from '@/lib/auth';
+import { hasPermission } from '@/lib/auth/hasPermission';
+
+export interface WithPermissionOptions {
+  allowSelf?: boolean;
+}
+
+export const withPermission = (
+  requiredPermission: string,
+  options?: WithPermissionOptions
+) => {
+  return (handler: NextApiHandler) =>
+    async (req: NextApiRequest, res: NextApiResponse) => {
+      const user = await getCurrentUser();
+      if (!user) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      if (options?.allowSelf && req.query.id === user.id) {
+        return handler(req, res);
+      }
+
+      const hasAccess = await hasPermission(user.id, requiredPermission as any);
+      if (!hasAccess) {
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+
+      return handler(req, res);
+    };
+};


### PR DESCRIPTION
## Summary
- add a permission-based middleware factory for Next.js API routes
- test the new middleware logic

## Testing
- `npm run test:coverage` *(fails: cannot read properties of undefined, many failing tests)*

------
https://chatgpt.com/codex/tasks/task_b_683daf405f0c833182e1b0d2faa48a46