### PR TITLE
Add permission testing utilities

### DIFF
--- a/app/api/permissions/validate/__tests__/route.test.ts
+++ b/app/api/permissions/validate/__tests__/route.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from '../route';
+import { withRouteAuth } from '@/middleware/auth';
+
+const mockPermissionService = {
+  hasPermission: vi.fn(),
+  hasResourcePermission: vi.fn(),
+  getUserRoles: vi.fn(),
+};
+const mockRoleService = {
+  getEffectivePermissions: vi.fn(),
+};
+const mockResolver = {
+  getResourceAncestors: vi.fn(),
+};
+
+vi.mock('@/services/permission/factory', () => ({
+  getApiPermissionService: () => mockPermissionService,
+}));
+vi.mock('@/services/role/factory', () => ({
+  getApiRoleService: () => mockRoleService,
+}));
+vi.mock('@/lib/services/resource-permission-resolver.service', () => ({
+  createResourcePermissionResolver: () => mockResolver,
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (withRouteAuth as any).mockImplementation((handler: any, req: any) => handler(req, {}));
+});
+
+describe('GET /api/permissions/validate', () => {
+  it('returns validation info for user permission', async () => {
+    mockPermissionService.hasPermission.mockResolvedValue(true);
+    mockPermissionService.getUserRoles.mockResolvedValue([{ roleId: 'r1' }]);
+    mockRoleService.getEffectivePermissions.mockResolvedValue(['VIEW']);
+    const req = new Request('http://localhost/api/permissions/validate?userId=u1&permission=VIEW');
+    const res = await GET(req as any);
+    const body = await res.json();
+    expect(body.data.allowed).toBe(true);
+    expect(body.data.roles).toEqual(['r1']);
+  });
+});

--- a/app/api/permissions/validate/route.ts
+++ b/app/api/permissions/validate/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { createMiddlewareChain } from '@/middleware/createMiddlewareChain';
+import { errorHandlingMiddleware, routeAuthMiddleware, validationMiddleware } from '@/middleware/createMiddlewareChain';
+import { createSuccessResponse } from '@/lib/api/common';
+import { getApiPermissionService } from '@/services/permission/factory';
+import { getApiRoleService } from '@/services/role/factory';
+import { createResourcePermissionResolver } from '@/lib/services/resource-permission-resolver.service';
+
+const querySchema = z.object({
+  userId: z.string(),
+  permission: z.string(),
+  resourceType: z.string().optional(),
+  resourceId: z.string().optional(),
+});
+
+const middleware = createMiddlewareChain([
+  errorHandlingMiddleware(),
+  routeAuthMiddleware(),
+  validationMiddleware(querySchema),
+]);
+
+async function handleGet(_req: NextRequest, _auth: any, data: z.infer<typeof querySchema>) {
+  const permissionService = getApiPermissionService();
+  const roleService = getApiRoleService();
+  const resolver = createResourcePermissionResolver();
+  const { userId, permission, resourceType, resourceId } = data;
+
+  let allowed: boolean;
+  if (resourceType && resourceId) {
+    allowed = await permissionService.hasResourcePermission(
+      userId,
+      permission as any,
+      resourceType,
+      resourceId,
+    );
+  } else {
+    allowed = await permissionService.hasPermission(userId, permission as any);
+  }
+
+  const userRoles = await permissionService.getUserRoles(userId);
+  const contributingRoles: string[] = [];
+  for (const r of userRoles) {
+    const perms = await roleService.getEffectivePermissions(r.roleId);
+    if (perms.includes(permission as any)) {
+      contributingRoles.push(r.roleId);
+    }
+  }
+
+  let inheritance: any[] = [];
+  if (resourceType && resourceId) {
+    inheritance = await resolver.getResourceAncestors(resourceType, resourceId);
+  }
+
+  return createSuccessResponse({
+    allowed,
+    roles: contributingRoles,
+    inheritance,
+  });
+}
+
+export const GET = middleware(handleGet);

--- a/src/services/permission/__tests__/permission-testing.service.test.ts
+++ b/src/services/permission/__tests__/permission-testing.service.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PermissionTestingService } from '../permission-testing.service';
+import type { Permission } from '@/core/permission/models';
+
+class FakePermissionService {
+  roles: Record<string, { permissions: Permission[]; parent?: string }> = {};
+  userRoles: Record<string, { roleId: string; expiresAt?: Date }[]> = {};
+  resourcePerms: Record<string, { permission: Permission; type: string; id: string }[]> = {};
+  resourceParents: Record<string, { type: string; id: string } | undefined> = {};
+
+  addRole(id: string, permissions: Permission[], parent?: string) {
+    this.roles[id] = { permissions, parent };
+  }
+
+  assignRole(userId: string, roleId: string, expiresAt?: Date) {
+    if (!this.userRoles[userId]) this.userRoles[userId] = [];
+    this.userRoles[userId].push({ roleId, expiresAt });
+  }
+
+  addResourcePermission(userId: string, permission: Permission, type: string, id: string) {
+    if (!this.resourcePerms[userId]) this.resourcePerms[userId] = [];
+    this.resourcePerms[userId].push({ permission, type, id });
+  }
+
+  setParentResource(type: string, id: string, parentType: string, parentId: string) {
+    this.resourceParents[`${type}:${id}`] = { type: parentType, id: parentId };
+  }
+
+  private roleHasPermission(roleId: string, permission: Permission, seen = new Set<string>()): boolean {
+    if (seen.has(roleId)) return false;
+    seen.add(roleId);
+    const role = this.roles[roleId];
+    if (!role) return false;
+    if (role.permissions.includes(permission)) return true;
+    if (role.parent) return this.roleHasPermission(role.parent, permission, seen);
+    return false;
+  }
+
+  async hasPermission(userId: string, permission: Permission): Promise<boolean> {
+    const roles = (this.userRoles[userId] || []).filter(r => !r.expiresAt || r.expiresAt > new Date());
+    return roles.some(r => this.roleHasPermission(r.roleId, permission));
+  }
+
+  async hasResourcePermission(userId: string, permission: Permission, type: string, id: string): Promise<boolean> {
+    const list = this.resourcePerms[userId] || [];
+    const direct = list.some(p => p.permission === permission && p.type === type && p.id === id);
+    if (direct) return true;
+    let current = this.resourceParents[`${type}:${id}`];
+    while (current) {
+      const found = list.some(p => p.permission === permission && p.type === current!.type && p.id === current!.id);
+      if (found) return true;
+      current = this.resourceParents[`${current.type}:${current.id}`];
+    }
+    return false;
+  }
+}
+
+describe('PermissionTestingService', () => {
+  let service: PermissionTestingService;
+  let provider: FakePermissionService;
+
+  const PERM = 'EDIT_PROJECT' as Permission;
+
+  beforeEach(() => {
+    provider = new FakePermissionService();
+    provider.addRole('parent', [PERM]);
+    provider.addRole('child', [], 'parent');
+    service = new PermissionTestingService(provider as any, {} as any, {} as any);
+  });
+
+  it('direct role assignment', async () => {
+    provider.addRole('simple', [PERM]);
+    provider.assignRole('u1', 'simple');
+    const res = await service.testRoleHierarchy('u1', PERM);
+    expect(res.success).toBe(true);
+  });
+
+  it('inherited role permission', async () => {
+    provider.assignRole('u1', 'child');
+    const res = await service.testRoleHierarchy('u1', PERM);
+    expect(res.success).toBe(true);
+  });
+
+  it('direct resource permission', async () => {
+    provider.addResourcePermission('u1', PERM, 'project', 'p1');
+    const res = await service.testResourceInheritance('u1', PERM, 'project', 'p1');
+    expect(res.success).toBe(true);
+  });
+
+  it('inherited resource permission', async () => {
+    provider.addResourcePermission('u1', PERM, 'project', 'parent');
+    provider.setParentResource('task', 't1', 'project', 'parent');
+    const res = await service.testResourceInheritance('u1', PERM, 'task', 't1');
+    expect(res.success).toBe(true);
+  });
+
+  it('expired permissions handled', async () => {
+    const past = new Date(Date.now() - 1000);
+    provider.assignRole('u1', 'simple', past);
+    const res = await service.testExpiredPermission('u1', PERM);
+    expect(res.success).toBe(true);
+  });
+});

