### PR TITLE
Add error factory and translator utilities

### DIFF
--- a/src/lib/utils/__tests__/error-factory.test.ts
+++ b/src/lib/utils/__tests__/error-factory.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { createError, createValidationError, createAuthenticationError, createNotFoundError } from '../error-factory';
+import { VALIDATION_ERROR_CODES, AUTH_ERROR_CODES, USER_ERROR_CODES } from '@/lib/api/common/error-codes';
+
+describe('error factory', () => {
+  it('creates basic error with details and stack', () => {
+    const cause = new Error('root cause');
+    const err = createError(VALIDATION_ERROR_CODES.INVALID_REQUEST, 'failed', { a: 1 }, cause, 400);
+    expect(err.code).toBe(VALIDATION_ERROR_CODES.INVALID_REQUEST);
+    expect(err.details).toEqual({ a: 1 });
+    expect(err.status).toBe(400);
+    expect(err.stack).toContain('root cause');
+  });
+
+  it('creates error without cause', () => {
+    const err = createError(AUTH_ERROR_CODES.FORBIDDEN, 'forbidden');
+    expect(err.cause).toBeUndefined();
+  });
+
+  it('creates validation error with field errors', () => {
+    const err = createValidationError({ email: 'invalid' });
+    expect(err.code).toBe(VALIDATION_ERROR_CODES.INVALID_REQUEST);
+    expect(err.details).toEqual({ fields: { email: 'invalid' } });
+  });
+
+  it('creates validation error with custom message', () => {
+    const err = createValidationError({ name: 'missing' }, 'bad');
+    expect(err.message).toBe('bad');
+  });
+
+  it('creates validation error with missing locale', () => {
+    const err = createValidationError({ field: 'x' }, undefined, undefined, 'zz');
+    expect(err.message).toBe('Validation failed.');
+  });
+
+  it('creates authentication error', () => {
+    const err = createAuthenticationError('Auth required');
+    expect(err.code).toBe(AUTH_ERROR_CODES.UNAUTHORIZED);
+    expect(err.message).toBe('Auth required');
+  });
+
+  it('uses localized default message when none provided', () => {
+    const err = createAuthenticationError(undefined as any);
+    expect(err.message).toBe('Authentication required.');
+  });
+
+  it('uses fallback for unknown locale', () => {
+    const err = createAuthenticationError(undefined as any, undefined, 'zz');
+    expect(err.message).toBe('Authentication required.');
+  });
+
+  it('creates not found error', () => {
+    const err = createNotFoundError('user', '1');
+    expect(err.code).toBe(USER_ERROR_CODES.NOT_FOUND);
+    expect(err.details).toEqual({ resourceType: 'user', resourceId: '1' });
+  });
+
+  it('falls back to default locale', () => {
+    const err = createNotFoundError('item', '2', undefined, 'zz');
+    expect(err.message).toBe('Resource not found.');
+  });
+
+  it('uses translation when locale available', () => {
+    const err = createNotFoundError('item', '3', undefined, 'en');
+    expect(err.message).toBe('Resource not found.');
+  });
+});

--- a/src/lib/utils/__tests__/error-translator.test.ts
+++ b/src/lib/utils/__tests__/error-translator.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { translateDatabaseError, translateApiError, enhanceError, formatErrorForLogging, sanitizeErrorForClient } from '../error-translator';
+import { SERVER_ERROR_CODES, USER_ERROR_CODES } from '@/lib/api/common/error-codes';
+
+describe('error translator', () => {
+  it('translates Prisma unique constraint error', () => {
+    const prismaErr = { code: 'P2002' };
+    const err = translateDatabaseError(prismaErr);
+    expect(err.code).toBe(SERVER_ERROR_CODES.DATABASE_ERROR);
+    expect(err.status).toBe(409);
+  });
+
+  it('translates database connection error', () => {
+    const dbErr = { code: 'ECONNREFUSED' };
+    const err = translateDatabaseError(dbErr);
+    expect(err.status).toBe(503);
+  });
+
+  it('handles unknown and non-object database errors', () => {
+    expect(translateDatabaseError({ code: 'OTHER' }).status).toBe(500);
+    expect(translateDatabaseError(null as any).status).toBe(500);
+  });
+
+  it('translates API 404 error', () => {
+    const apiErr = { response: { status: 404, data: { id: '5' } } };
+    const err = translateApiError(apiErr, 'service');
+    expect(err.code).toBe(USER_ERROR_CODES.NOT_FOUND);
+    expect(err.status).toBe(404);
+  });
+
+  it('translates API 401 error', () => {
+    const apiErr = { response: { status: 401 } };
+    const err = translateApiError(apiErr, 'svc');
+    expect(err.status).toBe(401);
+  });
+
+  it('handles generic API errors', () => {
+    expect(translateApiError({}, 'svc').code).toBe(SERVER_ERROR_CODES.OPERATION_FAILED);
+    const apiErr = { response: { status: 500 } };
+    expect(translateApiError(apiErr, 'svc').code).toBe(SERVER_ERROR_CODES.OPERATION_FAILED);
+  });
+
+  it('enhances plain and existing ApplicationError', () => {
+    const plain = enhanceError(new Error('oops'), { requestId: 'abc' });
+    expect(plain.requestId).toBe('abc');
+    const existing = translateDatabaseError({ code: 'P2002' });
+    const enhanced = enhanceError(existing, { requestId: 'xyz' });
+    expect(enhanced).toBe(existing);
+    expect(enhanced.requestId).toBe('xyz');
+  });
+
+  it('formats and sanitizes error', () => {
+    const err = enhanceError(new Error('bad'), { requestId: 'id1' });
+    const log = formatErrorForLogging(err);
+    const client = sanitizeErrorForClient(err);
+    expect(log.stack).toBeDefined();
+    expect(client.stack as any).toBeUndefined();
+    expect(client.code).toBe(err.code);
+  });
+});

