### PR TITLE
Add error translations

### DIFF
--- a/src/locales/en/errors.json
+++ b/src/locales/en/errors.json
@@ -1,0 +1,48 @@
+{
+  "auth": {
+    "unauthorized": "Authentication required.",
+    "forbidden": "Access denied.",
+    "invalid_credentials": "Invalid email or password.",
+    "email_not_verified": "Email not verified.",
+    "mfa_required": "Multi-factor authentication required.",
+    "account_locked": "Account locked.",
+    "password_expired": "Password expired.",
+    "session_expired": "Session expired."
+  },
+  "user": {
+    "not_found": "User {{id}} not found.",
+    "already_exists": "User already exists.",
+    "invalid_data": "Invalid user data.",
+    "update_failed": "Unable to update user.",
+    "delete_failed": "Unable to delete user."
+  },
+  "team": {
+    "not_found": "Team {{id}} not found.",
+    "already_exists": "Team already exists.",
+    "invalid_data": "Invalid team data.",
+    "update_failed": "Team update failed.",
+    "delete_failed": "Team deletion failed.",
+    "member_not_found": "Team member not found.",
+    "member_already_exists": "Team member already exists."
+  },
+  "permission": {
+    "not_found": "Permission {{key}} not found.",
+    "already_exists": "Permission already exists.",
+    "invalid_data": "Invalid permission data.",
+    "update_failed": "Permission update failed.",
+    "delete_failed": "Permission delete failed.",
+    "assignment_failed": "Permission assignment failed."
+  },
+  "validation": {
+    "error": "Validation failed.",
+    "missing_field": "{{field}} is required.",
+    "invalid_format": "Invalid format for {{field}}."
+  },
+  "server": {
+    "internal_error": "Internal server error.",
+    "service_unavailable": "Service is currently unavailable.",
+    "database_error": "Database error.",
+    "operation_failed": "Operation failed.",
+    "retrieval_failed": "Data retrieval failed."
+  }
+}

--- a/src/locales/es/errors.json
+++ b/src/locales/es/errors.json
@@ -1,0 +1,48 @@
+{
+  "auth": {
+    "unauthorized": "Autenticación requerida.",
+    "forbidden": "Acceso denegado.",
+    "invalid_credentials": "Credenciales inválidas.",
+    "email_not_verified": "Correo no verificado.",
+    "mfa_required": "Se requiere autenticación multifactor.",
+    "account_locked": "Cuenta bloqueada.",
+    "password_expired": "Contraseña expirada.",
+    "session_expired": "Sesión expirada."
+  },
+  "user": {
+    "not_found": "Usuario {{id}} no encontrado.",
+    "already_exists": "El usuario ya existe.",
+    "invalid_data": "Datos de usuario inválidos.",
+    "update_failed": "Error al actualizar usuario.",
+    "delete_failed": "Error al eliminar usuario."
+  },
+  "team": {
+    "not_found": "Equipo {{id}} no encontrado.",
+    "already_exists": "El equipo ya existe.",
+    "invalid_data": "Datos de equipo inválidos.",
+    "update_failed": "Error al actualizar equipo.",
+    "delete_failed": "Error al eliminar equipo.",
+    "member_not_found": "Miembro del equipo no encontrado.",
+    "member_already_exists": "El miembro del equipo ya existe."
+  },
+  "permission": {
+    "not_found": "Permiso {{key}} no encontrado.",
+    "already_exists": "El permiso ya existe.",
+    "invalid_data": "Datos de permiso inválidos.",
+    "update_failed": "Error al actualizar permiso.",
+    "delete_failed": "Error al eliminar permiso.",
+    "assignment_failed": "Error al asignar permiso."
+  },
+  "validation": {
+    "error": "Validación fallida.",
+    "missing_field": "El campo {{field}} es obligatorio.",
+    "invalid_format": "Formato inválido para {{field}}."
+  },
+  "server": {
+    "internal_error": "Error interno del servidor.",
+    "service_unavailable": "Servicio no disponible.",
+    "database_error": "Error de base de datos.",
+    "operation_failed": "La operación falló.",
+    "retrieval_failed": "Error al obtener datos."
+  }
+}

--- a/src/locales/fr/errors.json
+++ b/src/locales/fr/errors.json
@@ -1,0 +1,48 @@
+{
+  "auth": {
+    "unauthorized": "Authentification requise.",
+    "forbidden": "Accès refusé.",
+    "invalid_credentials": "Identifiants invalides.",
+    "email_not_verified": "Email non vérifié.",
+    "mfa_required": "Authentification multifacteur requise.",
+    "account_locked": "Compte verrouillé.",
+    "password_expired": "Mot de passe expiré.",
+    "session_expired": "Session expirée."
+  },
+  "user": {
+    "not_found": "Utilisateur {{id}} introuvable.",
+    "already_exists": "L'utilisateur existe déjà.",
+    "invalid_data": "Données utilisateur invalides.",
+    "update_failed": "Échec de la mise à jour de l'utilisateur.",
+    "delete_failed": "Échec de la suppression de l'utilisateur."
+  },
+  "team": {
+    "not_found": "Équipe {{id}} introuvable.",
+    "already_exists": "L'équipe existe déjà.",
+    "invalid_data": "Données d'équipe invalides.",
+    "update_failed": "Échec de la mise à jour de l'équipe.",
+    "delete_failed": "Échec de la suppression de l'équipe.",
+    "member_not_found": "Membre de l'équipe introuvable.",
+    "member_already_exists": "Le membre de l'équipe existe déjà."
+  },
+  "permission": {
+    "not_found": "Permission {{key}} introuvable.",
+    "already_exists": "La permission existe déjà.",
+    "invalid_data": "Données de permission invalides.",
+    "update_failed": "Échec de la mise à jour de la permission.",
+    "delete_failed": "Échec de la suppression de la permission.",
+    "assignment_failed": "Échec de l'attribution de la permission."
+  },
+  "validation": {
+    "error": "Échec de la validation.",
+    "missing_field": "Le champ {{field}} est requis.",
+    "invalid_format": "Format invalide pour {{field}}."
+  },
+  "server": {
+    "internal_error": "Erreur interne du serveur.",
+    "service_unavailable": "Service indisponible.",
+    "database_error": "Erreur de base de données.",
+    "operation_failed": "Échec de l'opération.",
+    "retrieval_failed": "Échec de la récupération des données."
+  }
+}


### PR DESCRIPTION
## Summary
- add error translation files for each language

## Testing
- `npx vitest run --coverage` *(fails: act warnings and missing mocks)*

------
https://chatgpt.com/codex/tasks/task_b_683eb261d66883319d98a71d9a5fafb6