### PR TITLE
Add role hierarchy to database schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -567,12 +567,16 @@ model roles {
   id               String             @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   name             String             @unique
   description      String?
+  parent_role_id   String?            @db.Uuid
+  parent_role      roles?             @relation("RoleParent", fields: [parent_role_id], references: [id])
+  child_roles      roles[]            @relation("RoleParent")
   created_at       DateTime?          @default(now()) @db.Timestamptz(6)
   updated_at       DateTime?          @default(now()) @db.Timestamptz(6)
   role_permissions role_permissions[]
   user_invitations user_invitations[]
   user_roles       user_roles[]
 
+  @@index([parent_role_id], map: "idx_roles_parent_role_id")
   @@schema("public")
 }
 
@@ -850,20 +854,20 @@ enum subscription_status {
 
 // API Key Management
 model api_keys {
-  id           String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  user_id      String    @db.Uuid
-  organization_id String? @db.Uuid
-  name         String
-  key_hash     String    @unique
-  prefix       String    @unique
-  scopes       String[]
-  expires_at   DateTime? @db.Timestamptz(6)
-  last_used_at DateTime? @db.Timestamptz(6)
-  created_at   DateTime  @default(now()) @db.Timestamptz(6)
-  updated_at   DateTime  @default(now()) @db.Timestamptz(6)
-  is_revoked   Boolean   @default(false)
-  users        users     @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  organizations organizations? @relation(fields: [organization_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  id              String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  user_id         String         @db.Uuid
+  organization_id String?        @db.Uuid
+  name            String
+  key_hash        String         @unique
+  prefix          String         @unique
+  scopes          String[]
+  expires_at      DateTime?      @db.Timestamptz(6)
+  last_used_at    DateTime?      @db.Timestamptz(6)
+  created_at      DateTime       @default(now()) @db.Timestamptz(6)
+  updated_at      DateTime       @default(now()) @db.Timestamptz(6)
+  is_revoked      Boolean        @default(false)
+  users           users          @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  organizations   organizations? @relation(fields: [organization_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@index([user_id])
   @@index([organization_id])
@@ -872,18 +876,18 @@ model api_keys {
 
 // Webhook Management
 model webhooks {
-  id                String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  user_id           String    @db.Uuid
-  organization_id   String?   @db.Uuid
-  name              String
-  url               String
-  events            String[]
-  secret            String?
-  is_active         Boolean   @default(true)
-  created_at        DateTime  @default(now()) @db.Timestamptz(6)
-  updated_at        DateTime  @default(now()) @db.Timestamptz(6)
-  users             users     @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  organizations     organizations? @relation(fields: [organization_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  id                 String               @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  user_id            String               @db.Uuid
+  organization_id    String?              @db.Uuid
+  name               String
+  url                String
+  events             String[]
+  secret             String?
+  is_active          Boolean              @default(true)
+  created_at         DateTime             @default(now()) @db.Timestamptz(6)
+  updated_at         DateTime             @default(now()) @db.Timestamptz(6)
+  users              users                @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  organizations      organizations?       @relation(fields: [organization_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
   webhook_deliveries webhook_deliveries[]
 
   @@index([user_id])
@@ -892,15 +896,15 @@ model webhooks {
 }
 
 model webhook_deliveries {
-  id           String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  webhook_id   String    @db.Uuid
-  event_type   String
-  payload      Json      @db.Json
-  status_code  Int?
-  response     String?
-  error        String?
-  created_at   DateTime  @default(now()) @db.Timestamptz(6)
-  webhook      webhooks  @relation(fields: [webhook_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  webhook_id  String   @db.Uuid
+  event_type  String
+  payload     Json     @db.Json
+  status_code Int?
+  response    String?
+  error       String?
+  created_at  DateTime @default(now()) @db.Timestamptz(6)
+  webhook     webhooks @relation(fields: [webhook_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@index([webhook_id])
   @@schema("public")

--- a/supabase/migrations/20240630120000_add_role_hierarchy.sql
+++ b/supabase/migrations/20240630120000_add_role_hierarchy.sql
@@ -1,0 +1,36 @@
+-- Migration: Add parent role hierarchy to roles table
+
+ALTER TABLE public.roles
+    ADD COLUMN IF NOT EXISTS parent_role_id UUID REFERENCES public.roles(id);
+
+-- Prevent self referencing
+ALTER TABLE public.roles
+    ADD CONSTRAINT roles_parent_not_self CHECK (parent_role_id IS NULL OR parent_role_id <> id);
+
+-- Index for fast traversal
+CREATE INDEX IF NOT EXISTS idx_roles_parent_role_id ON public.roles(parent_role_id);
+
+-- Trigger function to prevent circular references
+CREATE OR REPLACE FUNCTION public.check_role_hierarchy()
+RETURNS TRIGGER AS $$
+DECLARE
+    current_id UUID;
+BEGIN
+    IF NEW.parent_role_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+    current_id := NEW.parent_role_id;
+    WHILE current_id IS NOT NULL LOOP
+        IF current_id = NEW.id THEN
+            RAISE EXCEPTION 'Circular role hierarchy detected';
+        END IF;
+        SELECT parent_role_id INTO current_id FROM public.roles WHERE id = current_id;
+    END LOOP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS roles_check_hierarchy ON public.roles;
+CREATE TRIGGER roles_check_hierarchy
+BEFORE INSERT OR UPDATE ON public.roles
+FOR EACH ROW EXECUTE FUNCTION public.check_role_hierarchy();


### PR DESCRIPTION
## Summary
- add migration to introduce parent role relationship
- extend `roles` model with `parent_role_id` and related relations

## Testing
- `npx vitest run --coverage` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_683db6e3f240833192e8dc3a1281ad38