### PR TITLE
Secure permission-related endpoints

### DIFF
--- a/app/api/permissions/[id]/route.ts
+++ b/app/api/permissions/[id]/route.ts
@@ -2,14 +2,23 @@
 // PUT /api/permissions/[id] - Update permission
 // DELETE /api/permissions/[id] - Delete permission
 
-export function GET() {
-  return new Response('Not implemented', { status: 501 });
-}
+import { createProtectedHandler } from '@/middleware/permissions';
+import { withSecurity } from '@/middleware/with-security';
+import { PermissionValues } from '@/core/permission/models';
 
-export function PUT() {
-  return new Response('Not implemented', { status: 501 });
-}
+export const GET = createProtectedHandler(
+  async () => new Response('Not implemented', { status: 501 }),
+  PermissionValues.MANAGE_ROLES,
+);
 
-export function DELETE() {
-  return new Response('Not implemented', { status: 501 });
-}
+export const PUT = createProtectedHandler(
+  (req) =>
+    withSecurity(async () => new Response('Not implemented', { status: 501 }))(req),
+  PermissionValues.MANAGE_ROLES,
+);
+
+export const DELETE = createProtectedHandler(
+  (req) =>
+    withSecurity(async () => new Response('Not implemented', { status: 501 }))(req),
+  PermissionValues.MANAGE_ROLES,
+);

--- a/app/api/permissions/categories/route.ts
+++ b/app/api/permissions/categories/route.ts
@@ -1,5 +1,9 @@
 // GET /api/permissions/categories - List all permission categories
 
-export function GET() {
-  return new Response('Not implemented', { status: 501 });
-}
+import { createProtectedHandler } from '@/middleware/permissions';
+import { PermissionValues } from '@/core/permission/models';
+
+export const GET = createProtectedHandler(
+  async () => new Response('Not implemented', { status: 501 }),
+  PermissionValues.MANAGE_ROLES,
+);

--- a/app/api/permissions/route.ts
+++ b/app/api/permissions/route.ts
@@ -4,6 +4,9 @@
 import { type NextRequest } from 'next/server';
 import { createSuccessResponse } from '@/lib/api/common';
 import { withErrorHandling } from '@/middleware/error-handling';
+import { createProtectedHandler } from '@/middleware/permissions';
+import { withSecurity } from '@/middleware/with-security';
+import { PermissionValues } from '@/core/permission/models';
 import { getApiPermissionService } from '@/services/permission/factory';
 
 async function handleGet() {
@@ -12,10 +15,13 @@ async function handleGet() {
   return createSuccessResponse({ permissions });
 }
 
-export async function GET(req: NextRequest) {
-  return withErrorHandling(() => handleGet(), req);
-}
+export const GET = createProtectedHandler(
+  (req) => withErrorHandling(() => handleGet(), req),
+  PermissionValues.MANAGE_ROLES,
+);
 
-export async function POST() {
-  return new Response('Not implemented', { status: 501 });
-}
+export const POST = createProtectedHandler(
+  (req) =>
+    withSecurity(async () => new Response('Not implemented', { status: 501 }))(req),
+  PermissionValues.MANAGE_ROLES,
+);

--- a/app/api/resources/[type]/[id]/permissions/route.ts
+++ b/app/api/resources/[type]/[id]/permissions/route.ts
@@ -1,2 +1,10 @@
 // GET /api/resources/[type]/[id]/permissions - List permissions for a resource
 // GET /api/resources/[type]/[id]/users - List users with permissions for a resource
+
+import { createProtectedHandler } from '@/middleware/permissions';
+import { PermissionValues } from '@/core/permission/models';
+
+export const GET = createProtectedHandler(
+  async () => new Response('Not implemented', { status: 501 }),
+  PermissionValues.MANAGE_ROLES,
+);

--- a/app/api/resources/permissions/route.ts
+++ b/app/api/resources/permissions/route.ts
@@ -1,2 +1,18 @@
 // POST /api/resources/permissions - Assign permission to user for specific resource
 // DELETE /api/resources/permissions - Remove permission from user for specific resource
+
+import { createProtectedHandler } from '@/middleware/permissions';
+import { withSecurity } from '@/middleware/with-security';
+import { PermissionValues } from '@/core/permission/models';
+
+export const POST = createProtectedHandler(
+  (req) =>
+    withSecurity(async () => new Response('Not implemented', { status: 501 }))(req),
+  PermissionValues.MANAGE_ROLES,
+);
+
+export const DELETE = createProtectedHandler(
+  (req) =>
+    withSecurity(async () => new Response('Not implemented', { status: 501 }))(req),
+  PermissionValues.MANAGE_ROLES,
+);


### PR DESCRIPTION
## Summary
- use `createProtectedHandler` on `/api/permissions` endpoints
- secure permission categories and id-based permission routes
- guard resource permission APIs

## Testing
- `npm run test:coverage` *(fails: missing env vars and config)*

------
https://chatgpt.com/codex/tasks/task_b_683db1acec748331874510c4e5294616