### PR TITLE
Replace hardcoded keys in Playwright config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project-id.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-goes-here
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
+# Optional fallback credentials for Playwright tests
+PLAYWRIGHT_SUPABASE_URL=
+PLAYWRIGHT_SUPABASE_ANON_KEY=
+PLAYWRIGHT_SUPABASE_SERVICE_ROLE_KEY=
+
 # Database Configuration
 DATABASE_PROVIDER=supabase
 # Example connection string (optional)

--- a/e2e/utils/global-setup.ts
+++ b/e2e/utils/global-setup.ts
@@ -34,16 +34,16 @@ if (envResult.parsed) {
 } else {
   console.log('WARNING: No variables parsed from .env file in global setup, using fallback...');
   
-  // If dotenv parsing fails, manually set the known Supabase variables
-  // This is a fallback for when dotenv has parsing issues
+  // If dotenv parsing fails, use fallback environment variables instead of
+  // hardcoding secrets in the repository
   if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
-    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://izziigqgdurqsoyvajvu.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_URL = process.env.PLAYWRIGHT_SUPABASE_URL || '';
   }
   if (!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6emlpZ3FnZHVycXNveXZhanZ1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDE2MjYyODksImV4cCI6MjA1NzIwMjI4OX0.6njjAphh3g39kIi8jQJx8xsvelXP-zDrm-wP9-OJ1Fs';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = process.env.PLAYWRIGHT_SUPABASE_ANON_KEY || '';
   }
   if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
-    process.env.SUPABASE_SERVICE_ROLE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6emlpZ3FnZHVycXNveXZhanZ1Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc0MTYyNjI4OSwiZXhwIjoyMDU3MjAyMjg5fQ.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6emlpZ3FnZHVycXNveXZhanZ1Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc0MTYyNjI4OSwiZXhwIjoyMDU3MjAyMjg5fQ';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.PLAYWRIGHT_SUPABASE_SERVICE_ROLE_KEY || '';
   }
   
   console.log('Fallback environment variables in global setup:');

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,16 +38,16 @@ if (envResult.parsed && hasSupabaseInParsed) {
 } else {
   console.log('WARNING: No Supabase variables found in .env file, manually setting them...');
   
-  // If dotenv parsing fails or doesn't contain Supabase vars, manually set them
-  // This is a fallback for when dotenv has parsing issues
+  // If dotenv parsing fails or doesn't contain Supabase vars, use fallback
+  // environment variables to avoid hardcoding secrets in the repo
   if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
-    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://izziigqgdurqsoyvajvu.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_URL = process.env.PLAYWRIGHT_SUPABASE_URL || '';
   }
   if (!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6emlpZ3FnZHVycXNveXZhanZ1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDE2MjYyODksImV4cCI6MjA1NzIwMjI4OX0.6njjAphh3g39kIi8jQJx8xsvelXP-zDrm-wP9-OJ1Fs';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = process.env.PLAYWRIGHT_SUPABASE_ANON_KEY || '';
   }
   if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
-    process.env.SUPABASE_SERVICE_ROLE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6emlpZ3FnZHVycXNveXZhanZ1Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc0MTYyNjI4OSwiZXhwIjoyMDU3MjAyMjg5fQ.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6emlpZ3FnZHVycXNveXZhanZ1Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc0MTYyNjI4OSwiZXhwIjoyMDU3MjAyMjg5fQ';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.PLAYWRIGHT_SUPABASE_SERVICE_ROLE_KEY || '';
   }
   
   console.log('Fallback environment variables status:');


### PR DESCRIPTION
## Summary
- avoid committing real Supabase keys by reading fallback credentials from environment variables
- update Playwright global setup to use environment variables for fallbacks
- document new optional environment variables in `.env.example`

## Testing
- `npx vitest run --coverage src/lib/auth/__tests__/getUser.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_683e9c2100e08331bb7ea4017d42793c