### PR TITLE
Implement telemetry monitoring

### DIFF
--- a/src/lib/monitoring/__tests__/telemetry.test.ts
+++ b/src/lib/monitoring/__tests__/telemetry.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Telemetry, AlertNotifier } from '../telemetry';
+
+class TestNotifier implements AlertNotifier {
+  public alerts: any[] = [];
+  notify(alert: any) {
+    this.alerts.push(alert);
+  }
+}
+
+describe('Telemetry', () => {
+  let telemetry: Telemetry;
+  let notifier: TestNotifier;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    telemetry = new Telemetry({ alertThresholds: { DB_ERROR: 2 }, alertCooldownMs: 500 });
+    notifier = new TestNotifier();
+    telemetry.addAlertNotifier(notifier);
+  });
+
+  it('tracks error counts and user impact', () => {
+    telemetry.recordError({ type: 'DB_ERROR', message: 'fail', userId: 'u1', userSegment: 'pro', action: 'save', critical: true });
+    telemetry.recordError({ type: 'DB_ERROR', message: 'fail2', userId: 'u2', userSegment: 'free', action: 'save' });
+
+    const m = telemetry.getMetrics('DB_ERROR')!;
+    expect(m.count).toBe(2);
+    expect(m.criticalCount).toBe(1);
+    expect(m.nonCriticalCount).toBe(1);
+    expect(m.affectedUsers.size).toBe(2);
+    expect(m.segmentImpact.get('pro')).toBe(1);
+    expect(m.segmentImpact.get('free')).toBe(1);
+    expect(m.actionCounts.get('save')).toBe(2);
+  });
+
+  it('calculates resolution time', () => {
+    telemetry.recordError({ type: 'NET', message: 'timeout' });
+    vi.advanceTimersByTime(1000);
+    telemetry.resolveError('NET');
+    const m = telemetry.getMetrics('NET')!;
+    expect(m.resolutionTimes[0]).toBe(1000);
+  });
+
+  it('handles missing metrics gracefully', () => {
+    expect(telemetry.getMetrics('UNKNOWN')).toBeUndefined();
+    expect(telemetry.getErrorRate('UNKNOWN')).toBe(0);
+    telemetry.resolveError('UNKNOWN'); // should not throw
+  });
+
+  it('sends alerts respecting thresholds and cooldown', () => {
+    telemetry.recordError({ type: 'DB_ERROR', message: 'a', critical: true });
+    expect(notifier.alerts).toHaveLength(0);
+    telemetry.recordError({ type: 'DB_ERROR', message: 'b', critical: true });
+    expect(notifier.alerts).toHaveLength(1);
+    telemetry.recordError({ type: 'DB_ERROR', message: 'c', critical: true });
+    expect(notifier.alerts).toHaveLength(1); // within cooldown
+    vi.advanceTimersByTime(600);
+    telemetry.recordError({ type: 'DB_ERROR', message: 'd', critical: true });
+    expect(notifier.alerts).toHaveLength(2);
+  });
+
+  it('reports rates and highest impact errors', () => {
+    telemetry.recordError({ type: 'A', message: 'x', userId: 'u1' });
+    telemetry.recordError({ type: 'B', message: 'y', userId: 'u2' });
+    telemetry.recordError({ type: 'B', message: 'z', userId: 'u3' });
+    vi.advanceTimersByTime(30000);
+    const rate = telemetry.getErrorRate('A', 60000);
+    expect(rate).toBeCloseTo(1 / 60, 5);
+    const high = telemetry.getHighestImpactErrors();
+    expect(high[0]).toBe('B');
+  });
+});

