### PR TITLE
Add enhanced error boundary and handling hooks

### DIFF
--- a/src/components/ui/errors/ErrorBoundary.tsx
+++ b/src/components/ui/errors/ErrorBoundary.tsx
@@ -1,0 +1,159 @@
+import React, { Component, ErrorInfo } from 'react';
+import { Alert, AlertDescription, AlertTitle } from '@/ui/primitives/alert';
+import { Button } from '@/ui/primitives/button';
+import { AlertOctagon, RefreshCw } from 'lucide-react';
+import { analytics } from '@/lib/utils/analytics';
+import type { ApplicationError } from '@/core/common/errors';
+
+export interface ErrorBoundaryOptions {
+  fallback?: React.ReactNode | ((error: Error, reset: () => void) => React.ReactNode);
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryProps extends ErrorBoundaryOptions {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    analytics.trackError(error);
+    this.props.onError?.(error, info);
+  }
+
+  resetErrorBoundary = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError && this.state.error) {
+      if (this.props.fallback) {
+        return typeof this.props.fallback === 'function'
+          ? this.props.fallback(this.state.error, this.resetErrorBoundary)
+          : this.props.fallback;
+      }
+
+      return (
+        <Alert variant="destructive">
+          <AlertOctagon className="h-4 w-4" />
+          <AlertTitle>Something went wrong</AlertTitle>
+          <AlertDescription>
+            <div className="mt-2">
+              {this.state.error.message || 'An unexpected error occurred'}
+            </div>
+            <Button
+              onClick={this.resetErrorBoundary}
+              variant="outline"
+              size="sm"
+              className="mt-4 gap-2"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+              <span>Try Again</span>
+            </Button>
+          </AlertDescription>
+        </Alert>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export function withErrorBoundary<P>(
+  Component: React.ComponentType<P>,
+  options?: ErrorBoundaryOptions
+): React.ComponentType<P> {
+  const Wrapped: React.FC<P> = (props) => (
+    <ErrorBoundary {...options}>
+      <Component {...props} />
+    </ErrorBoundary>
+  );
+
+  Wrapped.displayName = `withErrorBoundary(${Component.displayName || Component.name || 'Component'})`;
+  return Wrapped;
+}
+
+export function CriticalSectionErrorBoundary({ children, ...options }: ErrorBoundaryProps) {
+  return (
+    <ErrorBoundary
+      {...options}
+      fallback={options.fallback || ((error, reset) => (
+        <Alert variant="destructive">
+          <AlertOctagon className="h-4 w-4" />
+          <AlertTitle>Critical failure</AlertTitle>
+          <AlertDescription>
+            <div className="mt-2">{error.message}</div>
+            <Button onClick={reset} variant="outline" size="sm" className="mt-4 gap-2">
+              <RefreshCw className="h-3.5 w-3.5" />
+              <span>Reload</span>
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ))}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+export function RouteErrorBoundary({ children, ...options }: ErrorBoundaryProps) {
+  return (
+    <ErrorBoundary
+      {...options}
+      fallback={options.fallback || ((error, reset) => (
+        <Alert variant="destructive">
+          <AlertOctagon className="h-4 w-4" />
+          <AlertTitle>Page failed to load</AlertTitle>
+          <AlertDescription>
+            <div className="mt-2">{error.message}</div>
+            <Button onClick={reset} variant="outline" size="sm" className="mt-4 gap-2">
+              <RefreshCw className="h-3.5 w-3.5" />
+              <span>Retry</span>
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ))}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+export function FormErrorBoundary({ children, ...options }: ErrorBoundaryProps) {
+  return (
+    <ErrorBoundary
+      {...options}
+      fallback={options.fallback || ((error, reset) => (
+        <Alert variant="destructive">
+          <AlertOctagon className="h-4 w-4" />
+          <AlertTitle>Form Error</AlertTitle>
+          <AlertDescription>
+            <div className="mt-2">{error.message}</div>
+            <Button type="button" onClick={reset} variant="outline" size="sm" className="mt-4 gap-2">
+              <RefreshCw className="h-3.5 w-3.5" />
+              <span>Try Again</span>
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ))}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+export type { ApplicationError };
+export default ErrorBoundary;

--- a/src/components/ui/errors/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/ui/errors/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { ErrorBoundary } from '../ErrorBoundary';
+
+function ProblemChild() {
+  throw new Error('boom');
+}
+
+describe('ErrorBoundary', () => {
+  it('renders fallback on error and recovers', () => {
+    const { rerender } = render(
+      <ErrorBoundary>
+        <ProblemChild />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+
+    rerender(
+      <ErrorBoundary>
+        <div>safe</div>
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('safe')).toBeInTheDocument();
+  });
+});

--- a/src/hooks/errors/__tests__/useErrorHandling.test.tsx
+++ b/src/hooks/errors/__tests__/useErrorHandling.test.tsx
@@ -1,0 +1,36 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useErrorHandling } from '../useErrorHandling';
+
+describe('useErrorHandling', () => {
+  it('handles errors and clears them', () => {
+    const { result } = renderHook(() => useErrorHandling());
+    act(() => {
+      result.current.handleError(new Error('oops'));
+    });
+    expect(result.current.error?.message).toBe('oops');
+    act(() => {
+      result.current.clearError();
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('retries with exponential backoff', async () => {
+    vi.useFakeTimers();
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue(undefined);
+    const { result } = renderHook(() => useErrorHandling({ retryFn: fn }));
+    const promise = act(async () => {
+      const p = result.current.retry();
+      vi.runAllTimers();
+      await p;
+    });
+    await promise;
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(result.current.error).toBeNull();
+    expect(result.current.retryCount).toBe(0);
+    vi.useRealTimers();
+  });
+});

--- a/src/hooks/errors/useErrorHandling.ts
+++ b/src/hooks/errors/useErrorHandling.ts
@@ -1,0 +1,88 @@
+import { useCallback, useState } from 'react';
+import { ApplicationError, SERVER_ERROR, createError } from '@/core/common/errors';
+
+export interface RetryStrategy {
+  (attempt: number): number;
+}
+
+export interface UseErrorHandlingOptions {
+  retryFn?: () => Promise<void>;
+  maxRetries?: number;
+  retryStrategy?: RetryStrategy;
+}
+
+interface State {
+  isLoading: boolean;
+  error: ApplicationError | null;
+  retryCount: number;
+}
+
+const defaultStrategy: RetryStrategy = (attempt) => 2 ** attempt * 100;
+
+export function useErrorHandling(options: UseErrorHandlingOptions = {}) {
+  const { retryFn, maxRetries = 3, retryStrategy = defaultStrategy } = options;
+
+  const [state, setState] = useState<State>({ isLoading: false, error: null, retryCount: 0 });
+
+  const handleError = useCallback((err: unknown) => {
+    let appError: ApplicationError;
+    if (err instanceof ApplicationError) {
+      appError = err;
+    } else if (err instanceof Error) {
+      appError = new ApplicationError(SERVER_ERROR.SERVER_001, err.message);
+    } else {
+      appError = new ApplicationError(SERVER_ERROR.SERVER_001, 'Unknown error');
+    }
+    setState((s) => ({ ...s, error: appError, isLoading: false }));
+  }, []);
+
+  const clearError = useCallback(() => {
+    setState((s) => ({ ...s, error: null, retryCount: 0 }));
+  }, []);
+
+  const retry = useCallback(async () => {
+    if (!retryFn) return;
+    let attempt = 0;
+    setState((s) => ({ ...s, isLoading: true }));
+    while (attempt < maxRetries) {
+      try {
+        await retryFn();
+        setState({ isLoading: false, error: null, retryCount: 0 });
+        return;
+      } catch (err) {
+        attempt += 1;
+        if (attempt >= maxRetries) {
+          handleError(err);
+          setState((s) => ({ ...s, isLoading: false, retryCount: attempt }));
+          return;
+        }
+        setState((s) => ({ ...s, retryCount: attempt }));
+        const delay = retryStrategy(attempt);
+        await new Promise((res) => setTimeout(res, delay));
+      }
+    }
+  }, [retryFn, maxRetries, retryStrategy, handleError]);
+
+  return {
+    handleError,
+    isLoading: state.isLoading,
+    error: state.error,
+    clearError,
+    retry,
+    retryCount: state.retryCount,
+  };
+}
+
+export function useApiErrorHandling(apiCall: () => Promise<void>, options?: Omit<UseErrorHandlingOptions, 'retryFn'>) {
+  return useErrorHandling({ ...options, retryFn: apiCall });
+}
+
+export function useFormErrorHandling(submit: () => Promise<void>, options?: Omit<UseErrorHandlingOptions, 'retryFn'>) {
+  return useErrorHandling({ ...options, retryFn: submit });
+}
+
+export function useAuthErrorHandling(authCall: () => Promise<void>, options?: Omit<UseErrorHandlingOptions, 'retryFn'>) {
+  return useErrorHandling({ ...options, retryFn: authCall });
+}
+
+export default useErrorHandling;


### PR DESCRIPTION
## Summary
- add a robust ErrorBoundary component with HOC and specialized wrappers
- implement `useErrorHandling` hook with retry logic
- expose specialized hooks for API, forms and auth errors
- cover new utilities with tests

## Testing
- `npm run test:coverage` *(fails: environment lacks network access)*

------
https://chatgpt.com/codex/tasks/task_b_683ea05b2c5c83319c3e60f8a1d41378