### PR TITLE
Implement service error handler

### DIFF
--- a/src/services/auth/default-auth.service.ts
+++ b/src/services/auth/default-auth.service.ts
@@ -18,6 +18,8 @@ import {
 } from '@/core/auth/models';
 import { AuthEventType } from '@/core/auth/events';
 import { translateError } from '@/lib/utils/error';
+import { handleServiceError } from '@/services/common/service-error-handler';
+import { ERROR_CODES } from '@/core/common/error-codes';
 import { TypedEventEmitter } from '@/lib/utils/typed-event-emitter';
 import type {
   OAuthProvider,
@@ -225,9 +227,13 @@ export class DefaultAuthService
       this.user = await this.provider.getCurrentUser();
       return this.user;
     } catch (error) {
-      const message = translateError(error, { defaultMessage: 'Failed to get user' });
-      console.error(message);
-      throw new Error(message);
+      const { error: err } = handleServiceError(error, {
+        service: 'DefaultAuthService',
+        method: 'getCurrentUser',
+        resourceType: 'user',
+        resourceId: 'current',
+      }, ERROR_CODES.INTERNAL_ERROR);
+      throw err;
     }
   }
 

--- a/src/services/common/service-error-handler.ts
+++ b/src/services/common/service-error-handler.ts
@@ -1,0 +1,86 @@
+import { createError, ApplicationError } from '@/core/common/errors';
+import { enhanceError, createValidationError } from '@/lib/utils/error-factory';
+import { ERROR_CODES } from '@/core/common/error-codes';
+import type { ZodSchema } from 'zod';
+
+export interface ErrorContext {
+  service: string;
+  method: string;
+  resourceType?: string;
+  resourceId?: string;
+}
+
+export function logServiceError(error: ApplicationError, context: ErrorContext) {
+  const { service, method, ...rest } = context;
+  const safeDetails = error.details ? { ...error.details } : undefined;
+  if (safeDetails && 'password' in safeDetails) {
+    safeDetails.password = '***';
+  }
+  const msg = `[${service}.${method}] ${error.message}`;
+  if (error.httpStatus >= 500) {
+    console.error(msg, { code: error.code, ...rest, details: safeDetails });
+  } else {
+    console.warn(msg, { code: error.code, ...rest, details: safeDetails });
+  }
+}
+
+export function handleServiceError<T>(
+  error: unknown,
+  context: ErrorContext,
+  defaultErrorCode: string = ERROR_CODES.INTERNAL_ERROR,
+): { success: false; error: ApplicationError } {
+  const enhanced = enhanceError(error, context);
+  const code = (enhanced as any).code || defaultErrorCode;
+  const appError =
+    enhanced instanceof ApplicationError
+      ? enhanced
+      : createError(code as any, enhanced.message, { context }, enhanced);
+  logServiceError(appError, context);
+  return { success: false, error: appError };
+}
+
+export function withErrorHandling<T, Args extends any[]>(
+  fn: (...args: Args) => Promise<T>,
+  context: ErrorContext,
+) {
+  return async (...args: Args): Promise<T> => {
+    try {
+      return await fn(...args);
+    } catch (err) {
+      const res = handleServiceError(err, context);
+      throw res.error;
+    }
+  };
+}
+
+export async function safeQuery<T>(
+  queryFn: () => Promise<T>,
+  fallback: T,
+  context: ErrorContext,
+): Promise<T> {
+  try {
+    return await queryFn();
+  } catch (err) {
+    handleServiceError(err, context);
+    return fallback;
+  }
+}
+
+export async function validateAndExecute<T, V>(
+  data: unknown,
+  schema: ZodSchema<V>,
+  fn: (validated: V) => Promise<T>,
+  context: ErrorContext,
+): Promise<T | { success: false; error: ApplicationError }> {
+  const parsed = schema.safeParse(data);
+  if (!parsed.success) {
+    const err = createValidationError(parsed.error.flatten().fieldErrors);
+    logServiceError(err, context);
+    return { success: false, error: err };
+  }
+  try {
+    return await fn(parsed.data);
+  } catch (e) {
+    return handleServiceError(e, context);
+  }
+}

--- a/src/services/team/default-team.service.ts
+++ b/src/services/team/default-team.service.ts
@@ -28,6 +28,8 @@ import { translateError } from '@/lib/utils/error';
 import { TypedEventEmitter } from '@/lib/utils/typed-event-emitter';
 import { MemoryCache } from '@/lib/cache';
 import { prisma } from '@/lib/database/prisma';
+import { handleServiceError } from '@/services/common/service-error-handler';
+import { ERROR_CODES } from '@/core/common/error-codes';
 
 /**
  * Default implementation of the TeamService interface
@@ -108,9 +110,14 @@ export class DefaultTeamService
         this.teamDataProvider.getTeam(teamId)
       );
     } catch (error) {
-      console.error('Error fetching team:', error);
+      const { error: err } = handleServiceError(error, {
+        service: 'DefaultTeamService',
+        method: 'getTeam',
+        resourceType: 'team',
+        resourceId: teamId,
+      }, ERROR_CODES.NOT_FOUND);
       DefaultTeamService.teamCache.delete(teamId);
-      return null;
+      throw err;
     }
   }
   

--- a/src/services/user/default-user.service.ts
+++ b/src/services/user/default-user.service.ts
@@ -22,6 +22,8 @@ import {
 import { UserEventType } from '@/core/user/events';
 import { TypedEventEmitter } from '@/lib/utils/typed-event-emitter';
 import { MemoryCache, getFromBrowser, setInBrowser, removeFromBrowser } from '@/lib/cache';
+import { handleServiceError } from '@/services/common/service-error-handler';
+import { ERROR_CODES } from '@/core/common/error-codes';
 
 /**
  * Default implementation of the UserService interface
@@ -63,9 +65,14 @@ export class DefaultUserService
         this.userDataProvider.getUserProfile(userId)
       );
     } catch (error) {
-      console.error('Error fetching user profile:', error);
+      const { error: err } = handleServiceError(error, {
+        service: 'DefaultUserService',
+        method: 'getUserProfile',
+        resourceType: 'user',
+        resourceId: userId,
+      }, ERROR_CODES.NOT_FOUND);
       DefaultUserService.profileCache.delete(userId);
-      return null;
+      throw err;
     }
   }
 


### PR DESCRIPTION
## Summary
- add common error handler for services
- use handleServiceError in auth, user and team services

## Testing
- `npx vitest run src/services/user/__tests__/api-user.service.test.ts src/services/team/__tests__/default-team.service.test.ts src/services/auth/__tests__/factory.test.ts --coverage`

------
https://chatgpt.com/codex/tasks/task_b_683dbf26b1648331b62e8080665bfc0b