### PR TITLE
Add resource permission API endpoints

### DIFF
--- a/app/api/permissions/check/route.ts
+++ b/app/api/permissions/check/route.ts
@@ -19,35 +19,57 @@ const querySchema = z.object({
   resourceId: z.string().optional(),
 });
 
+const batchSchema = z.object({
+  checks: z.array(querySchema).min(1),
+});
+
 type QueryParams = z.infer<typeof querySchema>;
 
 async function handlePermissionCheck(
   _req: NextRequest,
   user: User,
-  data: QueryParams
+  data: QueryParams,
 ) {
-  const { permission } = data;
+  const { permission, resource, resourceId } = data;
 
   if (!isPermission(permission)) {
     throw createPermissionNotFoundError(permission);
   }
 
   try {
-    const metadataPerms: string[] =
-      (user.app_metadata as any)?.permissions ?? [];
-    let hasPermission = metadataPerms.includes(permission);
-
-    if (!hasPermission) {
-      const permissionService = getApiPermissionService();
-      hasPermission = await permissionService.hasPermission(
+    const service = getApiPermissionService();
+    let allowed = false;
+    if (resource && resourceId) {
+      allowed = await service.hasResourcePermission(
         user.id,
-        permission as Permission
+        permission as Permission,
+        resource,
+        resourceId,
       );
+    } else {
+      const metadataPerms: string[] =
+        (user.app_metadata as any)?.permissions ?? [];
+      allowed = metadataPerms.includes(permission);
+      if (!allowed) {
+        allowed = await service.hasPermission(user.id, permission as Permission);
+      }
     }
-    return createSuccessResponse({ hasPermission });
+    return createSuccessResponse({ allowed });
   } catch (error) {
     throw mapPermissionServiceError(error as Error);
   }
+}
+
+async function handleBatchCheck(
+  req: NextRequest,
+  user: User,
+  data: z.infer<typeof batchSchema>,
+) {
+  const results = await Promise.all(
+    data.checks.map((c) => handlePermissionCheck(req, user, c).then((r) => r.data.allowed)),
+  );
+  const formatted = data.checks.map((c, idx) => ({ ...c, allowed: results[idx] }));
+  return createSuccessResponse({ results: formatted });
 }
 
 export async function GET(request: NextRequest) {
@@ -68,5 +90,25 @@ export async function GET(request: NextRequest) {
         { includeUser: true }
       ),
     request
+  );
+}
+
+export async function POST(request: NextRequest) {
+  return withErrorHandling(
+    (req) =>
+      withRouteAuth(
+        async (r, ctx) => {
+          const body = await r.json();
+          return withValidation(
+            batchSchema,
+            (r2, data) => handleBatchCheck(r2, ctx.user!, data),
+            r,
+            body,
+          );
+        },
+        req,
+        { includeUser: true },
+      ),
+    request,
   );
 }

--- a/app/api/resources/[type]/[id]/permissions/__tests__/route.test.ts
+++ b/app/api/resources/[type]/[id]/permissions/__tests__/route.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from '../route';
+import { withRouteAuth } from '@/middleware/auth';
+import { getApiPermissionService } from '@/services/permission/factory';
+
+vi.mock('@/middleware/auth', () => ({
+  withRouteAuth: vi.fn((handler: any, req: any) => handler(req, { userId: 'u1' })),
+}));
+vi.mock('@/middleware/with-security', () => ({ withSecurity: (h: any) => h }));
+vi.mock('@/services/permission/factory', () => ({ getApiPermissionService: vi.fn() }));
+
+const mockService = { getPermissionsForResource: vi.fn() };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (getApiPermissionService as unknown as vi.Mock).mockReturnValue(mockService);
+});
+
+describe('resource permissions list API', () => {
+  it('returns paginated permissions', async () => {
+    mockService.getPermissionsForResource.mockResolvedValue([
+      { id: '1', userId: 'u1', permission: 'VIEW_PROJECTS', resourceType: 'project', resourceId: 'p1', createdAt: new Date() },
+      { id: '2', userId: 'u2', permission: 'VIEW_PROJECTS', resourceType: 'project', resourceId: 'p1', createdAt: new Date() },
+    ]);
+    const req = new Request('http://test');
+    const res = await GET(req as any, { params: { type: 'project', id: 'p1' } } as any);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.data.length).toBe(2);
+    expect(mockService.getPermissionsForResource).toHaveBeenCalledWith('project', 'p1');
+  });
+});

