### PR TITLE
Add resource ancestors API route

### DIFF
--- a/app/api/resources/[type]/[id]/ancestors/__tests__/route.test.ts
+++ b/app/api/resources/[type]/[id]/ancestors/__tests__/route.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+// Mock permission middleware to bypass auth
+vi.mock("@/middleware/auth", () => ({
+  withRouteAuth: vi.fn((handler: any, req: any) =>
+    handler(req, { userId: "u1" }),
+  ),
+}));
+vi.mock("@/middleware/error-handling", () => ({
+  withErrorHandling: (handler: any, req: any) => handler(req),
+}));
+
+const resolverMock = { getResourceAncestors: vi.fn() };
+vi.mock("@/services/permission/resource-permission-resolver", () => ({
+  ResourcePermissionResolver: vi.fn(() => resolverMock),
+}));
+vi.mock("@/lib/database/supabase", () => ({
+  getServiceSupabase: vi.fn(() => ({})),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resource ancestors API", () => {
+  it("returns ancestors", async () => {
+    resolverMock.getResourceAncestors.mockResolvedValue([
+      { resourceType: "team", resourceId: "t1" },
+    ]);
+    const req = new NextRequest("http://test");
+    const res = await GET(req, {
+      params: { type: "project", id: "p1" },
+    } as any);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.ancestors).toEqual([
+      { resourceType: "team", resourceId: "t1" },
+    ]);
+    expect(resolverMock.getResourceAncestors).toHaveBeenCalledWith(
+      "project",
+      "p1",
+    );
+  });
+});

--- a/app/api/resources/[type]/[id]/ancestors/route.ts
+++ b/app/api/resources/[type]/[id]/ancestors/route.ts
@@ -1,0 +1,22 @@
+import { type NextRequest } from "next/server";
+import { withErrorHandling } from "@/middleware/error-handling";
+import { withRouteAuth } from "@/middleware/auth";
+import { createSuccessResponse } from "@/lib/api/common";
+import { ResourcePermissionResolver } from "@/services/permission/resource-permission-resolver";
+import { getServiceSupabase } from "@/lib/database/supabase";
+
+async function handleGet(type: string, id: string) {
+  const resolver = new ResourcePermissionResolver(getServiceSupabase());
+  const ancestors = await resolver.getResourceAncestors(type, id);
+  return createSuccessResponse({ ancestors });
+}
+
+export const GET = (
+  req: NextRequest,
+  ctx: { params: { type: string; id: string } },
+) =>
+  withRouteAuth(
+    (r) =>
+      withErrorHandling(() => handleGet(ctx.params.type, ctx.params.id), r),
+    req,
+  );


### PR DESCRIPTION
## Summary
- expose GET /api/resources/[type]/[id]/ancestors to fetch resource hierarchy
- test the new endpoint

## Testing
- `npx vitest run app/api/resources/[type]/[id]/ancestors/__tests__/route.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_683ea5071a4083319ea148abe9423f72