### PR TITLE
Add resource relationship API

### DIFF
--- a/app/api/resources/relationships/__tests__/route.test.ts
+++ b/app/api/resources/relationships/__tests__/route.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET, POST } from '../route';
+import { createResourceRelationshipService } from '@/services/resource-relationship/factory';
+
+vi.mock('@/middleware/createMiddlewareChain', async () => {
+  const actual = await vi.importActual<any>('@/middleware/createMiddlewareChain');
+  return {
+    ...actual,
+    routeAuthMiddleware: vi.fn(() => (handler: any) => handler),
+    errorHandlingMiddleware: vi.fn(() => (handler: any) => handler),
+    validationMiddleware: vi.fn(() => (handler: any) => (req: any, ctx: any) => handler(req, ctx, {
+      parentType: 'project',
+      parentId: 'p1',
+      childType: 'task',
+      childId: 't1',
+      relationshipType: 'contains',
+    })),
+    createMiddlewareChain: (mws: any[]) => (handler: any) => handler,
+  };
+});
+
+const service = {
+  getChildResources: vi.fn(),
+  getParentResources: vi.fn(),
+  createRelationship: vi.fn(),
+};
+
+vi.mock('@/services/resource-relationship/factory', () => ({
+  createResourceRelationshipService: vi.fn(() => service),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('resource relationships API', () => {
+  it('GET fetches children', async () => {
+    service.getChildResources.mockResolvedValue([{ id: '1' }]);
+    const req = new Request('http://test?parentType=project&parentId=p1');
+    const res = await GET(req as any);
+    const body = await res.json();
+    expect(body.data.relationships).toEqual([{ id: '1' }]);
+  });
+
+  it('GET fetches parents', async () => {
+    service.getParentResources.mockResolvedValue([{ id: '2' }]);
+    const req = new Request('http://test?childType=task&childId=t1');
+    const res = await GET(req as any);
+    const body = await res.json();
+    expect(body.data.relationships).toEqual([{ id: '2' }]);
+  });
+
+  it('POST creates relationship', async () => {
+    service.createRelationship.mockResolvedValue({ id: '3' });
+    const req = new Request('http://test', { method: 'POST' });
+    const res = await POST(req as any, { userId: 'u1' } as any, {
+      parentType: 'project',
+      parentId: 'p1',
+      childType: 'task',
+      childId: 't1',
+      relationshipType: 'contains',
+    });
+    const body = await res.json();
+    expect(body.data.relationship).toEqual({ id: '3' });
+  });
+});

--- a/app/api/resources/relationships/route.ts
+++ b/app/api/resources/relationships/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { getServiceSupabase } from '@/lib/database/supabase';
+import { createResourceRelationshipService } from '@/services/resource-relationship/factory';
+import {
+  createMiddlewareChain,
+  errorHandlingMiddleware,
+  routeAuthMiddleware,
+  validationMiddleware,
+} from '@/middleware/createMiddlewareChain';
+import { createSuccessResponse, createCreatedResponse } from '@/lib/api/common';
+
+const relationshipSchema = z.object({
+  parentType: z.string().min(1),
+  parentId: z.string().min(1),
+  childType: z.string().min(1),
+  childId: z.string().min(1),
+  relationshipType: z.string().min(1).default('contains'),
+});
+
+const middleware = createMiddlewareChain([
+  errorHandlingMiddleware(),
+  routeAuthMiddleware(),
+  validationMiddleware(relationshipSchema),
+]);
+
+async function handleGet(req: NextRequest) {
+  const url = new URL(req.url);
+  const parentType = url.searchParams.get('parentType');
+  const parentId = url.searchParams.get('parentId');
+  const childType = url.searchParams.get('childType');
+  const childId = url.searchParams.get('childId');
+
+  if (!((parentType && parentId) || (childType && childId))) {
+    return Response.json(
+      { error: 'Must provide either parent or child resource identifiers' },
+      { status: 400 }
+    );
+  }
+
+  const service = createResourceRelationshipService(getServiceSupabase());
+
+  if (parentType && parentId) {
+    const children = await service.getChildResources(parentType, parentId);
+    return createSuccessResponse({ relationships: children });
+  } else {
+    const parents = await service.getParentResources(childType!, childId!);
+    return createSuccessResponse({ relationships: parents });
+  }
+}
+
+async function handlePost(
+  req: NextRequest,
+  auth: any,
+  data: z.infer<typeof relationshipSchema>
+) {
+  const service = createResourceRelationshipService(getServiceSupabase());
+  const relationship = await service.createRelationship({
+    ...data,
+    createdBy: auth.userId,
+  });
+
+  return createCreatedResponse({ relationship });
+}
+
+export const GET = (req: NextRequest) =>
+  errorHandlingMiddleware()(routeAuthMiddleware()(handleGet))(req);
+
+export const POST = middleware(handlePost);

--- a/src/adapters/resource-relationship/supabase-provider.ts
+++ b/src/adapters/resource-relationship/supabase-provider.ts
@@ -1,0 +1,69 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import type { IResourceRelationshipDataProvider } from '@/core/resource-relationship/IResourceRelationshipDataProvider';
+import type { ResourceRelationship, CreateRelationshipPayload } from '@/core/resource-relationship/models';
+
+export class SupabaseResourceRelationshipProvider implements IResourceRelationshipDataProvider {
+  constructor(private supabase: SupabaseClient) {}
+
+  private map(row: any): ResourceRelationship {
+    return {
+      id: row.id,
+      parentType: row.parent_type,
+      parentId: row.parent_id,
+      childType: row.child_type,
+      childId: row.child_id,
+      relationshipType: row.relationship_type,
+    };
+  }
+
+  async createRelationship(payload: CreateRelationshipPayload): Promise<ResourceRelationship> {
+    const { data, error } = await this.supabase
+      .from('resource_relationships')
+      .insert({
+        parent_type: payload.parentType,
+        parent_id: payload.parentId,
+        child_type: payload.childType,
+        child_id: payload.childId,
+        relationship_type: payload.relationshipType,
+      })
+      .select('*')
+      .single();
+    if (error || !data) {
+      throw new Error(error?.message || 'failed to create relationship');
+    }
+    return this.map(data);
+  }
+
+  async getChildRelationships(parentType: string, parentId: string): Promise<ResourceRelationship[]> {
+    const { data, error } = await this.supabase
+      .from('resource_relationships')
+      .select('*')
+      .eq('parent_type', parentType)
+      .eq('parent_id', parentId);
+    if (error || !data) return [];
+    return data.map((r: any) => this.map(r));
+  }
+
+  async getParentRelationships(childType: string, childId: string): Promise<ResourceRelationship[]> {
+    const { data, error } = await this.supabase
+      .from('resource_relationships')
+      .select('*')
+      .eq('child_type', childType)
+      .eq('child_id', childId);
+    if (error || !data) return [];
+    return data.map((r: any) => this.map(r));
+  }
+
+  async removeRelationship(parentType: string, parentId: string, childType: string, childId: string): Promise<boolean> {
+    const { error } = await this.supabase
+      .from('resource_relationships')
+      .delete()
+      .eq('parent_type', parentType)
+      .eq('parent_id', parentId)
+      .eq('child_type', childType)
+      .eq('child_id', childId);
+    return !error;
+  }
+}
+
+export default SupabaseResourceRelationshipProvider;

--- a/src/core/resource-relationship/IResourceRelationshipDataProvider.ts
+++ b/src/core/resource-relationship/IResourceRelationshipDataProvider.ts
@@ -1,0 +1,8 @@
+import type { ResourceRelationship, CreateRelationshipPayload } from './models';
+
+export interface IResourceRelationshipDataProvider {
+  createRelationship(payload: CreateRelationshipPayload): Promise<ResourceRelationship>;
+  getChildRelationships(parentType: string, parentId: string): Promise<ResourceRelationship[]>;
+  getParentRelationships(childType: string, childId: string): Promise<ResourceRelationship[]>;
+  removeRelationship(parentType: string, parentId: string, childType: string, childId: string): Promise<boolean>;
+}

--- a/src/core/resource-relationship/index.ts
+++ b/src/core/resource-relationship/index.ts
@@ -1,0 +1,2 @@
+export * from './models';
+export * from './interfaces';

--- a/src/core/resource-relationship/interfaces.ts
+++ b/src/core/resource-relationship/interfaces.ts
@@ -1,0 +1,8 @@
+import type { ResourceRelationship, CreateRelationshipPayload } from './models';
+
+export interface ResourceRelationshipService {
+  getChildResources(parentType: string, parentId: string): Promise<ResourceRelationship[]>;
+  getParentResources(childType: string, childId: string): Promise<ResourceRelationship[]>;
+  createRelationship(payload: CreateRelationshipPayload): Promise<ResourceRelationship>;
+  removeRelationship(parentType: string, parentId: string, childType: string, childId: string): Promise<boolean>;
+}

--- a/src/core/resource-relationship/models.ts
+++ b/src/core/resource-relationship/models.ts
@@ -1,0 +1,17 @@
+export interface ResourceRelationship {
+  id: string;
+  parentType: string;
+  parentId: string;
+  childType: string;
+  childId: string;
+  relationshipType: string;
+}
+
+export interface CreateRelationshipPayload {
+  parentType: string;
+  parentId: string;
+  childType: string;
+  childId: string;
+  relationshipType: string;
+  createdBy: string;
+}

--- a/src/services/resource-relationship/__tests__/default-resource-relationship.service.test.ts
+++ b/src/services/resource-relationship/__tests__/default-resource-relationship.service.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { DefaultResourceRelationshipService } from '../default-resource-relationship.service';
+import type { IResourceRelationshipDataProvider } from '@/core/resource-relationship/IResourceRelationshipDataProvider';
+
+const relationship = {
+  id: '1',
+  parentType: 'project',
+  parentId: 'p1',
+  childType: 'task',
+  childId: 't1',
+  relationshipType: 'contains',
+};
+
+describe('DefaultResourceRelationshipService', () => {
+  let provider: IResourceRelationshipDataProvider;
+  let service: DefaultResourceRelationshipService;
+
+  beforeEach(() => {
+    provider = {
+      createRelationship: vi.fn().mockResolvedValue(relationship),
+      getChildRelationships: vi.fn().mockResolvedValue([relationship]),
+      getParentRelationships: vi.fn().mockResolvedValue([relationship]),
+      removeRelationship: vi.fn().mockResolvedValue(true),
+    };
+    service = new DefaultResourceRelationshipService(provider);
+  });
+
+  it('creates relationship', async () => {
+    const res = await service.createRelationship({
+      parentType: 'project',
+      parentId: 'p1',
+      childType: 'task',
+      childId: 't1',
+      relationshipType: 'contains',
+      createdBy: 'u1',
+    });
+    expect(res).toEqual(relationship);
+    expect(provider.createRelationship).toHaveBeenCalled();
+  });
+
+  it('gets children', async () => {
+    const res = await service.getChildResources('project', 'p1');
+    expect(res).toEqual([relationship]);
+    expect(provider.getChildRelationships).toHaveBeenCalledWith('project', 'p1');
+  });
+
+  it('gets parents', async () => {
+    const res = await service.getParentResources('task', 't1');
+    expect(res).toEqual([relationship]);
+    expect(provider.getParentRelationships).toHaveBeenCalledWith('task', 't1');
+  });
+
+  it('removes relationship', async () => {
+    const ok = await service.removeRelationship('project', 'p1', 'task', 't1');
+    expect(ok).toBe(true);
+    expect(provider.removeRelationship).toHaveBeenCalledWith('project', 'p1', 'task', 't1');
+  });
+});

--- a/src/services/resource-relationship/default-resource-relationship.service.ts
+++ b/src/services/resource-relationship/default-resource-relationship.service.ts
@@ -1,0 +1,23 @@
+import type { ResourceRelationshipService } from '@/core/resource-relationship/interfaces';
+import type { IResourceRelationshipDataProvider } from '@/core/resource-relationship/IResourceRelationshipDataProvider';
+import type { CreateRelationshipPayload, ResourceRelationship } from '@/core/resource-relationship/models';
+
+export class DefaultResourceRelationshipService implements ResourceRelationshipService {
+  constructor(private provider: IResourceRelationshipDataProvider) {}
+
+  getChildResources(parentType: string, parentId: string): Promise<ResourceRelationship[]> {
+    return this.provider.getChildRelationships(parentType, parentId);
+  }
+
+  getParentResources(childType: string, childId: string): Promise<ResourceRelationship[]> {
+    return this.provider.getParentRelationships(childType, childId);
+  }
+
+  createRelationship(payload: CreateRelationshipPayload): Promise<ResourceRelationship> {
+    return this.provider.createRelationship(payload);
+  }
+
+  removeRelationship(parentType: string, parentId: string, childType: string, childId: string): Promise<boolean> {
+    return this.provider.removeRelationship(parentType, parentId, childType, childId);
+  }
+}

--- a/src/services/resource-relationship/factory.ts
+++ b/src/services/resource-relationship/factory.ts
@@ -1,0 +1,19 @@
+import { AdapterRegistry } from '@/adapters/registry';
+import { getServiceSupabase } from '@/lib/database/supabase';
+import type { ResourceRelationshipService } from '@/core/resource-relationship/interfaces';
+import type { IResourceRelationshipDataProvider } from '@/core/resource-relationship/IResourceRelationshipDataProvider';
+import { DefaultResourceRelationshipService } from './default-resource-relationship.service';
+import { SupabaseResourceRelationshipProvider } from '@/adapters/resource-relationship/supabase-provider';
+
+export function createResourceRelationshipService(
+  supabase = getServiceSupabase(),
+): ResourceRelationshipService {
+  let provider: IResourceRelationshipDataProvider | null = null;
+  try {
+    provider = AdapterRegistry.getInstance().getAdapter<IResourceRelationshipDataProvider>('resourceRelationship');
+  } catch {
+    provider = new SupabaseResourceRelationshipProvider(supabase);
+    AdapterRegistry.getInstance().registerAdapter('resourceRelationship', provider);
+  }
+  return new DefaultResourceRelationshipService(provider);
+}

--- a/src/services/resource-relationship/index.ts
+++ b/src/services/resource-relationship/index.ts
@@ -1,0 +1,2 @@
+export * from './factory';
+export * from './default-resource-relationship.service';


### PR DESCRIPTION
## Summary
- implement resource relationship data models and service layer
- add Supabase provider and service factory
- create API route for resource relationships
- test service and API endpoints

## Testing
- `npx vitest run --coverage`

------
https://chatgpt.com/codex/tasks/task_b_683e9f8a5ba483318ae243ddce12b179