### PR TITLE
Add resource relationship tracking

### DIFF
--- a/app/api/company/migrations/003_resource_relationships.sql
+++ b/app/api/company/migrations/003_resource_relationships.sql
@@ -1,0 +1,22 @@
+CREATE TABLE resource_relationships (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  parent_type VARCHAR(50) NOT NULL,
+  parent_id UUID NOT NULL, 
+  child_type VARCHAR(50) NOT NULL,
+  child_id UUID NOT NULL,
+  relationship_type VARCHAR(20) NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+  created_by UUID REFERENCES auth.users(id),
+  UNIQUE(parent_type, parent_id, child_type, child_id)
+);
+
+-- Create indexes for better query performance
+CREATE INDEX idx_resource_relationships_parent ON resource_relationships(parent_type, parent_id);
+CREATE INDEX idx_resource_relationships_child ON resource_relationships(child_type, child_id);
+
+-- Add updated_at trigger
+CREATE TRIGGER update_resource_relationships_updated_at
+    BEFORE UPDATE ON resource_relationships
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();

--- a/src/lib/services/__tests__/resource-relationship.service.test.ts
+++ b/src/lib/services/__tests__/resource-relationship.service.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ResourceRelationshipService } from '../resource-relationship.service';
+
+type QueryResult = Promise<{ data: any; error: any }>;
+
+describe('ResourceRelationshipService', () => {
+  let db: any;
+  let service: ResourceRelationshipService;
+
+  beforeEach(() => {
+    const single = vi.fn().mockResolvedValue({ data: { id: '1' }, error: null });
+    const insert = vi.fn(() => ({ select: () => ({ single }) }));
+
+    const eqFinal = vi.fn<QueryResult, []>(() => Promise.resolve({ data: [{ id: 1 }], error: null }));
+    const eq = vi.fn(() => ({ eq: eqFinal }));
+    const select = vi.fn(() => ({ eq }));
+    const delMatch = vi.fn().mockResolvedValue({ error: null });
+    const del = vi.fn(() => ({ match: delMatch }));
+
+    db = { from: vi.fn((table: string) => ({ insert, select, delete: del })) };
+    service = new ResourceRelationshipService(db);
+  });
+
+  it('creates relationship', async () => {
+    const res = await service.createRelationship({
+      parentType: 'org',
+      parentId: 'p1',
+      childType: 'team',
+      childId: 'c1',
+      relationshipType: 'member',
+    });
+    expect(db.from).toHaveBeenCalledWith('resource_relationships');
+    expect(res).toEqual({ data: { id: '1' }, error: null });
+  });
+
+  it('gets parent resources', async () => {
+    const result = await service.getParentResources('doc', 'd1');
+    expect(db.from).toHaveBeenCalledWith('resource_relationships');
+    expect(result).toEqual([{ id: 1 }]);
+  });
+
+  it('throws on getParentResources error', async () => {
+    const eqFinal = vi.fn<QueryResult, []>(() => Promise.resolve({ data: null, error: { message: 'fail' } }));
+    const eq = vi.fn(() => ({ eq: eqFinal }));
+    const select = vi.fn(() => ({ eq }));
+    db.from.mockReturnValueOnce({ select });
+    await expect(service.getParentResources('x','y')).rejects.toEqual({ message: 'fail' });
+  });
+
+  it('gets child resources', async () => {
+    const result = await service.getChildResources('org', 'o1');
+    expect(result).toEqual([{ id: 1 }]);
+  });
+
+  it('throws on getChildResources error', async () => {
+    const eqFinal = vi.fn<QueryResult, []>(() => Promise.resolve({ data: null, error: { message: 'oops' } }));
+    const eq = vi.fn(() => ({ eq: eqFinal }));
+    const select = vi.fn(() => ({ eq }));
+    db.from.mockReturnValueOnce({ select });
+    await expect(service.getChildResources('a','b')).rejects.toEqual({ message: 'oops' });
+  });
+
+  it('returns empty array when no child resources', async () => {
+    const eqFinal = vi.fn<QueryResult, []>(() => Promise.resolve({ data: null, error: null }));
+    const eq = vi.fn(() => ({ eq: eqFinal }));
+    const select = vi.fn(() => ({ eq }));
+    db.from.mockReturnValueOnce({ select });
+    const res = await service.getChildResources('x', 'y');
+    expect(res).toEqual([]);
+  });
+
+  it('deletes relationship', async () => {
+    await service.deleteRelationship('org','o1','team','t1');
+    expect(db.from).toHaveBeenCalledWith('resource_relationships');
+  });
+});

--- a/src/lib/services/resource-relationship.service.ts
+++ b/src/lib/services/resource-relationship.service.ts
@@ -1,0 +1,62 @@
+export class ResourceRelationshipService {
+  constructor(private db: any) {}
+
+  async createRelationship(relationship: {
+    parentType: string;
+    parentId: string;
+    childType: string;
+    childId: string;
+    relationshipType: string;
+    createdBy?: string;
+  }) {
+    return this.db
+      .from('resource_relationships')
+      .insert({
+        parent_type: relationship.parentType,
+        parent_id: relationship.parentId,
+        child_type: relationship.childType,
+        child_id: relationship.childId,
+        relationship_type: relationship.relationshipType,
+        created_by: relationship.createdBy
+      })
+      .select()
+      .single();
+  }
+
+  async getParentResources(resourceType: string, resourceId: string) {
+    const { data, error } = await this.db
+      .from('resource_relationships')
+      .select('parent_type, parent_id, relationship_type')
+      .eq('child_type', resourceType)
+      .eq('child_id', resourceId);
+    if (error) throw error;
+    return data || [];
+  }
+
+  async getChildResources(resourceType: string, resourceId: string) {
+    const { data, error } = await this.db
+      .from('resource_relationships')
+      .select('child_type, child_id, relationship_type')
+      .eq('parent_type', resourceType)
+      .eq('parent_id', resourceId);
+    if (error) throw error;
+    return data || [];
+  }
+
+  async deleteRelationship(
+    parentType: string,
+    parentId: string,
+    childType: string,
+    childId: string
+  ) {
+    return this.db
+      .from('resource_relationships')
+      .delete()
+      .match({
+        parent_type: parentType,
+        parent_id: parentId,
+        child_type: childType,
+        child_id: childId
+      });
+  }
+}


### PR DESCRIPTION
## Summary
- add migration for resource relationships table
- implement `ResourceRelationshipService`
- test service logic

## Testing
- `npx vitest run src/lib/services/__tests__/resource-relationship.service.test.ts`
- `npx vitest run --coverage src/lib/services/__tests__/resource-relationship.service.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_683e9f629eb08331b0e14b25a9010ef5