### PR TITLE
Add comprehensive error handling tests

### DIFF
--- a/src/components/ui/errors/__tests__/ErrorDisplay.test.tsx
+++ b/src/components/ui/errors/__tests__/ErrorDisplay.test.tsx
@@ -2,7 +2,13 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
-import { ErrorDisplay, NetworkErrorDisplay, ValidationErrorDisplay } from '../ErrorDisplay';
+import {
+  ErrorDisplay,
+  NetworkErrorDisplay,
+  ValidationErrorDisplay,
+  NotFoundErrorDisplay,
+  PermissionErrorDisplay,
+} from '../ErrorDisplay';
 import { toast } from '@/lib/hooks/use-toast';
 
 vi.mock('@/lib/hooks/use-toast', () => {
@@ -31,11 +37,23 @@ describe('ErrorDisplay', () => {
     expect(screen.getByText('Modal')).toBeInTheDocument();
   });
 
+  it('has accessible alert attributes', () => {
+    render(<ErrorDisplay message="Accessible" />);
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+  });
+
   it('specialized component uses defaults', () => {
     render(<NetworkErrorDisplay />);
     expect(toast).toHaveBeenCalledWith(expect.objectContaining({ title: expect.stringContaining('Network error') }));
 
     render(<ValidationErrorDisplay message="Form invalid" />);
     expect(screen.getByText('Form invalid')).toBeInTheDocument();
+
+    render(<NotFoundErrorDisplay />);
+    expect(screen.getByText(/requested resource/)).toBeInTheDocument();
+
+    render(<PermissionErrorDisplay />);
+    expect(screen.getByText(/permission to perform/)).toBeInTheDocument();
   });
 });

--- a/src/ui/styled/common/__tests__/ApiErrorAlert.test.tsx
+++ b/src/ui/styled/common/__tests__/ApiErrorAlert.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@/tests/utils/test-utils';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { ApiErrorAlert } from '../ApiErrorAlert';
+
+describe('ApiErrorAlert', () => {
+  it('renders message and calls retry', async () => {
+    const user = userEvent.setup();
+    const retry = vi.fn();
+    render(<ApiErrorAlert message="Oops" onRetry={retry} />);
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Oops');
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    expect(retry).toHaveBeenCalled();
+  });
+
+  it('renders nothing when message is null', () => {
+    const { container } = render(<ApiErrorAlert message={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/ui/styled/common/__tests__/GlobalErrorDisplay.test.tsx
+++ b/src/ui/styled/common/__tests__/GlobalErrorDisplay.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@/tests/utils/test-utils';
+import userEvent from '@testing-library/user-event';
+import { act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GlobalErrorDisplay } from '../GlobalErrorDisplay';
+import { useErrorStore } from '@/lib/state/errorStore';
+
+describe('GlobalErrorDisplay', () => {
+  beforeEach(() => {
+    act(() => {
+      useErrorStore.setState({ globalQueue: [], sectionQueues: {}, history: [] });
+    });
+  });
+
+  it('shows global error and handles retry', async () => {
+    const retry = vi.fn();
+    const user = userEvent.setup();
+    act(() => {
+      useErrorStore.getState().addError({ message: 'Boom', onRetry: retry });
+    });
+    render(<GlobalErrorDisplay />);
+    const container = screen.getByRole('alert').parentElement?.parentElement as HTMLElement;
+    expect(container).toHaveClass('fixed bottom-4 right-4 max-w-md w-full');
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    expect(retry).toHaveBeenCalled();
+    expect(useErrorStore.getState().globalQueue.length).toBe(0);
+  });
+
+  it('renders nothing when there is no error', () => {
+    const { container } = render(<GlobalErrorDisplay />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- enhance `ErrorDisplay` test coverage
- test default ErrorBoundary recovery and analytics
- add GlobalErrorDisplay and ApiErrorAlert tests
- verify `useHasErrorType` cleanup logic

## Testing
- `CI=1 npx vitest run src/components/ui/errors/__tests__/ErrorBoundary.test.tsx --reporter dot`
- `CI=1 npx vitest run src/components/ui/errors/__tests__/ErrorDisplay.test.tsx src/ui/styled/common/__tests__/ApiErrorAlert.test.tsx src/ui/styled/common/__tests__/GlobalErrorDisplay.test.tsx src/lib/state/__tests__/errorStore.test.ts src/hooks/errors/__tests__/useErrorHandling.test.tsx --reporter dot`
- `CI=1 npx vitest run --coverage` (fails: coverage summary not produced)

------
https://chatgpt.com/codex/tasks/task_b_683eaa766ff88331bcc392cc6b0f953b