### PR TITLE
Implement API error handling helpers

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -4,14 +4,11 @@ import { withSecurity } from '@/middleware/with-security';
 import { logUserAction } from '@/lib/audit/auditLogger';
 import { getApiAuthService } from '@/services/auth/factory';
 import { LoginPayload } from '@/core/auth/models';
-import {
-  createSuccessResponse,
-  ApiError,
-  ERROR_CODES
-} from '@/lib/api/common';
+import { createSuccessResponse } from '@/lib/api/response/api-response';
+import { handleApiError } from '@/lib/api/middleware/error-handler.middleware';
+import { ApiError, ERROR_CODES } from '@/lib/api/common';
 import {
   createMiddlewareChain,
-  errorHandlingMiddleware,
   validationMiddleware,
   rateLimitMiddleware
 } from '@/middleware/createMiddlewareChain';
@@ -116,10 +113,9 @@ async function handleLogin(req: NextRequest, validatedData: z.infer<typeof Login
  */
 const middleware = createMiddlewareChain([
   rateLimitMiddleware({ windowMs: 15 * 60 * 1000, max: 30 }),
-  errorHandlingMiddleware(),
   validationMiddleware(LoginSchema)
 ]);
 
 export const POST = withSecurity((request: NextRequest) =>
-  middleware(handleLogin)(request)
+  withApiErrorHandling(middleware(handleLogin), request)
 );

--- a/src/lib/api/middleware/error-handler.middleware.ts
+++ b/src/lib/api/middleware/error-handler.middleware.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { logApiError } from '@/lib/audit/error-logger';
+import {
+  ApplicationError,
+  createErrorFromUnknown,
+} from '@/core/common/errors';
+import { createErrorResponse, ResponseMeta } from '../response/api-response';
+
+export interface ErrorHandlerContext extends ResponseMeta {
+  service?: string;
+  operation?: string;
+}
+
+function sanitizeError(error: ApplicationError): ApplicationError {
+  const sanitized = new ApplicationError(
+    error.code,
+    error.message,
+    error.httpStatus,
+    error.details && { ...error.details }
+  );
+  sanitized.timestamp = error.timestamp;
+  return sanitized;
+}
+
+export async function withApiErrorHandling(
+  handler: (req: NextRequest) => Promise<NextResponse>,
+  req: NextRequest,
+  context: ErrorHandlerContext = {}
+): Promise<NextResponse> {
+  try {
+    return await handler(req);
+  } catch (err) {
+    const appErr = createErrorFromUnknown(err);
+    await logApiError(appErr, {
+      ipAddress: req.headers.get('x-forwarded-for') || undefined,
+      userAgent: req.headers.get('user-agent') || undefined,
+      path: req.nextUrl.pathname,
+    });
+    const safe = process.env.NODE_ENV === 'development' ? appErr : sanitizeError(appErr);
+    const meta: ResponseMeta = {
+      requestId: context.requestId || '',
+      timestamp: safe.timestamp,
+    };
+    const body = createErrorResponse(safe, meta);
+    return NextResponse.json(body, { status: safe.httpStatus });
+  }
+}
+
+export function handleApiError(
+  error: unknown,
+  context: ErrorHandlerContext = {}
+): NextResponse {
+  const appErr = createErrorFromUnknown(error);
+  const safe = process.env.NODE_ENV === 'development' ? appErr : sanitizeError(appErr);
+  const body = createErrorResponse(safe, {
+    requestId: context.requestId || '',
+    timestamp: safe.timestamp,
+  });
+  return NextResponse.json(body, { status: safe.httpStatus });
+}

--- a/src/lib/api/response/api-response.ts
+++ b/src/lib/api/response/api-response.ts
@@ -1,0 +1,73 @@
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: {
+    code: string;
+    message: string;
+    details?: Record<string, unknown>;
+  };
+  meta?: {
+    timestamp: string;
+    requestId: string;
+  };
+}
+
+export interface ResponseMeta {
+  timestamp?: string;
+  requestId?: string;
+}
+
+export function createSuccessResponse<T>(data: T, meta: ResponseMeta = {}): ApiResponse<T> {
+  return {
+    success: true,
+    data,
+    meta: {
+      timestamp: meta.timestamp || new Date().toISOString(),
+      requestId: meta.requestId || '',
+    },
+  };
+}
+
+import type { ApplicationError } from '@/core/common/errors';
+
+export function createErrorResponse(error: ApplicationError, meta: ResponseMeta = {}): ApiResponse<never> {
+  return {
+    success: false,
+    error: {
+      code: error.code,
+      message: error.message,
+      ...(error.details && { details: error.details }),
+    },
+    meta: {
+      timestamp: meta.timestamp || error.timestamp || new Date().toISOString(),
+      requestId: meta.requestId || '',
+    },
+  };
+}
+
+export interface PaginationMeta {
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+}
+
+export function createPaginatedResponse<T>(data: T[], pagination: PaginationMeta, meta: ResponseMeta = {}): ApiResponse<T[]> {
+  return {
+    success: true,
+    data,
+    meta: {
+      timestamp: meta.timestamp || new Date().toISOString(),
+      requestId: meta.requestId || '',
+      pagination,
+    } as any,
+  };
+}
+
+export function createdResponse<T>(data: T, meta?: ResponseMeta): ApiResponse<T> {
+  return createSuccessResponse(data, meta);
+}
+
+export function updatedResponse<T>(data: T, meta?: ResponseMeta): ApiResponse<T> {
+  return createSuccessResponse(data, meta);
+}


### PR DESCRIPTION
## Summary
- implement api response helpers
- add API error handler middleware
- update login route to use new middleware

## Testing
- `bun test` *(fails: Playwright tests require full environment)*

------
https://chatgpt.com/codex/tasks/task_b_683e9955932c8331bb2f49912ad99e90