### PR TITLE
Implement role hierarchy validation

### DIFF
--- a/src/services/role/__tests__/role.service.test.ts
+++ b/src/services/role/__tests__/role.service.test.ts
@@ -83,6 +83,16 @@ describe('RoleService', () => {
     expect(from.eq).toHaveBeenCalledWith('id', 'B');
   });
 
+  it('rejects parent role when depth limit exceeded', async () => {
+    const supabase = getServiceSupabase();
+    const from = { update: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnValue({ error: null }) };
+    (supabase.from as any).mockReturnValue(from);
+    vi.spyOn(RoleService.prototype as any, 'hasCircularDependency').mockResolvedValue(false);
+    vi.spyOn(RoleService.prototype as any, 'exceedsDepthLimit').mockResolvedValue(true);
+    const service = new RoleService();
+    await expect(service.setParentRole('B', 'A')).rejects.toThrow('Role hierarchy depth limit exceeded');
+  });
+
   it('returns ancestor roles in order', async () => {
     const roles: any = {
       A: { id: 'A', name: 'A', isSystemRole: false, createdAt: '', updatedAt: '', parentRoleId: null },

--- a/src/services/role/default-role.service.ts
+++ b/src/services/role/default-role.service.ts
@@ -16,11 +16,61 @@ export class DefaultRoleService {
     this.permissionCache.clear();
   }
 
+  private isCircular(roleId: string, parentId: string | null): boolean {
+    let current = parentId;
+    const visited = new Set<string>();
+    while (current) {
+      if (current === roleId) return true;
+      if (visited.has(current)) break;
+      visited.add(current);
+      const parent = this.roles.get(current);
+      if (!parent) break;
+      current = parent.parentRoleId ?? null;
+    }
+    return false;
+  }
+
+  private getDepth(roleId: string): number {
+    let depth = 1;
+    let current = this.roles.get(roleId)?.parentRoleId ?? null;
+    const visited = new Set<string>();
+    while (current) {
+      if (visited.has(current)) break;
+      visited.add(current);
+      depth += 1;
+      current = this.roles.get(current)?.parentRoleId ?? null;
+    }
+    return depth;
+  }
+
   setParentRole(roleId: string, parentRoleId: string | null): void {
     const role = this.roles.get(roleId);
-    if (role) {
-      role.parentRoleId = parentRoleId;
-      this.permissionCache.clear();
+    if (!role) return;
+    if (parentRoleId && this.isCircular(roleId, parentRoleId)) {
+      throw new Error('Circular role hierarchy');
+    }
+    role.parentRoleId = parentRoleId;
+    this.permissionCache.clear();
+  }
+
+  validateHierarchy(maxDepth = Infinity): void {
+    for (const role of this.roles.values()) {
+      if (role.parentRoleId && this.isCircular(role.id, role.parentRoleId)) {
+        throw new Error('Circular role hierarchy');
+      }
+      if (this.getDepth(role.id) > maxDepth) {
+        throw new Error('Role hierarchy depth limit exceeded');
+      }
+      const effective = this.getEffectivePermissions(role.id).sort();
+      const expected = Array.from(
+        new Set([
+          ...role.permissionIds,
+          ...this.getAncestorRoles(role.id).flatMap((r) => r.permissionIds),
+        ])
+      ).sort();
+      if (effective.join(',') !== expected.join(',')) {
+        throw new Error('Permission hierarchy validation failed');
+      }
     }
   }
 

--- a/src/services/role/role.service.ts
+++ b/src/services/role/role.service.ts
@@ -35,7 +35,10 @@ import { getServiceSupabase } from '@/lib/database/supabase';
 import type { Permission } from '@/types/rbac';
 
 export class RoleService {
-  constructor(private supabase = getServiceSupabase()) {}
+  constructor(
+    private supabase = getServiceSupabase(),
+    private maxHierarchyDepth = Infinity,
+  ) {}
 
   async getAllRoles(filters?: { isSystemRole?: boolean }): Promise<Role[]> {
     let query = this.supabase.from('roles').select('*');
@@ -92,10 +95,36 @@ export class RoleService {
     return false;
   }
 
+  private async exceedsDepthLimit(parentId: string | null): Promise<boolean> {
+    if (!parentId || this.maxHierarchyDepth === Infinity) return false;
+    let depth = 1;
+    let current = parentId;
+    const visited = new Set<string>();
+    while (current) {
+      if (visited.has(current)) break;
+      visited.add(current);
+      if (depth >= this.maxHierarchyDepth) return true;
+      const { data, error } = await this.supabase
+        .from('roles')
+        .select('parent_role_id')
+        .eq('id', current)
+        .single();
+      if (error || !data) break;
+      current = (data as { parent_role_id: string | null }).parent_role_id;
+      depth += 1;
+    }
+    return false;
+  }
+
   async createRole(name: string, description = '', parentRoleId?: string | null): Promise<Role> {
     await this.ensureUniqueName(name);
-    if (parentRoleId && (await this.hasCircularDependency('', parentRoleId))) {
-      throw new Error('Circular role hierarchy');
+    if (parentRoleId) {
+      if (await this.hasCircularDependency('', parentRoleId)) {
+        throw new Error('Circular role hierarchy');
+      }
+      if (await this.exceedsDepthLimit(parentRoleId)) {
+        throw new Error('Role hierarchy depth limit exceeded');
+      }
     }
     const { data, error } = await this.supabase
       .from('roles')
@@ -110,8 +139,13 @@ export class RoleService {
     if (data.name) {
       await this.ensureUniqueName(data.name, id);
     }
-    if (data.parentRoleId && (await this.hasCircularDependency(id, data.parentRoleId))) {
-      throw new Error('Circular role hierarchy');
+    if (data.parentRoleId) {
+      if (await this.hasCircularDependency(id, data.parentRoleId)) {
+        throw new Error('Circular role hierarchy');
+      }
+      if (await this.exceedsDepthLimit(data.parentRoleId)) {
+        throw new Error('Role hierarchy depth limit exceeded');
+      }
     }
     const { data: updated, error } = await this.supabase
       .from('roles')
@@ -173,8 +207,13 @@ export class RoleService {
   }
 
   async setParentRole(roleId: string, parentRoleId: string | null): Promise<void> {
-    if (parentRoleId && (await this.hasCircularDependency(roleId, parentRoleId))) {
-      throw new Error('Circular role hierarchy');
+    if (parentRoleId) {
+      if (await this.hasCircularDependency(roleId, parentRoleId)) {
+        throw new Error('Circular role hierarchy');
+      }
+      if (await this.exceedsDepthLimit(parentRoleId)) {
+        throw new Error('Role hierarchy depth limit exceeded');
+      }
     }
     const { error } = await this.supabase
       .from('roles')


### PR DESCRIPTION
## Summary
- validate role hierarchy in-memory implementation
- enforce depth limit when setting role parent
- update tests for new validation logic

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683db736a5c88331841a2c94a9135999