--- a/src/lib/utils/error-factory.ts
+++ b/src/lib/utils/error-factory.ts
@@ -1,0 +1,114 @@
+// Application-wide error factory and utilities
+import { VALIDATION_ERROR_CODES, AUTH_ERROR_CODES, SERVER_ERROR_CODES, USER_ERROR_CODES } from '@/lib/api/common/error-codes';
+import type { ErrorCode } from '@/lib/api/common/error-codes';
+
+export interface ApplicationError extends Error {
+  code: ErrorCode;
+  details?: Record<string, any>;
+  status?: number;
+  timestamp: string;
+  requestId?: string;
+  cause?: unknown;
+}
+
+/**
+ * Map of localized messages by locale and error code.
+ * Only English translations are provided currently but the structure
+ * allows adding more locales easily.
+ */
+const LOCALIZED_MESSAGES: Record<string, Record<string, string>> = {
+  en: {
+    [AUTH_ERROR_CODES.UNAUTHORIZED]: 'Authentication required.',
+    [AUTH_ERROR_CODES.FORBIDDEN]: 'Access denied.',
+    [VALIDATION_ERROR_CODES.INVALID_REQUEST]: 'Validation failed.',
+    [USER_ERROR_CODES.NOT_FOUND]: 'Resource not found.',
+    [SERVER_ERROR_CODES.INTERNAL_ERROR]: 'Internal server error.',
+  },
+};
+
+function getLocalizedMessage(code: ErrorCode, locale: string): string | undefined {
+  return LOCALIZED_MESSAGES[locale]?.[code] || LOCALIZED_MESSAGES.en[code];
+}
+
+/**
+ * Create a basic ApplicationError instance.
+ */
+export function createError(
+  code: ErrorCode,
+  message: string,
+  details?: Record<string, any>,
+  cause?: unknown,
+  httpStatus?: number
+): ApplicationError {
+  const err = new Error(message) as ApplicationError;
+  err.name = 'ApplicationError';
+  err.code = code;
+  err.details = details;
+  err.status = httpStatus;
+  err.timestamp = new Date().toISOString();
+  err.cause = cause;
+  if (cause instanceof Error && cause.stack) {
+    err.stack = `${err.stack}\nCaused by: ${cause.stack}`;
+  }
+  return err;
+}
+
+/**
+ * Create a validation error with optional field level details.
+ */
+export function createValidationError(
+  fieldErrors: Record<string, string>,
+  message?: string,
+  cause?: unknown,
+  locale = 'en'
+) {
+  let msg = message;
+  if (!msg) {
+    msg = getLocalizedMessage(VALIDATION_ERROR_CODES.INVALID_REQUEST, locale);
+  }
+  /* c8 ignore next */
+  if (!msg) {
+    msg = 'Validation failed.';
+  }
+  return createError(
+    VALIDATION_ERROR_CODES.INVALID_REQUEST,
+    msg,
+    { fields: fieldErrors },
+    cause,
+    400
+  );
+}
+
+/**
+ * Create an authentication error.
+ */
+export function createAuthenticationError(
+  message: string,
+  cause?: unknown,
+  locale = 'en'
+) {
+  let msg = message;
+  if (!msg) {
+    msg = getLocalizedMessage(AUTH_ERROR_CODES.UNAUTHORIZED, locale);
+  }
+  /* c8 ignore next */
+  if (!msg) {
+    msg = 'Authentication required.';
+  }
+  return createError(AUTH_ERROR_CODES.UNAUTHORIZED, msg, undefined, cause, 401);
+}
+
+/**
+ * Create a not found error for a given resource.
+ */
+export function createNotFoundError(
+  resourceType: string,
+  resourceId: string,
+  cause?: unknown,
+  locale = 'en'
+) {
+  const code = USER_ERROR_CODES.NOT_FOUND;
+  const defaultMsg = `${resourceType} ${resourceId} not found`;
+  const msg = getLocalizedMessage(code, locale) || defaultMsg;
+  return createError(code as ErrorCode, msg, { resourceType, resourceId }, cause, 404);
+}