--- a/app/api/resources/[type]/[id]/permissions/route.ts
+++ b/app/api/resources/[type]/[id]/permissions/route.ts
@@ -1,10 +1,64 @@
 // GET /api/resources/[type]/[id]/permissions - List permissions for a resource
 // GET /api/resources/[type]/[id]/users - List users with permissions for a resource
 
+import { type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { createPaginatedResponse } from '@/lib/api/common';
+import { withErrorHandling } from '@/middleware/error-handling';
+import { withValidation } from '@/middleware/validation';
 import { createProtectedHandler } from '@/middleware/permissions';
 import { PermissionValues } from '@/core/permission/models';
+import { getApiPermissionService } from '@/services/permission/factory';
+
+const querySchema = z.object({
+  page: z.coerce.number().int().positive().default(1).optional(),
+  pageSize: z.coerce.number().int().positive().max(100).default(20).optional(),
+  userId: z.string().optional(),
+  permission: z.string().optional(),
+});
+type Query = z.infer<typeof querySchema>;
+
+async function handleGet(
+  _req: NextRequest,
+  resourceType: string,
+  resourceId: string,
+  query: Query,
+) {
+  const service = getApiPermissionService();
+  let permissions = await service.getPermissionsForResource(resourceType, resourceId);
+  if (query.userId) {
+    permissions = permissions.filter((p) => p.userId === query.userId);
+  }
+  if (query.permission) {
+    permissions = permissions.filter((p) => p.permission === query.permission);
+  }
+  const page = query.page ?? 1;
+  const pageSize = query.pageSize ?? 20;
+  const totalItems = permissions.length;
+  const totalPages = Math.ceil(totalItems / pageSize);
+  const start = (page - 1) * pageSize;
+  const paginated = permissions.slice(start, start + pageSize);
+  return createPaginatedResponse(paginated, {
+    page,
+    pageSize,
+    totalItems,
+    totalPages,
+    hasNextPage: page < totalPages,
+    hasPreviousPage: page > 1,
+  });
+}
 
 export const GET = createProtectedHandler(
-  async () => new Response('Not implemented', { status: 501 }),
+  (req, ctx) =>
+    withErrorHandling(() => {
+      const url = new URL(req.url);
+      const params = Object.fromEntries(url.searchParams.entries());
+      return withValidation(
+        querySchema,
+        (r, data) => handleGet(r, ctx.params.type, ctx.params.id, data),
+        req,
+        params,
+      );
+    }, req),
   PermissionValues.MANAGE_ROLES,
 );

--- a/app/api/resources/permissions/__tests__/route.test.ts
+++ b/app/api/resources/permissions/__tests__/route.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST, DELETE } from '../route';
+import { withRouteAuth } from '@/middleware/auth';
+import { getApiPermissionService } from '@/services/permission/factory';
+
+vi.mock('@/middleware/with-security', () => ({ withSecurity: (h: any) => h }));
+vi.mock('@/middleware/auth', () => ({
+  withRouteAuth: vi.fn((handler: any, req: any) => handler(req, { userId: 'u1' })),
+}));
+vi.mock('@/services/permission/factory', () => ({ getApiPermissionService: vi.fn() }));
+
+const mockService = {
+  assignResourcePermission: vi.fn(),
+  removeResourcePermission: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (getApiPermissionService as unknown as vi.Mock).mockReturnValue(mockService);
+});
+
+describe('resource permission API', () => {
+  it('POST assigns permission', async () => {
+    mockService.assignResourcePermission.mockResolvedValue({ id: '1' });
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ userId: 'u1', permission: 'VIEW_PROJECTS', resourceType: 'project', resourceId: 'p1' }),
+    });
+    const res = await POST(req as any);
+    expect(res.status).toBe(201);
+    expect(mockService.assignResourcePermission).toHaveBeenCalled();
+  });
+
+  it('DELETE removes permission', async () => {
+    mockService.removeResourcePermission.mockResolvedValue(true);
+    const req = new Request('http://test?userId=u1&permission=VIEW_PROJECTS&resourceType=project&resourceId=p1');
+    const res = await DELETE(req as any);
+    expect(res.status).toBe(204);
+    expect(mockService.removeResourcePermission).toHaveBeenCalledWith('u1', 'VIEW_PROJECTS', 'project', 'p1');
+  });
+});

