### PR TITLE
Implement correlation ID tracking utilities

### DIFF
--- a/src/lib/monitoring/__tests__/correlation-id.test.ts
+++ b/src/lib/monitoring/__tests__/correlation-id.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { validate as uuidValidate } from 'uuid';
+import React from 'react';
+import {
+  generateCorrelationId,
+  runWithCorrelationId,
+  getCorrelationId,
+  correlationIdMiddleware,
+  CorrelationIdProvider,
+  useCorrelationId,
+} from '../correlation-id';
+import { render, screen } from '@testing-library/react';
+
+const DisplayId = () => {
+  const id = useCorrelationId();
+  return <div data-testid="cid">{id}</div>;
+};
+
+describe('correlation-id utilities', () => {
+  it('generates valid uuid v4', () => {
+    const id = generateCorrelationId();
+    expect(uuidValidate(id)).toBe(true);
+  });
+
+  it('creates hierarchical ids', () => {
+    const parent = 'parent';
+    const id = generateCorrelationId(parent);
+    expect(id.startsWith(`${parent}.`)).toBe(true);
+    const child = id.split('.')[1];
+    expect(uuidValidate(child)).toBe(true);
+  });
+
+  it('runWithCorrelationId provides id in context', () => {
+    const id = generateCorrelationId();
+    const value = runWithCorrelationId(id, () => getCorrelationId());
+    expect(value).toBe(id);
+    expect(getCorrelationId()).toBeUndefined();
+  });
+
+  it('React provider exposes id via context', () => {
+    render(
+      <CorrelationIdProvider correlationId="test-id">
+        <DisplayId />
+      </CorrelationIdProvider>
+    );
+    expect(screen.getByTestId('cid').textContent).toBe('test-id');
+  });
+});
+
+describe('correlationIdMiddleware', () => {
+  it('assigns correlation id and sets header', async () => {
+    const middleware = correlationIdMiddleware();
+    const { req, res } = createMocks();
+    const next = async () => {
+      expect(getCorrelationId()).toBe((req as any).correlationId);
+    };
+
+    await middleware(req as any, res as any, next);
+
+    const id = (req as any).correlationId;
+    expect(uuidValidate(id)).toBe(true);
+    expect(res.getHeader('X-Correlation-Id')).toBe(id);
+  });
+
+  it('attaches correlation id to errors', async () => {
+    const middleware = correlationIdMiddleware();
+    const { req, res } = createMocks();
+    const next = async () => {
+      throw new Error('failure');
+    };
+
+    try {
+      await middleware(req as any, res as any, next);
+    } catch (e: any) {
+      expect(e.correlationId).toBe((req as any).correlationId);
+    }
+  });
+});

--- a/src/lib/monitoring/correlation-id.ts
+++ b/src/lib/monitoring/correlation-id.ts
@@ -1,0 +1,92 @@
+import { v4 as uuidv4 } from 'uuid';
+import { AsyncLocalStorage } from 'async_hooks';
+import { isServer } from '@/core/platform';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import React, { createContext, useContext } from 'react';
+
+interface Store { correlationId: string; }
+
+const asyncStorage: AsyncLocalStorage<Store> | undefined =
+  isServer ? new AsyncLocalStorage<Store>() : undefined;
+
+let clientCorrelationId: string | undefined;
+
+const CorrelationIdContext = createContext<string | undefined>(undefined);
+
+export interface CorrelationIdProviderProps {
+  correlationId?: string;
+  children: React.ReactNode;
+}
+
+export function CorrelationIdProvider({
+  correlationId,
+  children,
+}: CorrelationIdProviderProps) {
+  const id = correlationId ?? generateCorrelationId();
+  setCorrelationId(id);
+  return <CorrelationIdContext.Provider value={id}>{children}</CorrelationIdContext.Provider>;
+}
+
+export function useCorrelationId(): string | undefined {
+  return useContext(CorrelationIdContext);
+}
+
+export function generateCorrelationId(parentId?: string): string {
+  const id = uuidv4();
+  return parentId ? `${parentId}.${id}` : id;
+}
+
+export function getCorrelationId(): string | undefined {
+  if (isServer && asyncStorage) {
+    return asyncStorage.getStore()?.correlationId;
+  }
+  return clientCorrelationId;
+}
+
+export function setCorrelationId(id: string) {
+  if (isServer && asyncStorage) {
+    asyncStorage.enterWith({ correlationId: id });
+  } else {
+    clientCorrelationId = id;
+  }
+}
+
+export function runWithCorrelationId<T>(id: string, fn: () => T): T {
+  if (isServer && asyncStorage) {
+    return asyncStorage.run({ correlationId: id }, fn);
+  }
+  const previous = clientCorrelationId;
+  clientCorrelationId = id;
+  try {
+    return fn();
+  } finally {
+    clientCorrelationId = previous;
+  }
+}
+
+export function correlationIdMiddleware() {
+  return async function (
+    req: NextApiRequest,
+    res: NextApiResponse,
+    next: () => Promise<void>
+  ) {
+    const parentId = getCorrelationId();
+    const incomingId = (req.headers['x-correlation-id'] as string) || undefined;
+    const id = incomingId || generateCorrelationId(parentId);
+
+    setCorrelationId(id);
+    (req as any).correlationId = id;
+    res.setHeader('X-Correlation-Id', id);
+
+    try {
+      await runWithCorrelationId(id, async () => {
+        await next();
+      });
+    } catch (error: any) {
+      if (error && typeof error === 'object') {
+        error.correlationId = id;
+      }
+      throw error;
+    }
+  };
+}

--- a/src/lib/monitoring/index.ts
+++ b/src/lib/monitoring/index.ts
@@ -1,0 +1,1 @@
+export * from './correlation-id';

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -4,6 +4,7 @@ import { securityHeaders } from '@/middleware/security-headers';
 import { auditLog } from '@/middleware/audit-log';
 import { cors } from '@/middleware/cors';
 import { csrf } from '@/middleware/csrf';
+import { correlationIdMiddleware } from '@/lib/monitoring';
 
 type NextFunction = () => Promise<void>;
 
@@ -144,3 +145,4 @@ export function withSecurity(
 }
 
 export { withErrorHandling } from './error-handling';
+export { correlationIdMiddleware };


### PR DESCRIPTION
## Summary
- add correlation ID generation/propagation utilities
- provide middleware for auto correlation ID assignment
- export correlationIdMiddleware from middleware index
- test correlation ID logic

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683ea43162e88331bbd952b4c0d9dc8c