### PR TITLE
Add permission and role assignment UI components

### DIFF
--- a/src/hooks/resource/useResourceHierarchy.ts
+++ b/src/hooks/resource/useResourceHierarchy.ts
@@ -1,0 +1,35 @@
+import { useState, useCallback, useEffect } from 'react';
+import { UserManagementConfiguration } from '@/core/config';
+import type { ResourceRelationshipService } from '@/core/resource-relationship/interfaces';
+
+export interface ResourceNode {
+  id: string;
+  type: string;
+  children: ResourceNode[];
+}
+
+export function useResourceHierarchy(rootType: string, rootId: string) {
+  const service = UserManagementConfiguration.getServiceProvider<ResourceRelationshipService>('resourceRelationshipService');
+  const [root, setRoot] = useState<ResourceNode | null>(null);
+
+  const buildTree = useCallback(async (type: string, id: string): Promise<ResourceNode> => {
+    if (!service) throw new Error('resourceRelationshipService not available');
+    const children = await service.getChildResources(type, id);
+    const childNodes = await Promise.all(
+      children.map((c) => buildTree(c.childType, c.childId)),
+    );
+    return { id, type, children: childNodes };
+  }, [service]);
+
+  const refresh = useCallback(async () => {
+    if (!service) return;
+    setRoot(await buildTree(rootType, rootId));
+  }, [service, buildTree, rootType, rootId]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { tree: root, refresh };
+}
+export default useResourceHierarchy;

--- a/src/ui/headless/admin/UserRoleAssigner.tsx
+++ b/src/ui/headless/admin/UserRoleAssigner.tsx
@@ -1,0 +1,84 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useAdminUsers } from '@/hooks/admin/useAdminUsers';
+import { useRoles } from '@/hooks/team/useRoles';
+import { Permission } from '@/core/permission/models';
+import { PermissionService } from '@/core/permission/interfaces';
+import { UserManagementConfiguration } from '@/core/config';
+
+export interface UserRoleAssignerProps {
+  onUserSelect?: (id: string) => void;
+  render: (props: {
+    users: any[];
+    roles: any[];
+    search: (q: string) => Promise<void>;
+    selectUser: (id: string) => void;
+    selectedUserId: string | null;
+    assign: (roleId: string, expiresAt?: Date) => Promise<void>;
+    remove: (roleId: string) => Promise<void>;
+    effectivePermissions: Permission[];
+    isLoading: boolean;
+    error: string | null;
+  }) => React.ReactNode;
+}
+
+export function UserRoleAssigner({ onUserSelect, render }: UserRoleAssignerProps) {
+  const { users, searchUsers, isLoading: searching, error } = useAdminUsers();
+  const {
+    roles,
+    assignRoleToUser,
+    removeRoleFromUser,
+    getUserRoles,
+    isLoading,
+  } = useRoles();
+  const permissionService = UserManagementConfiguration.getServiceProvider<PermissionService>('permissionService');
+
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const [effective, setEffective] = useState<Permission[]>([]);
+
+  const selectUser = useCallback((id: string) => {
+    setSelectedUserId(id);
+    onUserSelect?.(id);
+  }, [onUserSelect]);
+
+  const loadEffective = useCallback(async (userId: string) => {
+    if (!permissionService) return [] as Permission[];
+    const perms = await permissionService.getUserResourcePermissions(userId);
+    setEffective(perms.map(p => p.permission));
+  }, [permissionService]);
+
+  useEffect(() => {
+    if (selectedUserId) loadEffective(selectedUserId);
+  }, [selectedUserId, loadEffective]);
+
+  const assign = useCallback(async (roleId: string, expiresAt?: Date) => {
+    if (!selectedUserId) return;
+    await assignRoleToUser(selectedUserId, roleId, 'self', expiresAt);
+    await loadEffective(selectedUserId);
+  }, [assignRoleToUser, selectedUserId, loadEffective]);
+
+  const remove = useCallback(async (roleId: string) => {
+    if (!selectedUserId) return;
+    await removeRoleFromUser(selectedUserId, roleId);
+    await loadEffective(selectedUserId);
+  }, [removeRoleFromUser, selectedUserId, loadEffective]);
+
+  const search = useCallback(async (q: string) => {
+    await searchUsers({ query: q });
+  }, [searchUsers]);
+
+  return (
+    <>{render({
+      users,
+      roles,
+      search,
+      selectUser,
+      selectedUserId,
+      assign,
+      remove,
+      effectivePermissions: effective,
+      isLoading: searching || isLoading,
+      error,
+    })}</>
+  );
+}
+export default UserRoleAssigner;

