### PR TITLE
Add core error class tests

### DIFF
--- a/src/core/common/__tests__/errors.test.ts
+++ b/src/core/common/__tests__/errors.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ApplicationError,
+  ValidationError,
+  AuthenticationError,
+  AuthorizationError,
+  ResourceNotFoundError,
+  ConflictError,
+  RateLimitError,
+  ServiceError,
+  DatabaseError,
+  isApplicationError,
+  isValidationError,
+  isAuthenticationError,
+  isAuthorizationError,
+  isResourceNotFoundError,
+  isConflictError,
+  isRateLimitError,
+  isServiceError,
+  isDatabaseError,
+  createErrorFromUnknown,
+  serializeError,
+  deserializeError,
+  createError,
+} from '..';
+import { SERVER_ERROR } from '../error-codes';
+
+describe('ApplicationError hierarchy', () => {
+  it('preserves inheritance and properties', () => {
+    const err = new ApplicationError(SERVER_ERROR.SERVER_001, 'fail', 500, { a: 1 });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('ApplicationError');
+    expect(err.code).toBe(SERVER_ERROR.SERVER_001);
+    expect(err.details).toEqual({ a: 1 });
+    expect(err.httpStatus).toBe(500);
+    expect(err.timestamp).toBeDefined();
+  });
+
+  it('serializes and deserializes correctly', () => {
+    const err = new ValidationError('bad input', { field: 'x' });
+    const json = serializeError(err);
+    const copy = deserializeError(json);
+    expect(copy).toBeInstanceOf(ApplicationError);
+    expect(copy.name).toBe('ApplicationError');
+    expect(copy.code).toBe(err.code);
+    expect(copy.message).toBe(err.message);
+    expect(copy.httpStatus).toBe(err.httpStatus);
+    expect(copy.details).toEqual(err.details);
+    expect(copy.timestamp).toBe(err.timestamp);
+  });
+
+  it('preserves stack traces when extending', () => {
+    const cause = new Error('root cause');
+    const err = createError(SERVER_ERROR.SERVER_001, 'boom', undefined, cause);
+    expect(err.stack).toContain('Caused by:');
+    expect(err.stack).toContain('root cause');
+  });
+});
+
+describe('specific error subclasses', () => {
+  it('sets correct HTTP status and names', () => {
+    const auth = new AuthenticationError(SERVER_ERROR.SERVER_001, 'a');
+    const conflict = new ConflictError('c');
+    const notFound = new ResourceNotFoundError('n');
+    const db = new DatabaseError('d');
+    expect(auth.httpStatus).toBe(401);
+    expect(auth.name).toBe('AuthenticationError');
+    expect(conflict.httpStatus).toBe(409);
+    expect(notFound.httpStatus).toBe(404);
+    expect(db.httpStatus).toBe(500);
+  });
+
+  it('type guards identify errors', () => {
+    const rate = new RateLimitError('oops');
+    const authz = new AuthorizationError('nope');
+    const basic = new ApplicationError(SERVER_ERROR.SERVER_001, 'b');
+    const db = new DatabaseError('d');
+    expect(isRateLimitError(rate)).toBe(true);
+    expect(isAuthorizationError(authz)).toBe(true);
+    expect(isApplicationError(rate)).toBe(true);
+    expect(isValidationError(rate)).toBe(false);
+    expect(isAuthenticationError(authz)).toBe(false);
+    expect(isDatabaseError(db)).toBe(true);
+    expect(isResourceNotFoundError(new ResourceNotFoundError('x'))).toBe(true);
+    expect(isConflictError(new ConflictError('y'))).toBe(true);
+    expect(isServiceError(new ServiceError('z'))).toBe(true);
+    expect(isApplicationError(basic)).toBe(true);
+  });
+});
+
+describe('utility functions', () => {
+  it('creates ApplicationError from unknown input', () => {
+    const basic = createErrorFromUnknown(new Error('oops'));
+    expect(isServiceError(basic)).toBe(true);
+    expect(basic.message).toBe('oops');
+    const other = createErrorFromUnknown('oops');
+    expect(other.message).toBe('Unknown error');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for error classes in core layer

## Testing
- `npx vitest run --coverage src/core/common/__tests__/errors.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_683eaa06043c8331ae15dbd578dde5f9