### PR TITLE
Add i18n message helpers and RTL support

### DIFF
--- a/src/components/ui/errors/ErrorDisplay.tsx
+++ b/src/components/ui/errors/ErrorDisplay.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { isRtlLanguage } from '@/lib/i18n/messages';
 import { Alert, AlertTitle, AlertDescription } from '@/ui/primitives/alert';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle as DialogHeading } from '@/ui/primitives/dialog';
 import { Button } from '@/ui/primitives/button';
@@ -40,6 +42,8 @@ export function ErrorDisplay({
   onOpenChange,
 }: ErrorDisplayProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
+  const { i18n } = useTranslation();
+  const dir = isRtlLanguage(i18n.language) ? 'rtl' : undefined;
 
   useEffect(() => {
     if (style === 'toast') {
@@ -64,7 +68,7 @@ export function ErrorDisplay({
   if (style === 'modal') {
     return (
       <Dialog open={isOpen} onOpenChange={onOpenChange}>
-        <DialogContent ref={dialogRef} tabIndex={-1} aria-labelledby="error-title">
+        <DialogContent ref={dialogRef} tabIndex={-1} aria-labelledby="error-title" dir={dir}>
           <DialogHeader>
             <DialogHeading id="error-title">Error</DialogHeading>
           </DialogHeader>
@@ -82,7 +86,7 @@ export function ErrorDisplay({
   }
 
   return (
-    <Alert role="alert" className="flex flex-col gap-2" aria-live="assertive">
+    <Alert role="alert" className="flex flex-col gap-2" aria-live="assertive" dir={dir}>
       <AlertTitle>{message}</AlertTitle>
       {details && <AlertDescription>{details}</AlertDescription>}
       {onRetry && (

--- a/src/hooks/utils/useApiError.ts
+++ b/src/hooks/utils/useApiError.ts
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { formatErrorMessage } from '@/lib/i18n/messages';
 
 interface ApiErrorShape {
   code?: string;
@@ -11,23 +13,15 @@ interface ApiErrorShape {
  */
 export function useApiError() {
   const [error, setError] = useState<string | null>(null);
+  const { i18n } = useTranslation();
 
   const handleError = (err: ApiErrorShape | Error) => {
     let message = 'An unexpected error occurred.';
 
     if ('code' in err && err.code) {
-      switch (err.code) {
-        case 'auth/unauthorized':
-          message = 'Please log in to continue.';
-          break;
-        case 'validation/error':
-          message = err.message;
-          break;
-        case 'server/internal_error':
-          message = 'Server error. Please try again later.';
-          break;
-        default:
-          message = err.message || message;
+      message = formatErrorMessage(err.code, {}, i18n.language as any);
+      if (message === `errors.${err.code}`) {
+        message = err.message || message;
       }
     } else if (err instanceof Error) {
       message = err.message;

--- a/src/lib/i18n/__tests__/messages.test.ts
+++ b/src/lib/i18n/__tests__/messages.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { initializeI18n } from '../index';
+import { getMessageTemplate, formatMessage, formatErrorMessage } from '../messages';
+
+describe('i18n message helpers', () => {
+  it('extracts template by locale', () => {
+    const instance = initializeI18n({
+      resources: { de: { userManagement: { errors: { sample: 'Fehler' } } } },
+      defaultLanguage: 'de',
+    });
+    expect(getMessageTemplate('errors.sample', 'de')).toBe('Fehler');
+    expect(instance.t('errors.sample')).toBe('Fehler');
+  });
+
+  it('formats messages with variables', () => {
+    initializeI18n({
+      resources: { en: { userManagement: { errors: { greet: 'Hi {{name}}' } } } },
+      defaultLanguage: 'en',
+    });
+    expect(formatMessage('errors.greet', { name: 'Bob' }, 'en')).toBe('Hi Bob');
+    expect(formatErrorMessage('greet', { name: 'Bob' }, 'en')).toBe('Hi Bob');
+  });
+});

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -152,6 +152,13 @@ const enTranslations = {
       "invalidDocument": "Invalid document format"
     }
   },
+  "errors": {
+    "auth/unauthorized": "Authentication required.",
+    "auth/forbidden": "Access denied.",
+    "validation/error": "Validation failed.",
+    "user/not_found": "Resource not found.",
+    "server/internal_error": "Internal server error."
+  },
   // ... (rest of the JSON pasted as a JS object)
 };
-export default enTranslations; 
+export default enTranslations;

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -87,6 +87,13 @@
     "loginAlerts": "Alertas de Inicio de Sesión",
     "loginAlerts.description": "Recibe notificaciones cuando alguien inicie sesión en tu cuenta",
     "privacy": "Privacidad",
-    "account": "Cuenta"
+  "account": "Cuenta"
+  },
+  "errors": {
+    "auth/unauthorized": "Se requiere autenticación.",
+    "auth/forbidden": "Acceso denegado.",
+    "validation/error": "La validación falló.",
+    "user/not_found": "Recurso no encontrado.",
+    "server/internal_error": "Error interno del servidor."
   }
-} 
+}

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -66,7 +66,14 @@
       "marketingEmails": "E-mails Marketing",
       "marketingEmailsDesc": "Recevez du contenu promotionnel et des offres spéciales",
       "profileVisibility": "Visibilité du Profil",
-      "showOnlineStatus": "Afficher le Statut en Ligne"
+  "showOnlineStatus": "Afficher le Statut en Ligne"
     }
+  },
+  "errors": {
+    "auth/unauthorized": "Authentification requise.",
+    "auth/forbidden": "Accès refusé.",
+    "validation/error": "Échec de la validation.",
+    "user/not_found": "Ressource introuvable.",
+    "server/internal_error": "Erreur interne du serveur."
   }
-} 
+}

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -1,0 +1,47 @@
+import i18n from './index';
+import { USER_MANAGEMENT_NAMESPACE, type LanguageCode } from './index';
+
+/**
+ * Retrieve a raw translation template for the given key and locale.
+ */
+export function getMessageTemplate(
+  key: string,
+  locale: LanguageCode,
+  namespace: string = USER_MANAGEMENT_NAMESPACE
+): string | undefined {
+  return i18n.getResource(locale, namespace, key) as string | undefined;
+}
+
+/**
+ * Format a message using i18next with optional variables.
+ */
+export function formatMessage(
+  key: string,
+  variables: Record<string, string> = {},
+  locale: LanguageCode = i18n.language as LanguageCode,
+  namespace: string = USER_MANAGEMENT_NAMESPACE
+): string {
+  return i18n.t(key, { lng: locale, ns: namespace, ...variables, defaultValue: key });
+}
+
+/**
+ * Format an error message based on an error code.
+ */
+export function formatErrorMessage(
+  code: string,
+  variables: Record<string, string> = {},
+  locale: LanguageCode = i18n.language as LanguageCode,
+  namespace: string = USER_MANAGEMENT_NAMESPACE
+): string {
+  return formatMessage(`errors.${code}`, variables, locale, namespace);
+}
+
+/**
+ * List of languages that use right-to-left direction.
+ */
+export const RTL_LANGUAGES = ['ar', 'he', 'fa', 'ur'] as const;
+
+export function isRtlLanguage(code: string): boolean {
+  const lang = code.split('-')[0];
+  return RTL_LANGUAGES.includes(lang as (typeof RTL_LANGUAGES)[number]);
+}

--- a/src/ui/styled/common/ApiErrorAlert.tsx
+++ b/src/ui/styled/common/ApiErrorAlert.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { Alert, AlertDescription, AlertTitle } from '@/ui/primitives/alert';
+import { useTranslation } from 'react-i18next';
+import { isRtlLanguage } from '@/lib/i18n/messages';
 
 interface ApiErrorAlertProps {
   message: string | null;
@@ -11,10 +13,12 @@ interface ApiErrorAlertProps {
  * Display user-friendly API error messages with optional retry.
  */
 export function ApiErrorAlert({ message, onRetry }: ApiErrorAlertProps) {
+  const { i18n } = useTranslation();
+  const dir = isRtlLanguage(i18n.language) ? 'rtl' : undefined;
   if (!message) return null;
 
   return (
-    <Alert variant="destructive" role="alert">
+    <Alert variant="destructive" role="alert" dir={dir}>
       <AlertTitle>Something went wrong</AlertTitle>
       <AlertDescription className="flex items-center justify-between gap-2">
         <span>{message}</span>


### PR DESCRIPTION
## Summary
- add helpers to fetch and format translated messages
- support RTL languages in error components
- integrate message helpers in error factories and hooks
- localize common error codes in translations
- test new i18n helpers

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683eb28fadc0833194425d8b52d6ec31