### PR TITLE
Add role hierarchy info API and integrate hierarchy in permissions

### DIFF
--- a/app/api/roles/[roleId]/hierarchy/info/__tests__/route.test.ts
+++ b/app/api/roles/[roleId]/hierarchy/info/__tests__/route.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from '../route';
+
+const mockService = {
+  getAncestorRoles: vi.fn(),
+  getDescendantRoles: vi.fn(),
+  getInheritedPermissions: vi.fn(),
+  getEffectivePermissions: vi.fn(),
+};
+vi.mock('@/lib/services/roleHierarchy.service', () => ({
+  createRoleHierarchyService: () => mockService,
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('role hierarchy info API', () => {
+  it('GET returns hierarchy details', async () => {
+    mockService.getAncestorRoles.mockResolvedValue([]);
+    mockService.getDescendantRoles.mockResolvedValue([]);
+    mockService.getInheritedPermissions.mockResolvedValue(['p1']);
+    mockService.getEffectivePermissions.mockResolvedValue(['p1']);
+    const res = await GET({} as any, { params: { roleId: '1' } } as any);
+    expect(res.status).toBe(200);
+    expect(mockService.getAncestorRoles).toHaveBeenCalledWith('1');
+  });
+});

--- a/app/api/roles/[roleId]/hierarchy/info/route.ts
+++ b/app/api/roles/[roleId]/hierarchy/info/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from 'next/server';
+import { createRoleHierarchyService } from '@/lib/services/roleHierarchy.service';
+import {
+  createMiddlewareChain,
+  errorHandlingMiddleware,
+  routeAuthMiddleware,
+} from '@/middleware/createMiddlewareChain';
+import { createSuccessResponse } from '@/lib/api/common';
+
+const middleware = createMiddlewareChain([
+  errorHandlingMiddleware(),
+  routeAuthMiddleware(),
+]);
+
+async function handleGet(_req: NextRequest, ctx: any) {
+  const roleId = ctx.params.roleId;
+  const service = createRoleHierarchyService();
+
+  const [ancestors, descendants, inheritedPermissions, effectivePermissions] = await Promise.all([
+    service.getAncestorRoles(roleId),
+    service.getDescendantRoles(roleId),
+    service.getInheritedPermissions(roleId),
+    service.getEffectivePermissions(roleId),
+  ]);
+
+  return createSuccessResponse({
+    roleId,
+    ancestors,
+    descendants,
+    inheritedPermissions,
+    effectivePermissions,
+  });
+}
+
+export const GET = middleware((req: NextRequest, auth: any) => handleGet(req, auth));


### PR DESCRIPTION
## Summary
- enhance permission service to use role hierarchy
- expose `/api/roles/[roleId]/hierarchy/info` route
- test new endpoint

## Testing
- `npx vitest run --coverage` *(fails: `npx` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ea9b8b4508331aa514ec79388c157