### PR TITLE
Add role hierarchy visualization

### DIFF
--- a/app/admin/roles/hierarchy/page.tsx
+++ b/app/admin/roles/hierarchy/page.tsx
@@ -1,0 +1,10 @@
+import RoleHierarchyTree from '@/ui/styled/permission/RoleHierarchyTree';
+
+export default function RoleHierarchyPage() {
+  return (
+    <div className="container py-6">
+      <h1 className="text-3xl font-bold mb-6">Role Hierarchy Management</h1>
+      <RoleHierarchyTree />
+    </div>
+  );
+}

--- a/src/hooks/admin/__tests__/useRoleHierarchy.test.tsx
+++ b/src/hooks/admin/__tests__/useRoleHierarchy.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useRoleHierarchy } from '../useRoleHierarchy';
+import { useApi } from '@/hooks/core/useApi';
+
+vi.mock('@/hooks/core/useApi');
+
+describe('useRoleHierarchy', () => {
+  const fetchApi = vi.fn();
+
+  beforeEach(() => {
+    vi.mocked(useApi).mockReturnValue({ isLoading: false, error: null, fetchApi });
+    fetchApi.mockResolvedValue({});
+  });
+
+  it('fetches hierarchy', async () => {
+    const { result } = renderHook(() => useRoleHierarchy());
+    await act(async () => {
+      await result.current.fetchHierarchy('root');
+    });
+    expect(fetchApi).toHaveBeenCalledWith('/api/roles/root/hierarchy');
+  });
+
+  it('updates parent', async () => {
+    const { result } = renderHook(() => useRoleHierarchy());
+    await act(async () => {
+      await result.current.updateParent('c1', 'p1');
+    });
+    expect(fetchApi).toHaveBeenCalledWith('/api/roles/c1/hierarchy', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ parentRoleId: 'p1' }),
+    });
+  });
+});

--- a/src/hooks/admin/useRoleHierarchy.ts
+++ b/src/hooks/admin/useRoleHierarchy.ts
@@ -1,0 +1,22 @@
+import { useApi } from '@/hooks/core/useApi';
+
+export function useRoleHierarchy() {
+  const { isLoading, error, fetchApi } = useApi();
+
+  const fetchHierarchy = async (rootRoleId: string) => {
+    return fetchApi<{ ancestors: any[]; descendants: any[] }>(
+      `/api/roles/${rootRoleId}/hierarchy`,
+    );
+  };
+
+  const updateParent = async (roleId: string, parentRoleId: string | null) => {
+    return fetchApi(`/api/roles/${roleId}/hierarchy`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ parentRoleId }),
+    });
+  };
+
+  return { isLoading, error, fetchHierarchy, updateParent };
+}
+export default useRoleHierarchy;

