### PR TITLE
Add core error code registry

### DIFF
--- a/src/core/common/__tests__/error-code-registry.test.ts
+++ b/src/core/common/__tests__/error-code-registry.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ErrorCodeRegistry, ErrorSeverity } from '../error-code-registry';
+
+describe('ErrorCodeRegistry', () => {
+  beforeEach(() => {
+    ErrorCodeRegistry.clear();
+  });
+
+  it('registers and retrieves codes', () => {
+    ErrorCodeRegistry.register('TEST_001', 'test error', 'medium');
+    const info = ErrorCodeRegistry.get('TEST_001');
+    expect(info).toEqual({ code: 'TEST_001', description: 'test error', severity: 'medium' });
+    expect(ErrorCodeRegistry.has('TEST_001')).toBe(true);
+  });
+
+  it('prevents duplicate registration', () => {
+    ErrorCodeRegistry.register('DUP_001', 'one', 'low');
+    expect(() => ErrorCodeRegistry.register('DUP_001', 'two', 'high')).toThrow(/already registered/);
+  });
+
+  it('lists all codes', () => {
+    ErrorCodeRegistry.register('A', 'a', 'low');
+    ErrorCodeRegistry.register('B', 'b', 'high');
+    const list = ErrorCodeRegistry.list();
+    expect(list).toHaveLength(2);
+  });
+});

--- a/src/core/common/error-code-registry.ts
+++ b/src/core/common/error-code-registry.ts
@@ -1,0 +1,49 @@
+export type ErrorSeverity = 'low' | 'medium' | 'high' | 'critical';
+
+export interface ErrorCodeInfo {
+  code: string;
+  description: string;
+  severity: ErrorSeverity;
+}
+
+/**
+ * Simple registry to keep track of all error codes used by the core layer.
+ * Ensures each code is registered only once.
+ */
+export class ErrorCodeRegistry {
+  private static codes = new Map<string, ErrorCodeInfo>();
+
+  /**
+   * Register a new error code with description and severity.
+   * Throws if the code is already registered.
+   */
+  static register(code: string, description: string, severity: ErrorSeverity) {
+    if (this.codes.has(code)) {
+      throw new Error(`Error code '${code}' is already registered`);
+    }
+    this.codes.set(code, { code, description, severity });
+  }
+
+  /** Get information for a specific code. */
+  static get(code: string): ErrorCodeInfo | undefined {
+    return this.codes.get(code);
+  }
+
+  /** Check if a code is registered. */
+  static has(code: string): boolean {
+    return this.codes.has(code);
+  }
+
+  /** List all registered codes. */
+  static list(): ErrorCodeInfo[] {
+    return Array.from(this.codes.values());
+  }
+
+  /**
+   * Clear all registered codes. Intended for testing.
+   */
+  /* istanbul ignore next */
+  static clear() {
+    this.codes.clear();
+  }
+}

--- a/src/core/common/index.ts
+++ b/src/core/common/index.ts
@@ -1,2 +1,3 @@
 export * from './errors';
 export * from './error-codes';
+export * from './error-code-registry';


### PR DESCRIPTION
## Summary
- create ErrorCodeRegistry utility
- export registry from common index
- test error code registry behavior

## Testing
- `npx vitest run src/core/common/__tests__/error-code-registry.test.ts --coverage --reporter=dot`


------
https://chatgpt.com/codex/tasks/task_b_683eb0cc56108331bdede0604fb59a35