--- a/src/ui/headless/admin/__tests__/UserRoleAssigner.test.tsx
+++ b/src/ui/headless/admin/__tests__/UserRoleAssigner.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { UserRoleAssigner } from '../UserRoleAssigner';
+import * as adminUsers from '@/hooks/admin/useAdminUsers';
+import * as useRolesHook from '@/hooks/team/useRoles';
+import { UserManagementConfiguration } from '@/core/config';
+import { PermissionService } from '@/core/permission/interfaces';
+
+vi.mock('@/hooks/admin/useAdminUsers');
+vi.mock('@/hooks/team/useRoles');
+
+describe('UserRoleAssigner', () => {
+  it('assigns and removes roles', async () => {
+    const searchUsers = vi.fn();
+    vi.mocked(adminUsers.useAdminUsers).mockReturnValue({ users: [{ id: 'u1', firstName: 'A' }], searchUsers, isLoading: false, error: null });
+    const assignRoleToUser = vi.fn();
+    const removeRoleFromUser = vi.fn();
+    vi.mocked(useRolesHook.useRoles).mockReturnValue({
+      roles: [{ id: 'r1', name: 'Admin' }],
+      assignRoleToUser,
+      removeRoleFromUser,
+      getUserRoles: vi.fn().mockResolvedValue([]),
+      isLoading: false,
+    } as any);
+    const permissionService: PermissionService = {
+      getUserResourcePermissions: vi.fn().mockResolvedValue([]),
+    } as any;
+    vi.spyOn(UserManagementConfiguration, 'getServiceProvider').mockReturnValue(permissionService);
+
+    const renderProp = vi.fn(() => null);
+    renderHook(() => <UserRoleAssigner render={renderProp} />);
+    const args = renderProp.mock.calls[0][0];
+    await act(async () => {
+      await args.search('x');
+      args.selectUser('u1');
+      await args.assign('r1');
+      await args.remove('r1');
+    });
+    expect(searchUsers).toHaveBeenCalled();
+    expect(assignRoleToUser).toHaveBeenCalled();
+    expect(removeRoleFromUser).toHaveBeenCalled();
+  });
+});

--- a/src/ui/headless/permission/ResourcePermissionAssigner.tsx
+++ b/src/ui/headless/permission/ResourcePermissionAssigner.tsx
@@ -1,0 +1,60 @@
+import { useState, useCallback, useEffect } from 'react';
+import { Permission } from '@/core/permission/models';
+import { ResourcePermissionResolver } from '@/lib/services/resource-permission-resolver.service';
+import { usePermissions } from '@/hooks/permission/usePermissions';
+import useResourceHierarchy, { ResourceNode } from '@/hooks/resource/useResourceHierarchy';
+
+export interface ResourcePermissionAssignerProps {
+  userId: string;
+  rootType: string;
+  rootId: string;
+  render: (props: {
+    tree: ResourceNode | null;
+    assign: (resourceType: string, resourceId: string, permission: Permission) => Promise<void>;
+    revoke: (resourceType: string, resourceId: string, permission: Permission) => Promise<void>;
+    getEffective: (resourceType: string, resourceId: string) => Promise<Permission[]>;
+    isLoading: boolean;
+    error: string | null;
+  }) => React.ReactNode;
+}
+
+export function ResourcePermissionAssigner({ userId, rootType, rootId, render }: ResourcePermissionAssignerProps) {
+  const { assignResourcePermission, removeResourcePermission } = usePermissions();
+  const { tree, refresh } = useResourceHierarchy(rootType, rootId);
+  const [resolver] = useState(() => new ResourcePermissionResolver());
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const assign = useCallback(async (type: string, id: string, perm: Permission) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await assignResourcePermission(userId, perm, type, id);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'assign failed');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [assignResourcePermission, userId, refresh]);
+
+  const revoke = useCallback(async (type: string, id: string, perm: Permission) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await removeResourcePermission(userId, perm, type, id);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'revoke failed');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [removeResourcePermission, userId, refresh]);
+
+  const getEffective = useCallback((type: string, id: string) => {
+    return resolver.getEffectivePermissions(userId, type, id) as Promise<Permission[]>;
+  }, [resolver, userId]);
+
+  return <>{render({ tree, assign, revoke, getEffective, isLoading, error })}</>;
+}
+export default ResourcePermissionAssigner;