--- a/src/ui/styled/permission/PermissionInheritanceVisualizer.tsx
+++ b/src/ui/styled/permission/PermissionInheritanceVisualizer.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import { Badge } from '@/ui/primitives/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/ui/primitives/card';
+import { useRoleHierarchy } from '@/hooks/admin/useRoleHierarchy';
+import { useApi } from '@/hooks/core/useApi';
+
+interface Permission { id: string; name: string; }
+interface Role { id: string; name: string; parentRoleId?: string | null; }
+
+interface Props {
+  roleId: string;
+  title?: string;
+}
+
+export function PermissionInheritanceVisualizer({ roleId, title }: Props) {
+  const { fetchHierarchy } = useRoleHierarchy();
+  const { fetchApi } = useApi();
+  const [direct, setDirect] = useState<Permission[]>([]);
+  const [inherited, setInherited] = useState<Permission[]>([]);
+  const [effective, setEffective] = useState<Permission[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      const hierarchy = await fetchHierarchy(roleId);
+      const ancestorRoles = hierarchy?.ancestors || [];
+      const directRes = await fetchApi<{ permissions: Permission[] }>(
+        `/api/roles/${roleId}/permissions`,
+      );
+      const directPerms = directRes?.permissions || [];
+      const inheritedPerms: Permission[] = [];
+      for (const a of ancestorRoles) {
+        const res = await fetchApi<{ permissions: Permission[] }>(
+          `/api/roles/${a.id}/permissions`,
+        );
+        if (res) inheritedPerms.push(...res.permissions);
+      }
+      const effectivePerms = Array.from(
+        new Map(
+          [...directPerms, ...inheritedPerms].map((p) => [p.id, p]),
+        ).values(),
+      );
+      setDirect(directPerms);
+      setInherited(inheritedPerms.filter((p) => !directPerms.find((d) => d.id === p.id)));
+      setEffective(effectivePerms);
+    }
+    load();
+  }, [roleId, fetchHierarchy, fetchApi]);
+
+  return (
+    <Card className="mb-4">
+      <CardHeader>
+        <CardTitle>{title || roleId}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div>
+          <h4 className="font-semibold">Direct Permissions</h4>
+          <div className="flex flex-wrap gap-1">
+            {direct.map((p) => (
+              <Badge key={p.id} className="bg-blue-100 text-blue-800">
+                {p.name}
+              </Badge>
+            ))}
+          </div>
+        </div>
+        <div>
+          <h4 className="font-semibold">Inherited Permissions</h4>
+          <div className="flex flex-wrap gap-1">
+            {inherited.map((p) => (
+              <Badge key={p.id} className="bg-green-100 text-green-800">
+                {p.name}
+              </Badge>
+            ))}
+          </div>
+        </div>
+        <div>
+          <h4 className="font-semibold">Effective Permissions</h4>
+          <div className="flex flex-wrap gap-1">
+            {effective.map((p) => (
+              <Badge key={p.id} className="bg-gray-100 text-gray-800">
+                {p.name}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+export default PermissionInheritanceVisualizer;

--- a/src/ui/styled/permission/RoleHierarchyTree.tsx
+++ b/src/ui/styled/permission/RoleHierarchyTree.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { useRoleHierarchy } from '@/hooks/admin/useRoleHierarchy';
+import PermissionInheritanceVisualizer from './PermissionInheritanceVisualizer';
+
+interface RoleNode {
+  id: string;
+  name: string;
+  parentRoleId?: string | null;
+}
+
+export function RoleHierarchyTree({ rootRoleId = 'root' }: { rootRoleId?: string }) {
+  const { fetchHierarchy } = useRoleHierarchy();
+  const [roles, setRoles] = useState<RoleNode[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      const data = await fetchHierarchy(rootRoleId);
+      if (!data) return;
+      const allRoles: RoleNode[] = [{ id: rootRoleId, name: rootRoleId }, ...data.descendants];
+      setRoles(allRoles);
+    }
+    load();
+  }, [rootRoleId, fetchHierarchy]);
+
+  const renderRole = (role: RoleNode) => (
+    <li key={role.id} className="mt-2">
+      <PermissionInheritanceVisualizer roleId={role.id} title={role.name} />
+      {roles.some(r => r.parentRoleId === role.id) && (
+        <ul className="ml-4">
+          {roles.filter(r => r.parentRoleId === role.id).map(renderRole)}
+        </ul>
+      )}
+    </li>
+  );
+
+  const roots = roles.filter(r => r.parentRoleId === null || r.id === rootRoleId);
+
+  return <ul className="list-none p-0">{roots.map(renderRole)}</ul>;
+}
+export default RoleHierarchyTree;


### PR DESCRIPTION
## Summary
- add `useRoleHierarchy` hook for role hierarchy API
- create `PermissionInheritanceVisualizer` and `RoleHierarchyTree` components
- add role hierarchy admin page
- test `useRoleHierarchy` hook

## Testing
- `npx vitest run --coverage src/hooks/admin/__tests__/useRoleHierarchy.test.tsx`

------
https://chatgpt.com/codex/tasks/task_b_683dbdec0b748331a6318ad95c026251