--- a/src/lib/monitoring/telemetry.ts
+++ b/src/lib/monitoring/telemetry.ts
@@ -1,0 +1,141 @@
+import { TypedEventEmitter } from '@/lib/utils/typed-event-emitter';
+
+export interface TelemetryErrorEvent {
+  type: string;
+  message: string;
+  userId?: string;
+  userSegment?: string;
+  action?: string;
+  critical?: boolean;
+}
+
+export interface TelemetryAlert {
+  errorType: string;
+  severity: 'critical' | 'non-critical';
+  count: number;
+  message: string;
+}
+
+export interface AlertNotifier {
+  notify(alert: TelemetryAlert): void | Promise<void>;
+}
+
+interface TelemetryConfig {
+  alertThresholds?: Record<string, number>;
+  alertCooldownMs?: number;
+}
+
+interface ErrorMetrics {
+  count: number;
+  criticalCount: number;
+  nonCriticalCount: number;
+  firstSeen: number;
+  lastSeen: number;
+  resolutionTimes: number[];
+  affectedUsers: Set<string>;
+  segmentImpact: Map<string, number>;
+  actionCounts: Map<string, number>;
+  events: number[];
+}
+
+export type TelemetryEvent = { type: 'alert'; alert: TelemetryAlert };
+
+export class Telemetry extends TypedEventEmitter<TelemetryEvent> {
+  private metrics = new Map<string, ErrorMetrics>();
+  private alertThresholds: Record<string, number>;
+  private alertCooldownMs: number;
+  private lastAlertTime: Record<string, number> = {};
+  private notifiers: AlertNotifier[] = [];
+
+  constructor(config: TelemetryConfig = {}) {
+    super();
+    this.alertThresholds = config.alertThresholds || {};
+    this.alertCooldownMs = config.alertCooldownMs ?? 60_000;
+  }
+
+  addAlertNotifier(notifier: AlertNotifier) {
+    this.notifiers.push(notifier);
+  }
+
+  setAlertThreshold(type: string, threshold: number) {
+    this.alertThresholds[type] = threshold;
+  }
+
+  recordError(event: TelemetryErrorEvent) {
+    const now = Date.now();
+    let m = this.metrics.get(event.type);
+    if (!m) {
+      m = {
+        count: 0,
+        criticalCount: 0,
+        nonCriticalCount: 0,
+        firstSeen: now,
+        lastSeen: now,
+        resolutionTimes: [],
+        affectedUsers: new Set(),
+        segmentImpact: new Map(),
+        actionCounts: new Map(),
+        events: [],
+      };
+      this.metrics.set(event.type, m);
+    }
+    m.count++;
+    m.lastSeen = now;
+    m.events.push(now);
+    if (event.critical) m.criticalCount++; else m.nonCriticalCount++;
+    if (event.userId) m.affectedUsers.add(event.userId);
+    if (event.userSegment)
+      m.segmentImpact.set(
+        event.userSegment,
+        (m.segmentImpact.get(event.userSegment) || 0) + 1,
+      );
+    if (event.action)
+      m.actionCounts.set(event.action, (m.actionCounts.get(event.action) || 0) + 1);
+
+    this.checkAlert(event.type, event.critical ? 'critical' : 'non-critical', m);
+  }
+
+  resolveError(type: string) {
+    const m = this.metrics.get(type);
+    if (!m) return;
+    const now = Date.now();
+    m.resolutionTimes.push(now - m.lastSeen);
+  }
+
+  getMetrics(type?: string) {
+    if (type) return this.metrics.get(type);
+    const obj: Record<string, ErrorMetrics> = {};
+    this.metrics.forEach((v, k) => (obj[k] = v));
+    return obj;
+  }
+
+  getErrorRate(type: string, windowMs = 60_000): number {
+    const m = this.metrics.get(type);
+    if (!m) return 0;
+    const now = Date.now();
+    m.events = m.events.filter(t => now - t <= windowMs);
+    return m.events.length / (windowMs / 1000);
+  }
+
+  getHighestImpactErrors(): string[] {
+    return Array.from(this.metrics.entries())
+      .sort((a, b) => b[1].affectedUsers.size - a[1].affectedUsers.size)
+      .map(e => e[0]);
+  }
+
+  private checkAlert(type: string, severity: 'critical' | 'non-critical', m: ErrorMetrics) {
+    const threshold = this.alertThresholds[type];
+    if (!threshold || m.count < threshold) return;
+    const now = Date.now();
+    if (now - (this.lastAlertTime[type] || 0) < this.alertCooldownMs) return;
+    this.lastAlertTime[type] = now;
+    const alert: TelemetryAlert = {
+      errorType: type,
+      severity,
+      count: m.count,
+      message: `Error ${type} occurred ${m.count} times`,
+    };
+    for (const n of this.notifiers) n.notify(alert);
+    this.emit({ type: 'alert', alert });
+  }
+}


### PR DESCRIPTION
## Summary
- add monitoring telemetry module
- track metrics, error rates, user impact and alerts
- test telemetry

## Testing
- `npx vitest run --coverage src/lib/monitoring/__tests__/telemetry.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_683ea45358688331899638bdf2a9c6be