### PR TITLE
Implement message templates for errors

### DIFF
--- a/src/lib/utils/__tests__/error-factory.test.ts
+++ b/src/lib/utils/__tests__/error-factory.test.ts
@@ -57,12 +57,12 @@ describe('error factory', () => {
 
   it('falls back to default locale', () => {
     const err = createNotFoundError('item', '2', undefined, 'zz');
-    expect(err.message).toBe('Resource not found.');
+    expect(err.message).toBe('item 2 not found.');
   });
 
   it('uses translation when locale available', () => {
     const err = createNotFoundError('item', '3', undefined, 'en');
-    expect(err.message).toBe('Resource not found.');
+    expect(err.message).toBe('item 3 not found.');
   });
 
   it('sets timestamp and name properly', () => {


### PR DESCRIPTION
## Summary
- support templated translations in error factory
- update not found messages to use templates
- extend tests for new template behavior

## Testing
- `npx vitest run --coverage src/lib/utils/__tests__/error-factory.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_683eb0fabf7083318386e31a8ece7107