### PR TITLE
Add ErrorDisplay component

### DIFF
--- a/src/components/ui/errors/ErrorDisplay.tsx
+++ b/src/components/ui/errors/ErrorDisplay.tsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useRef } from 'react';
+import { Alert, AlertTitle, AlertDescription } from '@/ui/primitives/alert';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle as DialogHeading } from '@/ui/primitives/dialog';
+import { Button } from '@/ui/primitives/button';
+import { toast } from '@/lib/hooks/use-toast';
+import { ScreenReaderAnnouncement } from '../ScreenReaderAnnouncement';
+
+export type ErrorSeverity = 'info' | 'warning' | 'error';
+export type ErrorStyle = 'inline' | 'toast' | 'modal';
+
+export interface ErrorDisplayProps {
+  message: string;
+  details?: React.ReactNode;
+  severity?: ErrorSeverity;
+  style?: ErrorStyle;
+  onRetry?: () => void;
+  /** Modal open state when style="modal" */
+  isOpen?: boolean;
+  /** Modal open change handler when style="modal" */
+  onOpenChange?: (open: boolean) => void;
+}
+
+const severityIcon = {
+  info: null,
+  warning: null,
+  error: null,
+};
+
+/**
+ * Generic error display component supporting inline, toast and modal styles.
+ * Includes accessibility features and optional retry functionality.
+ */
+export function ErrorDisplay({
+  message,
+  details,
+  severity = 'error',
+  style = 'inline',
+  onRetry,
+  isOpen,
+  onOpenChange,
+}: ErrorDisplayProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (style === 'toast') {
+      toast({
+        title: message,
+        description: details,
+        variant: severity === 'error' ? 'destructive' : severity,
+      });
+    }
+  }, [message, details, severity, style]);
+
+  useEffect(() => {
+    if (style === 'modal' && isOpen && dialogRef.current) {
+      dialogRef.current.focus();
+    }
+  }, [style, isOpen]);
+
+  if (style === 'toast') {
+    return <ScreenReaderAnnouncement message={message} assertive />;
+  }
+
+  if (style === 'modal') {
+    return (
+      <Dialog open={isOpen} onOpenChange={onOpenChange}>
+        <DialogContent ref={dialogRef} tabIndex={-1} aria-labelledby="error-title">
+          <DialogHeader>
+            <DialogHeading id="error-title">Error</DialogHeading>
+          </DialogHeader>
+          <p>{message}</p>
+          {details && <div className="mt-2 text-sm text-muted-foreground">{details}</div>}
+          <DialogFooter className="mt-4">
+            {onRetry && (
+              <Button onClick={onRetry}>Retry</Button>
+            )}
+            <Button variant="secondary" onClick={() => onOpenChange?.(false)}>Close</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Alert role="alert" className="flex flex-col gap-2" aria-live="assertive">
+      <AlertTitle>{message}</AlertTitle>
+      {details && <AlertDescription>{details}</AlertDescription>}
+      {onRetry && (
+        <Button size="sm" variant="outline" onClick={onRetry} className="self-start">
+          Retry
+        </Button>
+      )}
+    </Alert>
+  );
+}
+
+interface SpecializedProps extends Omit<ErrorDisplayProps, 'severity' | 'style'> {
+  style?: ErrorStyle;
+}
+
+export function ValidationErrorDisplay(props: SpecializedProps) {
+  return <ErrorDisplay severity="error" {...props} />;
+}
+
+export function NetworkErrorDisplay({
+  message = 'Network error. Please check your connection.',
+  style = 'toast',
+  ...rest
+}: SpecializedProps) {
+  return <ErrorDisplay severity="error" message={message} style={style} {...rest} />;
+}
+
+export function NotFoundErrorDisplay({
+  message = 'The requested resource was not found.',
+  style = 'inline',
+  ...rest
+}: SpecializedProps) {
+  return <ErrorDisplay severity="warning" message={message} style={style} {...rest} />;
+}
+
+export function PermissionErrorDisplay({
+  message = 'You do not have permission to perform this action.',
+  style = 'inline',
+  ...rest
+}: SpecializedProps) {
+  return <ErrorDisplay severity="error" message={message} style={style} {...rest} />;
+}
+
+export default ErrorDisplay;

--- a/src/components/ui/errors/__tests__/ErrorDisplay.test.tsx
+++ b/src/components/ui/errors/__tests__/ErrorDisplay.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { ErrorDisplay, NetworkErrorDisplay, ValidationErrorDisplay } from '../ErrorDisplay';
+import { toast } from '@/lib/hooks/use-toast';
+
+vi.mock('@/lib/hooks/use-toast', () => {
+  return {
+    toast: vi.fn(),
+  };
+});
+
+describe('ErrorDisplay', () => {
+  it('renders inline error and triggers retry', async () => {
+    const retry = vi.fn();
+    const user = userEvent.setup();
+    render(<ErrorDisplay message="Failed" onRetry={retry} />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed');
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    expect(retry).toHaveBeenCalled();
+  });
+
+  it('shows toast for toast style', () => {
+    render(<ErrorDisplay message="Toast error" style="toast" />);
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({ title: 'Toast error' }));
+  });
+
+  it('renders modal when style modal', () => {
+    render(<ErrorDisplay message="Modal" style="modal" isOpen onOpenChange={() => {}} />);
+    expect(screen.getByText('Modal')).toBeInTheDocument();
+  });
+
+  it('specialized component uses defaults', () => {
+    render(<NetworkErrorDisplay />);
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({ title: expect.stringContaining('Network error') }));
+
+    render(<ValidationErrorDisplay message="Form invalid" />);
+    expect(screen.getByText('Form invalid')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add flexible `ErrorDisplay` component with toast, inline, and modal styles
- provide specialized error components
- test error display logic

## Testing
- `npx vitest run src/components/ui/errors/__tests__/ErrorDisplay.test.tsx --coverage`


------
https://chatgpt.com/codex/tasks/task_b_683ea033a4e48331a186032a2a4384fb