--- a/src/ui/headless/permission/__tests__/ResourcePermissionAssigner.test.tsx
+++ b/src/ui/headless/permission/__tests__/ResourcePermissionAssigner.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ResourcePermissionAssigner } from '../ResourcePermissionAssigner';
+import * as usePermissionsHook from '@/hooks/permission/usePermissions';
+import * as useHierarchyHook from '@/hooks/resource/useResourceHierarchy';
+
+vi.mock('@/hooks/permission/usePermissions');
+vi.mock('@/hooks/resource/useResourceHierarchy');
+
+describe('ResourcePermissionAssigner', () => {
+  it('calls assign and revoke handlers', async () => {
+    const assign = vi.fn();
+    const revoke = vi.fn();
+    vi.mocked(usePermissionsHook.usePermissions).mockReturnValue({
+      assignResourcePermission: assign,
+      removeResourcePermission: revoke,
+    } as any);
+    vi.mocked(useHierarchyHook.default).mockReturnValue({
+      tree: { id: 'root', type: 'project', children: [] },
+      refresh: vi.fn(),
+    } as any);
+
+    const renderProp = vi.fn(() => null);
+    renderHook(() => (
+      <ResourcePermissionAssigner userId="1" rootType="project" rootId="1" render={renderProp} />
+    ));
+
+    expect(renderProp).toHaveBeenCalled();
+    const args = renderProp.mock.calls[0][0];
+    await act(async () => {
+      await args.assign('project', '1', 'VIEW_PROJECTS');
+    });
+    expect(assign).toHaveBeenCalled();
+    await act(async () => {
+      await args.revoke('project', '1', 'VIEW_PROJECTS');
+    });
+    expect(revoke).toHaveBeenCalled();
+  });
+});

