### PR TITLE
Add offline error queue

### DIFF
--- a/src/lib/offline/__tests__/error-queue.test.ts
+++ b/src/lib/offline/__tests__/error-queue.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { OfflineErrorQueue, SerializedError } from '../error-queue';
+
+describe('OfflineErrorQueue', () => {
+  let queue: OfflineErrorQueue;
+  let processor: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    queue = new OfflineErrorQueue('test-error-queue', 1); // baseDelay=1ms for tests
+    processor = vi.fn().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('persists queued errors', () => {
+    queue.enqueue(new Error('oops'));
+    const stored = JSON.parse(localStorage.getItem('test-error-queue') || '[]');
+    expect(stored.length).toBe(1);
+    expect(stored[0].error.message).toBe('oops');
+  });
+
+  it('processes critical errors first', async () => {
+    const results: string[] = [];
+    processor.mockImplementation(async (e: SerializedError) => {
+      results.push(e.message);
+    });
+    queue.enqueue(new Error('normal')); // normal priority
+    queue.enqueue(new Error('critical'), 'critical');
+    await queue.process(processor);
+    expect(results).toEqual(['critical', 'normal']);
+  });
+
+  it('retries failed errors with exponential backoff', async () => {
+    let attempt = 0;
+    processor.mockImplementation(() => {
+      attempt += 1;
+      return attempt < 2 ? Promise.reject(new Error('fail')) : Promise.resolve();
+    });
+    queue.enqueue(new Error('retry'));
+    await queue.process(processor); // first attempt fails
+
+    let stored = JSON.parse(localStorage.getItem('test-error-queue') || '[]');
+    expect(stored[0].attempts).toBe(1);
+    const firstNext = stored[0].nextRetry;
+
+    await new Promise(r => setTimeout(r, 2));
+    await queue.process(processor); // second attempt succeeds
+
+    stored = JSON.parse(localStorage.getItem('test-error-queue') || '[]');
+    expect(stored.length).toBe(0);
+    expect(firstNext).toBeLessThan(Date.now());
+  });
+
+  it('drops errors after max attempts', async () => {
+    processor.mockRejectedValue(new Error('fail'));
+    queue.enqueue(new Error('drop'), 'normal', 1); // maxAttempts=1
+    await queue.process(processor);
+    const stored = JSON.parse(localStorage.getItem('test-error-queue') || '[]');
+    expect(stored.length).toBe(0);
+  });
+
+  it('skips processing when retry time not reached', async () => {
+    processor.mockResolvedValue(undefined);
+    const id = queue.enqueue(new Error('wait'));
+    const stored = JSON.parse(localStorage.getItem('test-error-queue') || '[]');
+    stored[0].nextRetry = Date.now() + 1000;
+    localStorage.setItem('test-error-queue', JSON.stringify(stored));
+    queue = new OfflineErrorQueue('test-error-queue', 1);
+    await queue.process(processor);
+    expect(processor).not.toHaveBeenCalled();
+    const storedAfter = JSON.parse(localStorage.getItem('test-error-queue') || '[]');
+    expect(storedAfter[0].id).toBe(id);
+  });
+
+  it('loads existing queue from storage', () => {
+    const data = [
+      { id: 'a', error: { message: 'm' }, priority: 'normal', attempts: 0, maxAttempts: 5, nextRetry: Date.now() }
+    ];
+    localStorage.setItem('test-error-queue', JSON.stringify(data));
+    const q = new OfflineErrorQueue('test-error-queue', 1);
+    expect((q as any).queue.length).toBe(1);
+    expect((q as any).queue[0].id).toBe('a');
+  });
+
+  it('handles invalid stored data gracefully', () => {
+    localStorage.setItem('test-error-queue', 'not json');
+    const q = new OfflineErrorQueue('test-error-queue', 1);
+    expect((q as any).queue).toEqual([]);
+  });
+
+  it('skips items that already exceeded max attempts', async () => {
+    const item = { id: 'b', error: { message: 'fail' }, priority: 'normal', attempts: 5, maxAttempts: 5, nextRetry: Date.now() };
+    localStorage.setItem('test-error-queue', JSON.stringify([item]));
+    queue = new OfflineErrorQueue('test-error-queue', 1);
+    await queue.process(processor);
+    expect(processor).not.toHaveBeenCalled();
+    const stored = JSON.parse(localStorage.getItem('test-error-queue') || '[]');
+    expect(stored.length).toBe(0);
+  });
+});

--- a/src/lib/offline/error-queue.ts
+++ b/src/lib/offline/error-queue.ts
@@ -1,0 +1,102 @@
+export type ErrorPriority = 'critical' | 'normal';
+
+export interface SerializedError {
+  message: string;
+  stack?: string;
+}
+
+interface QueueItem {
+  id: string;
+  error: SerializedError;
+  priority: ErrorPriority;
+  attempts: number;
+  maxAttempts: number;
+  nextRetry: number;
+}
+
+export type ErrorProcessor = (error: SerializedError) => Promise<void>;
+
+export class OfflineErrorQueue {
+  private storageKey: string;
+  private baseDelay: number;
+  private queue: QueueItem[] = [];
+
+  constructor(storageKey = 'um-error-queue', baseDelay = 1000) {
+    this.storageKey = storageKey;
+    this.baseDelay = baseDelay;
+    this.queue = this.load();
+  }
+
+  enqueue(error: Error, priority: ErrorPriority = 'normal', maxAttempts = 5): string {
+    const item: QueueItem = {
+      id: `err_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+      error: { message: error.message, stack: error.stack },
+      priority,
+      attempts: 0,
+      maxAttempts,
+      nextRetry: Date.now(),
+    };
+    this.queue.push(item);
+    this.persist();
+    return item.id;
+  }
+
+  async process(processor: ErrorProcessor): Promise<void> {
+    // Sort by priority so critical errors are handled first
+    this.queue.sort((a, b) => (a.priority === b.priority ? 0 : a.priority === 'critical' ? -1 : 1));
+
+    const now = Date.now();
+    const remaining: QueueItem[] = [];
+
+    for (const item of this.queue) {
+      if (item.attempts >= item.maxAttempts) {
+        continue; // drop
+      }
+      if (item.nextRetry > now) {
+        remaining.push(item);
+        continue;
+      }
+
+      try {
+        await processor(item.error);
+      } catch {
+        item.attempts += 1;
+        if (item.attempts < item.maxAttempts) {
+          item.nextRetry = Date.now() + this.getRetryDelay(item.attempts);
+          remaining.push(item);
+        }
+        continue;
+      }
+      // success -> do not requeue
+    }
+
+    this.queue = remaining;
+    this.persist();
+  }
+
+  private getRetryDelay(attempt: number): number {
+    return this.baseDelay * Math.pow(2, attempt - 1);
+  }
+
+  private persist() {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(this.storageKey, JSON.stringify(this.queue));
+    }
+  }
+
+  private load(): QueueItem[] {
+    if (typeof localStorage !== 'undefined') {
+      const raw = localStorage.getItem(this.storageKey);
+      if (raw) {
+        try {
+          return JSON.parse(raw) as QueueItem[];
+        } catch {
+          return [];
+        }
+      }
+    }
+    return [];
+  }
+}
+
+export const offlineErrorQueue = new OfflineErrorQueue();


### PR DESCRIPTION
## Summary
- implement `OfflineErrorQueue` with persistent storage
- prioritize critical errors and retry with exponential backoff
- add unit tests for error queue

## Testing
- `npx vitest run --coverage src/lib/offline/__tests__/error-queue.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_683eb2b2f1f08331b60eee497a074ef4