### PR TITLE
Add monitoring error logger

### DIFF
--- a/src/lib/monitoring/__tests__/error-logger.test.ts
+++ b/src/lib/monitoring/__tests__/error-logger.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ErrorLogger, ConsoleTransport, LogEntry } from '../error-logger';
+
+class MemoryTransport implements ConsoleTransport {
+  entries: LogEntry[] = [];
+  log(entry: LogEntry) {
+    this.entries.push(entry);
+  }
+}
+
+describe('ErrorLogger', () => {
+  let transport: MemoryTransport;
+  let logger: ErrorLogger;
+
+  beforeEach(() => {
+    transport = new MemoryTransport();
+    logger = new ErrorLogger([transport], 2);
+  });
+
+  it('buffers and flushes logs', () => {
+    logger.info('a');
+    expect(transport.entries.length).toBe(0);
+    logger.info('b');
+    expect(transport.entries.length).toBe(2);
+  });
+
+  it('sanitizes sensitive fields', () => {
+    logger.error('boom', { user: '1', password: 'secret', token: 't' });
+    logger.flush();
+    expect(transport.entries[0].context).toEqual({ user: '1', password: '[REDACTED]', token: '[REDACTED]' });
+  });
+
+  it('specialized methods set types', () => {
+    const err = new Error('oops');
+    logger.logServiceError(err, { service: 'svc' });
+    logger.flush();
+    expect(transport.entries[0].context.type).toBe('service');
+    expect(transport.entries[0].context.service).toBe('svc');
+  });
+});

--- a/src/lib/monitoring/error-logger.ts
+++ b/src/lib/monitoring/error-logger.ts
@@ -1,0 +1,139 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'critical';
+
+export interface LogContext {
+  user?: string;
+  service?: string;
+  action?: string;
+  [key: string]: any;
+}
+
+export interface LogEntry {
+  timestamp: string;
+  level: LogLevel;
+  message: string;
+  context: LogContext;
+}
+
+export interface LogTransport {
+  log(entry: LogEntry): void;
+}
+
+function sanitizeContext(context: LogContext): LogContext {
+  const clone: LogContext = { ...context };
+  if ('password' in clone) clone.password = '[REDACTED]';
+  if ('token' in clone) clone.token = '[REDACTED]';
+  if ('authorization' in clone) clone.authorization = '[REDACTED]';
+  return clone;
+}
+
+export class ConsoleTransport implements LogTransport {
+  log(entry: LogEntry) {
+    const method = entry.level === 'error' || entry.level === 'critical'
+      ? console.error
+      : entry.level === 'warn'
+        ? console.warn
+        : console.log;
+    method(`[${entry.level.toUpperCase()}] ${entry.message}`, entry.context);
+  }
+}
+
+import fs from 'fs';
+
+export class FileTransport implements LogTransport {
+  constructor(private filePath: string = 'error.log') {}
+
+  log(entry: LogEntry) {
+    const line = JSON.stringify(entry) + '\n';
+    try {
+      fs.appendFileSync(this.filePath, line, 'utf8');
+    } catch (err) {
+      console.error('FileTransport failed', err);
+    }
+  }
+}
+
+export type ExternalLogger = (entry: LogEntry) => void;
+
+export class ExternalTransport implements LogTransport {
+  constructor(private send: ExternalLogger) {}
+
+  log(entry: LogEntry) {
+    try {
+      this.send(entry);
+    } catch (err) {
+      console.error('ExternalTransport failed', err);
+    }
+  }
+}
+
+function defaultTransports(): LogTransport[] {
+  const list: LogTransport[] = [];
+  const { NODE_ENV, MONITORING_SERVICE } = process.env;
+  if (NODE_ENV === 'development') {
+    list.push(new ConsoleTransport());
+  }
+  if (NODE_ENV === 'production') {
+    list.push(new FileTransport());
+  }
+  if (MONITORING_SERVICE) {
+    list.push(new ExternalTransport(() => {}));
+  }
+  return list;
+}
+
+export class ErrorLogger {
+  private buffer: LogEntry[] = [];
+  private transports: LogTransport[];
+  private bufferSize: number;
+
+  constructor(transports: LogTransport[] = defaultTransports(), bufferSize = 5) {
+    this.transports = transports;
+    this.bufferSize = bufferSize;
+  }
+
+  log(level: LogLevel, message: string, context: LogContext = {}) {
+    const entry: LogEntry = {
+      timestamp: new Date().toISOString(),
+      level,
+      message,
+      context: sanitizeContext(context),
+    };
+    this.buffer.push(entry);
+    if (this.buffer.length >= this.bufferSize) {
+      this.flush();
+    }
+  }
+
+  flush() {
+    const entries = this.buffer.splice(0);
+    for (const entry of entries) {
+      for (const t of this.transports) {
+        t.log(entry);
+      }
+    }
+  }
+
+  debug(msg: string, ctx?: LogContext) { this.log('debug', msg, ctx); }
+  info(msg: string, ctx?: LogContext) { this.log('info', msg, ctx); }
+  warn(msg: string, ctx?: LogContext) { this.log('warn', msg, ctx); }
+  error(msg: string, ctx?: LogContext) { this.log('error', msg, ctx); }
+  critical(msg: string, ctx?: LogContext) { this.log('critical', msg, ctx); }
+
+  logServiceError(error: Error, context: LogContext = {}) {
+    this.error(error.message, { ...context, stack: error.stack, type: 'service' });
+  }
+
+  logApiError(error: Error, context: LogContext = {}) {
+    this.warn(error.message, { ...context, stack: error.stack, type: 'api' });
+  }
+
+  logClientError(error: Error, context: LogContext = {}) {
+    this.warn(error.message, { ...context, stack: error.stack, type: 'client' });
+  }
+
+  logSecurityEvent(message: string, context: LogContext = {}) {
+    this.critical(message, { ...context, type: 'security' });
+  }
+}
+
+export const errorLogger = new ErrorLogger();


### PR DESCRIPTION
## Summary
- implement a monitoring `ErrorLogger` service with buffer and transports
- add unit tests for the logger

## Testing
- `bun x vitest run` *(fails: node:inspector not implemented)*

------
https://chatgpt.com/codex/tasks/task_b_683ea412bc7c833183d0b4cdc59c2329