### PR TITLE
Add permission dashboard panels

### DIFF
--- a/app/admin/permissions/AuditLogViewer.tsx
+++ b/app/admin/permissions/AuditLogViewer.tsx
@@ -1,0 +1,6 @@
+'use client';
+import { AuditLogViewer as StyledAuditLogViewer } from '@/ui/styled/audit/AuditLogViewer';
+
+export default function AuditLogViewer() {
+  return <StyledAuditLogViewer isAdmin={true} />;
+}

--- a/app/admin/permissions/ResourcePermissionPanel.tsx
+++ b/app/admin/permissions/ResourcePermissionPanel.tsx
@@ -1,0 +1,99 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { Input } from '@/ui/primitives/input';
+import { Button } from '@/ui/primitives/button';
+import { Select } from '@/ui/primitives/select';
+import { UserManagementConfiguration } from '@/core/config';
+import type { PermissionService } from '@/core/permission/interfaces';
+
+interface ResourcePermission {
+  userId: string;
+  permission: string;
+}
+
+export default function ResourcePermissionPanel() {
+  const permissionService =
+    UserManagementConfiguration.getServiceProvider<PermissionService>('permissionService');
+
+  const [resourceType, setResourceType] = useState('team');
+  const [resourceId, setResourceId] = useState('');
+  const [permissions, setPermissions] = useState<ResourcePermission[]>([]);
+  const [userId, setUserId] = useState('');
+  const [permission, setPermission] = useState('');
+
+  const fetchPermissions = async () => {
+    if (!permissionService || !resourceId) return;
+    const perms = await permissionService.getPermissionsForResource(resourceType, resourceId);
+    setPermissions(perms as unknown as ResourcePermission[]);
+  };
+
+  const grantPermission = async () => {
+    if (!permissionService || !userId || !permission || !resourceId) return;
+    await permissionService.assignResourcePermission(
+      userId,
+      permission,
+      resourceType,
+      resourceId,
+    );
+    fetchPermissions();
+  };
+
+  const revokePermission = async (uid: string, perm: string) => {
+    if (!permissionService) return;
+    await permissionService.removeResourcePermission(uid, perm, resourceType, resourceId);
+    fetchPermissions();
+  };
+
+  useEffect(() => {
+    fetchPermissions();
+  }, [resourceType, resourceId]);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Resource Permissions</h2>
+      <div className="flex items-center space-x-2">
+        <label>Resource Type:</label>
+        <Select value={resourceType} onValueChange={setResourceType}>
+          <option value="team">Team</option>
+          <option value="project">Project</option>
+          <option value="document">Document</option>
+        </Select>
+        <Input
+          placeholder="Resource ID"
+          value={resourceId}
+          onChange={(e) => setResourceId(e.target.value)}
+        />
+        <Button onClick={fetchPermissions}>Load</Button>
+      </div>
+      {resourceId && (
+        <>
+          <ul className="space-y-1">
+            {permissions.map((p) => (
+              <li key={`${p.userId}-${p.permission}`} className="flex items-center gap-2">
+                <span>
+                  {p.userId} - {p.permission}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => revokePermission(p.userId, p.permission)}
+                >
+                  Revoke
+                </Button>
+              </li>
+            ))}
+          </ul>
+          <div className="flex items-center gap-2">
+            <Input placeholder="User ID" value={userId} onChange={(e) => setUserId(e.target.value)} />
+            <Input
+              placeholder="Permission"
+              value={permission}
+              onChange={(e) => setPermission(e.target.value)}
+            />
+            <Button onClick={grantPermission}>Grant</Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/admin/permissions/RoleManagementPanel.tsx
+++ b/app/admin/permissions/RoleManagementPanel.tsx
@@ -1,0 +1,6 @@
+'use client';
+import { RoleManager } from '@/ui/styled/permission/RoleManager';
+
+export default function RoleManagementPanel() {
+  return <RoleManager />;
+}

--- a/app/admin/permissions/UserRoleAssignmentPanel.tsx
+++ b/app/admin/permissions/UserRoleAssignmentPanel.tsx
@@ -1,0 +1,14 @@
+'use client';
+import { useEffect } from 'react';
+import { useAdminUsers } from '@/hooks/admin/useAdminUsers';
+import RoleManagementPanel from '@/ui/styled/admin/RoleManagementPanel';
+
+export default function UserRoleAssignmentPanel() {
+  const { users, searchUsers } = useAdminUsers();
+
+  useEffect(() => {
+    searchUsers({});
+  }, [searchUsers]);
+
+  return <RoleManagementPanel users={users} />;
+}

--- a/app/admin/permissions/page.tsx
+++ b/app/admin/permissions/page.tsx
@@ -1,11 +1,40 @@
+'use client';
 import { Metadata } from 'next';
-import PermissionsManagementPageClient from './ClientPage';
+import RoleManagementPanel from './RoleManagementPanel';
+import UserRoleAssignmentPanel from './UserRoleAssignmentPanel';
+import ResourcePermissionPanel from './ResourcePermissionPanel';
+import AuditLogViewer from './AuditLogViewer';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/primitives/tabs';
 
 export const metadata: Metadata = {
   title: 'Permission Management',
-  description: 'Create and manage permissions for your application',
+  description: 'Manage roles and permissions',
 };
 
-export default function PermissionsManagementPage(): JSX.Element {
-  return <PermissionsManagementPageClient />;
+export default function PermissionDashboardPage() {
+  return (
+    <div className="container py-6 space-y-8">
+      <h1 className="text-3xl font-bold">Permission Management</h1>
+      <Tabs defaultValue="roles">
+        <TabsList>
+          <TabsTrigger value="roles">Roles</TabsTrigger>
+          <TabsTrigger value="users">User Assignments</TabsTrigger>
+          <TabsTrigger value="resources">Resource Permissions</TabsTrigger>
+          <TabsTrigger value="audit">Audit Log</TabsTrigger>
+        </TabsList>
+        <TabsContent value="roles">
+          <RoleManagementPanel />
+        </TabsContent>
+        <TabsContent value="users">
+          <UserRoleAssignmentPanel />
+        </TabsContent>
+        <TabsContent value="resources">
+          <ResourcePermissionPanel />
+        </TabsContent>
+        <TabsContent value="audit">
+          <AuditLogViewer />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add dashboard for permission management
- provide panels for roles, user assignments, resource permissions and audit logs

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683e9b02ee4083318f4e669ecdbb4606