--- a/src/ui/styled/admin/UserRoleAssigner.tsx
+++ b/src/ui/styled/admin/UserRoleAssigner.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { Input } from '@/ui/primitives/input';
+import { Button } from '@/ui/primitives/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/ui/primitives/card';
+import { Select, SelectItem } from '@/ui/primitives/select';
+import { UserRoleAssigner, UserRoleAssignerProps } from '../../headless/admin/UserRoleAssigner';
+
+export function UserRoleAssignerStyled(props: Omit<UserRoleAssignerProps, 'render'> & { title?: string }) {
+  const [query, setQuery] = useState('');
+  const [expiresAt, setExpiresAt] = useState<string>('');
+
+  return (
+    <UserRoleAssigner
+      {...props}
+      render={({ users, roles, search, selectUser, selectedUserId, assign, remove, effectivePermissions, isLoading, error }) => (
+        <Card>
+          <CardHeader>
+            <CardTitle>{props.title || 'User Roles'}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex space-x-2">
+              <Input value={query} onChange={e => setQuery(e.target.value)} placeholder="Search users" />
+              <Button onClick={() => search(query)}>Search</Button>
+            </div>
+            {error && <p className="text-red-500">{error}</p>}
+            <div className="flex flex-wrap gap-4">
+              {users.map(u => (
+                <Button key={u.id} variant={selectedUserId === u.id ? 'default' : 'outline'} onClick={() => selectUser(u.id)}>
+                  {u.firstName || u.email}
+                </Button>
+              ))}
+            </div>
+            {selectedUserId && (
+              <div className="space-y-2">
+                <div className="flex items-end space-x-2">
+                  <Select onValueChange={(v) => assign(v, expiresAt ? new Date(expiresAt) : undefined)}>
+                    <SelectItem value="" disabled>Select Role</SelectItem>
+                    {roles.map(r => (
+                      <SelectItem key={r.id} value={r.id}>{r.name}</SelectItem>
+                    ))}
+                  </Select>
+                  <Input type="date" value={expiresAt} onChange={e => setExpiresAt(e.target.value)} />
+                </div>
+                <div>
+                  <p className="font-medium">Effective Permissions:</p>
+                  <ul className="list-disc ml-6">
+                    {effectivePermissions.map(p => <li key={p}>{p}</li>)}
+                  </ul>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    />
+  );
+}
+export default UserRoleAssignerStyled;

--- a/src/ui/styled/permission/ResourcePermissionAssigner.tsx
+++ b/src/ui/styled/permission/ResourcePermissionAssigner.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { Checkbox } from '@/ui/primitives/checkbox';
+import { Card, CardContent, CardHeader, CardTitle } from '@/ui/primitives/card';
+import { Button } from '@/ui/primitives/button';
+import { PermissionValues, type Permission } from '@/core/permission/models';
+import { ResourcePermissionAssigner, ResourcePermissionAssignerProps } from '../../headless/permission/ResourcePermissionAssigner';
+
+interface NodeProps {
+  node: any;
+  getEffective: (t: string, id: string) => Promise<Permission[]>;
+  assign: (t: string, id: string, p: Permission) => Promise<void>;
+  revoke: (t: string, id: string, p: Permission) => Promise<void>;
+  level: number;
+}
+
+function Node({ node, getEffective, assign, revoke, level }: NodeProps) {
+  const [effective, setEffective] = useState<Permission[]>([]);
+  const [expanded, setExpanded] = useState(false);
+  const allPermissions = Object.values(PermissionValues);
+
+  const load = async () => {
+    setEffective(await getEffective(node.type, node.id));
+    setExpanded(true);
+  };
+
+  return (
+    <div className="ml-4">
+      <div className="flex items-center space-x-2">
+        <Button variant="ghost" size="sm" onClick={expanded ? () => setExpanded(false) : load}>
+          {expanded ? '-' : '+'}
+        </Button>
+        <span className="font-medium">{node.type}:{node.id}</span>
+      </div>
+      {expanded && (
+        <div className="ml-6 space-y-2">
+          {allPermissions.map(p => {
+            const has = effective.includes(p);
+            return (
+              <label key={p} className="flex items-center space-x-2">
+                <Checkbox
+                  checked={has}
+                  onCheckedChange={(v) => {
+                    if (v) assign(node.type, node.id, p); else revoke(node.type, node.id, p);
+                  }}
+                />
+                <span className={has ? '' : 'opacity-50'}>{p}</span>
+              </label>
+            );
+          })}
+          {node.children.map((c: any) => (
+            <Node key={c.id} node={c} getEffective={getEffective} assign={assign} revoke={revoke} level={level + 1} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ResourcePermissionAssignerStyled(props: Omit<ResourcePermissionAssignerProps, 'render'> & { title?: string }) {
+  return (
+    <ResourcePermissionAssigner
+      {...props}
+      render={({ tree, assign, revoke, getEffective, isLoading, error }) => (
+        <Card>
+          <CardHeader>
+            <CardTitle>{props.title || 'Resource Permissions'}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {error && <p className="text-red-500">{error}</p>}
+            {!tree ? (
+              <p>Loading...</p>
+            ) : (
+              <Node node={tree} getEffective={getEffective} assign={assign} revoke={revoke} level={0} />
+            )}
+          </CardContent>
+        </Card>
+      )}
+    />
+  );
+}
+export default ResourcePermissionAssignerStyled;


### PR DESCRIPTION
## Summary
- add `useResourceHierarchy` hook for hierarchical resource traversal
- create headless/styled `ResourcePermissionAssigner` components
- add headless/styled `UserRoleAssigner` components
- cover new headless components with unit tests

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_683eadbbc05c83318b165c6f9713bf32