--- a/app/api/resources/permissions/route.ts
+++ b/app/api/resources/permissions/route.ts
@@ -1,18 +1,88 @@
 // POST /api/resources/permissions - Assign permission to user for specific resource
 // DELETE /api/resources/permissions - Remove permission from user for specific resource
 
+import { type NextRequest } from 'next/server';
+import { z } from 'zod';
+import {
+  createCreatedResponse,
+  createNoContentResponse,
+} from '@/lib/api/common';
+import { withErrorHandling } from '@/middleware/error-handling';
+import { withValidation } from '@/middleware/validation';
 import { createProtectedHandler } from '@/middleware/permissions';
 import { withSecurity } from '@/middleware/with-security';
-import { PermissionValues } from '@/core/permission/models';
+import {
+  PermissionValues,
+  PermissionSchema,
+} from '@/core/permission/models';
+import { getApiPermissionService } from '@/services/permission/factory';
+import { mapPermissionServiceError } from '@/lib/api/permission/error-handler';
+
+const assignSchema = z.object({
+  userId: z.string(),
+  permission: PermissionSchema,
+  resourceType: z.string(),
+  resourceId: z.string(),
+});
+type AssignPayload = z.infer<typeof assignSchema>;
+
+const removeSchema = assignSchema;
+
+async function handlePost(_req: NextRequest, data: AssignPayload) {
+  const service = getApiPermissionService();
+  try {
+    const permission = await service.assignResourcePermission(
+      data.userId,
+      data.permission,
+      data.resourceType,
+      data.resourceId,
+    );
+    return createCreatedResponse({ permission });
+  } catch (e) {
+    throw mapPermissionServiceError(e as Error);
+  }
+}
+
+async function handleDelete(data: AssignPayload) {
+  const service = getApiPermissionService();
+  const ok = await service.removeResourcePermission(
+    data.userId,
+    data.permission,
+    data.resourceType,
+    data.resourceId,
+  );
+  console.log(
+    `[resource-permissions] removed ${data.permission} for ${data.userId} on ${data.resourceType}:${data.resourceId}`,
+  );
+  if (!ok) {
+    throw mapPermissionServiceError(new Error('delete failed'));
+  }
+  return createNoContentResponse();
+}
 
 export const POST = createProtectedHandler(
   (req) =>
-    withSecurity(async () => new Response('Not implemented', { status: 501 }))(req),
+    withSecurity(async (r) => {
+      const body = await r.json();
+      return withErrorHandling(
+        (r2) =>
+          withValidation(assignSchema, (_r, data) => handlePost(_r, data), r2, body),
+        r,
+      );
+    })(req),
   PermissionValues.MANAGE_ROLES,
 );
 
 export const DELETE = createProtectedHandler(
   (req) =>
-    withSecurity(async () => new Response('Not implemented', { status: 501 }))(req),
+    withSecurity(async (r) => {
+      const url = new URL(r.url);
+      const params = Object.fromEntries(url.searchParams.entries());
+      return withErrorHandling(
+        (r2) =>
+          withValidation(removeSchema, (_req2, data) => handleDelete(data), r2, params),
+        r,
+      );
+    })(req),
   PermissionValues.MANAGE_ROLES,
 );

