### PR TITLE
Add resource permission management

### DIFF
--- a/src/core/permission/IPermissionDataProvider.ts
+++ b/src/core/permission/IPermissionDataProvider.ts
@@ -168,6 +168,58 @@ export interface IPermissionDataProvider {
   getRolePermissions(roleId: string): Promise<Permission[]>;
 
   /**
+   * Assign a permission scoped to a specific resource to a user.
+   */
+  assignResourcePermission(
+    userId: string,
+    permission: Permission,
+    resourceType: string,
+    resourceId: string,
+  ): Promise<ResourcePermission>;
+
+  /**
+   * Remove a resource scoped permission from a user.
+   */
+  removeResourcePermission(
+    userId: string,
+    permission: Permission,
+    resourceType: string,
+    resourceId: string,
+  ): Promise<boolean>;
+
+  /**
+   * Check if a user holds a permission for a specific resource.
+   */
+  hasResourcePermission(
+    userId: string,
+    permission: Permission,
+    resourceType: string,
+    resourceId: string,
+  ): Promise<boolean>;
+
+  /**
+   * List all resource permissions granted to a user.
+   */
+  getUserResourcePermissions(userId: string): Promise<ResourcePermission[]>;
+
+  /**
+   * List all permissions for a given resource.
+   */
+  getPermissionsForResource(
+    resourceType: string,
+    resourceId: string,
+  ): Promise<ResourcePermission[]>;
+
+  /**
+   * Get all users that have a specific permission for a resource.
+   */
+  getUsersWithResourcePermission(
+    resourceType: string,
+    resourceId: string,
+    permission: Permission,
+  ): Promise<string[]>;
+
+  /**
    * Sync default role permissions with persistent storage.
    *
    * Implementations should ensure that the stored roles match the default

--- a/src/core/permission/interfaces.ts
+++ b/src/core/permission/interfaces.ts
@@ -160,6 +160,52 @@ export interface PermissionService {
    * @returns An array of permissions assigned to the role
    */
   getRolePermissions(roleId: string): Promise<Permission[]>;
+
+  /**
+   * Assign a permission scoped to a specific resource to a user
+   */
+  assignResourcePermission(
+    userId: string,
+    permission: Permission,
+    resourceType: string,
+    resourceId: string,
+  ): Promise<ResourcePermission>;
+
+  /**
+   * Remove a resource scoped permission from a user
+   */
+  removeResourcePermission(
+    userId: string,
+    permission: Permission,
+    resourceType: string,
+    resourceId: string,
+  ): Promise<boolean>;
+
+  /**
+   * Check if a user has a permission for a specific resource
+   */
+  hasResourcePermission(
+    userId: string,
+    permission: Permission,
+    resourceType: string,
+    resourceId: string,
+  ): Promise<boolean>;
+
+  /** Get all resource permissions for a user */
+  getUserResourcePermissions(userId: string): Promise<ResourcePermission[]>;
+
+  /** Get all permissions for a specific resource */
+  getPermissionsForResource(
+    resourceType: string,
+    resourceId: string,
+  ): Promise<ResourcePermission[]>;
+
+  /** Get all users with a permission for a resource */
+  getUsersWithResourcePermission(
+    resourceType: string,
+    resourceId: string,
+    permission: Permission,
+  ): Promise<string[]>;
   
   /**
    * Sync role permissions with the database

--- a/src/core/permission/models.ts
+++ b/src/core/permission/models.ts
@@ -229,3 +229,21 @@ export const DefaultRoleDefinitions: RolePermissionMap = {
     PermissionValues.CREATE_PROJECT,
   ],
 };
+
+/**
+ * Permission assignment tied to a specific resource
+ */
+export interface ResourcePermission {
+  /** Unique identifier */
+  id: string;
+  /** User that holds the permission */
+  userId: string;
+  /** Permission granted */
+  permission: Permission;
+  /** Resource type, e.g. "project" */
+  resourceType: string;
+  /** Resource identifier */
+  resourceId: string;
+  /** Date the permission was created */
+  createdAt: Date;
+}


### PR DESCRIPTION
## Summary
- extend permission domain models with `ResourcePermission`
- update provider/service interfaces for resource scoped permissions
- implement resource permission logic with caching in the default service
- add API service stubs and supabase provider queries
- cover new service logic in unit tests

## Testing
- `npx vitest run src/services/permission/__tests__/service/default-permission.service.test.ts`
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683db37ec0888331ac391c9ca3c0bbd0