--- a/src/lib/utils/error-translator.ts
+++ b/src/lib/utils/error-translator.ts
@@ -1,0 +1,125 @@
+import type { ApplicationError } from './error-factory';
+import { createError, createAuthenticationError, createNotFoundError } from './error-factory';
+import { SERVER_ERROR_CODES } from '@/lib/api/common/error-codes';
+import type { ErrorCode } from '@/lib/api/common/error-codes';
+
+export interface ErrorContext {
+  requestId?: string;
+  locale?: string;
+}
+
+/**
+ * Translate low level database errors into application errors.
+ */
+export function translateDatabaseError(error: any, locale = 'en'): ApplicationError {
+  if (error && typeof error === 'object') {
+    if (error.code === 'P2002' || error.code === '23505') {
+      return createError(
+        SERVER_ERROR_CODES.DATABASE_ERROR as ErrorCode,
+        getMessage('uniqueConstraint', locale),
+        { causeCode: error.code },
+        error,
+        409
+      );
+    }
+    if (error.code === 'ECONNREFUSED') {
+      return createError(
+        SERVER_ERROR_CODES.DATABASE_ERROR as ErrorCode,
+        getMessage('dbConnection', locale),
+        { causeCode: error.code },
+        error,
+        503
+      );
+    }
+  }
+  return createError(
+    SERVER_ERROR_CODES.DATABASE_ERROR as ErrorCode,
+    getMessage('genericDb', locale),
+    undefined,
+    error,
+    500
+  );
+}
+
+/**
+ * Translate third party API errors to application errors.
+ */
+export function translateApiError(error: any, serviceName: string, locale = 'en'): ApplicationError {
+  const status = error?.response?.status;
+  if (status === 401) {
+    return createAuthenticationError(getMessage('auth', locale), error, locale);
+  }
+  if (status === 404) {
+    return createNotFoundError(serviceName, error?.response?.data?.id || '', error, locale);
+  }
+  return createError(
+    SERVER_ERROR_CODES.OPERATION_FAILED as ErrorCode,
+    `${serviceName} ${getMessage('genericExternal', locale)}`,
+    { status },
+    error,
+    status || 500
+  );
+}
+
+/**
+ * Enhance any error with request context and convert to ApplicationError.
+ */
+export function enhanceError(error: any, context: ErrorContext, locale = 'en'): ApplicationError {
+  if (isApplicationError(error)) {
+    error.requestId = context.requestId;
+    return error;
+  }
+  const appError = createError(
+    SERVER_ERROR_CODES.INTERNAL_ERROR as ErrorCode,
+    getMessage('generic', locale),
+    undefined,
+    error,
+    500
+  );
+  appError.requestId = context.requestId;
+  return appError;
+}
+
+/**
+ * Format error for server side logging with stack and details.
+ */
+export function formatErrorForLogging(error: ApplicationError) {
+  return {
+    code: error.code,
+    message: error.message,
+    stack: error.stack,
+    details: error.details,
+    requestId: error.requestId,
+    timestamp: error.timestamp,
+  };
+}
+
+/**
+ * Sanitize error for client responses by removing stack traces and sensitive details.
+ */
+export function sanitizeErrorForClient(error: ApplicationError) {
+  return {
+    code: error.code,
+    message: error.message,
+    ...(error.requestId && { requestId: error.requestId }),
+  };
+}
+
+function isApplicationError(err: any): err is ApplicationError {
+  return err && typeof err === 'object' && 'code' in err && 'timestamp' in err;
+}
+
+const LOCALIZED_TRANSLATIONS: Record<string, Record<string, string>> = {
+  en: {
+    generic: 'An unexpected error occurred.',
+    uniqueConstraint: 'Record already exists.',
+    dbConnection: 'Database connection error.',
+    genericDb: 'Database error.',
+    auth: 'Authentication failed.',
+    genericExternal: 'service error.',
+  },
+};
+
+function getMessage(key: string, locale: string): string {
+  return LOCALIZED_TRANSLATIONS[locale]?.[key] || LOCALIZED_TRANSLATIONS.en[key];
+}

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -7,3 +7,5 @@ export function cn(...inputs: ClassValue[]) {
 
 export * from './error'
 export * from './typed-event-emitter'
+export * from './error-factory'
+export * from './error-translator'


### PR DESCRIPTION
## Summary
- add ApplicationError factory with helpers for validation, auth, and not-found
- implement error translation utilities for DB and external API errors
- export new utilities
- test error factory and translator

## Testing
- `npx vitest run --coverage src/lib/utils/__tests__/error-factory.test.ts src/lib/utils/__tests__/error-translator.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_683dba63ba8483319a29644c90522931