--- a/app/api/users/[id]/permissions/resources/__tests__/route.test.ts
+++ b/app/api/users/[id]/permissions/resources/__tests__/route.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from '../route';
+import { withRouteAuth } from '@/middleware/auth';
+import { getApiPermissionService } from '@/services/permission/factory';
+
+vi.mock('@/middleware/auth', () => ({
+  withRouteAuth: vi.fn((handler: any, req: any) => handler(req, { userId: 'u1' })),
+}));
+vi.mock('@/middleware/with-security', () => ({ withSecurity: (h: any) => h }));
+vi.mock('@/services/permission/factory', () => ({ getApiPermissionService: vi.fn() }));
+
+const mockService = { getUserResourcePermissions: vi.fn() };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (getApiPermissionService as unknown as vi.Mock).mockReturnValue(mockService);
+});
+
+describe('user resource permissions API', () => {
+  it('returns filtered permissions', async () => {
+    const now = new Date();
+    mockService.getUserResourcePermissions.mockResolvedValue([
+      { id: '1', userId: 'u1', permission: 'VIEW_PROJECTS', resourceType: 'project', resourceId: 'p1', createdAt: now },
+      { id: '2', userId: 'u1', permission: 'VIEW_PROJECTS', resourceType: 'doc', resourceId: 'd1', createdAt: now },
+    ]);
+    const req = new Request('http://test?resourceType=project');
+    const res = await GET(req as any, { params: { id: 'u1' } } as any);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.data.permissions.length).toBe(1);
+    expect(mockService.getUserResourcePermissions).toHaveBeenCalledWith('u1');
+  });
+});

--- a/app/api/users/[id]/permissions/resources/route.ts
+++ b/app/api/users/[id]/permissions/resources/route.ts
@@ -1,17 +1,44 @@
 import { type NextRequest } from 'next/server';
+import { z } from 'zod';
 import { createSuccessResponse } from '@/lib/api/common';
 import { withErrorHandling } from '@/middleware/error-handling';
+import { withValidation } from '@/middleware/validation';
 import { createProtectedHandler } from '@/middleware/permissions';
 import { PermissionValues } from '@/core/permission/models';
+import { getApiPermissionService } from '@/services/permission/factory';
 
 // GET /api/users/[id]/permissions/resources - Get resource permissions for a user
 
-async function handleGet() {
-  // TODO: Implement resource permission retrieval
-  return createSuccessResponse({ permissions: [] });
+const querySchema = z.object({
+  resourceType: z.string().optional(),
+  sortBy: z.enum(['created', 'type']).optional().default('created'),
+  order: z.enum(['asc', 'desc']).optional().default('asc'),
+});
+type Query = z.infer<typeof querySchema>;
+
+async function handleGet(userId: string, query: Query) {
+  const service = getApiPermissionService();
+  let permissions = await service.getUserResourcePermissions(userId);
+  if (query.resourceType) {
+    permissions = permissions.filter((p) => p.resourceType === query.resourceType);
+  }
+  if (query.sortBy === 'type') {
+    permissions.sort((a, b) => a.resourceType.localeCompare(b.resourceType));
+  } else {
+    permissions.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  }
+  if (query.order === 'desc') {
+    permissions.reverse();
+  }
+  return createSuccessResponse({ permissions });
 }
 
 export const GET = createProtectedHandler(
-  (req) => withErrorHandling(() => handleGet(), req),
+  (req, ctx) =>
+    withErrorHandling(() => {
+      const url = new URL(req.url);
+      const params = Object.fromEntries(url.searchParams.entries());
+      return withValidation(querySchema, (_r, data) => handleGet(ctx.params.id, data), req, params);
+    }, req),
   PermissionValues.MANAGE_ROLES,
 );


### PR DESCRIPTION
## Summary
- implement resource permission assignment and removal endpoints
- list permissions for resources and users
- extend permission check API for resource queries and batching
- add tests for new endpoints

## Testing
- `npx vitest run --coverage --reporter=basic` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683db6343f688331b02ae01f8adb00a9