--- a/src/services/permission/permission-testing.service.ts
+++ b/src/services/permission/permission-testing.service.ts
@@ -1,0 +1,58 @@
+import type { PermissionService } from '@/core/permission/interfaces';
+import type { Permission } from '@/core/permission/models';
+import { RoleService } from '@/services/role';
+import { ResourcePermissionResolver } from '@/lib/services/resource-permission-resolver.service';
+
+export interface PermissionTestResult {
+  scenario: string;
+  success: boolean;
+  reason: string;
+}
+
+export class PermissionTestingService {
+  constructor(
+    private permissionService: PermissionService,
+    private roleService: RoleService,
+    private resourceResolver: ResourcePermissionResolver,
+  ) {}
+
+  async testRoleHierarchy(userId: string, permission: Permission): Promise<PermissionTestResult> {
+    const allowed = await this.permissionService.hasPermission(userId, permission);
+    return {
+      scenario: 'role-hierarchy',
+      success: allowed,
+      reason: allowed ? 'permission inherited via roles' : 'permission missing',
+    };
+  }
+
+  async testResourceInheritance(
+    userId: string,
+    permission: Permission,
+    resourceType: string,
+    resourceId: string,
+  ): Promise<PermissionTestResult> {
+    const allowed = await this.permissionService.hasResourcePermission(
+      userId,
+      permission,
+      resourceType,
+      resourceId,
+    );
+    return {
+      scenario: 'resource-inheritance',
+      success: allowed,
+      reason: allowed ? 'permission inherited from resource ancestors' : 'permission missing',
+    };
+  }
+
+  async testExpiredPermission(
+    userId: string,
+    permission: Permission,
+  ): Promise<PermissionTestResult> {
+    const allowed = await this.permissionService.hasPermission(userId, permission);
+    return {
+      scenario: 'expired-permission',
+      success: !allowed,
+      reason: !allowed ? 'expired permissions ignored' : 'expired permission still active',
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add PermissionTestingService for validating role and resource permissions
- expose /api/permissions/validate endpoint for detailed permission checks
- cover permission scenarios with unit tests

## Testing
- `npx vitest run --coverage` *(fails: 4 test suites failed)*

------
https://chatgpt.com/codex/tasks/task_b_683eaeaee7248331bd59966633550baa