### PR TITLE
Implement network connectivity detector

### DIFF
--- a/src/lib/offline/__tests__/network-detector.test.ts
+++ b/src/lib/offline/__tests__/network-detector.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { detectNetworkStatus, verifyConnectivity, NetworkDetector } from '../network-detector';
+
+describe('detectNetworkStatus', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses navigator.onLine when available', () => {
+    vi.spyOn(navigator, 'onLine', 'get').mockReturnValueOnce(false);
+    expect(detectNetworkStatus()).toBe(false);
+    vi.spyOn(navigator, 'onLine', 'get').mockReturnValueOnce(true);
+    expect(detectNetworkStatus()).toBe(true);
+  });
+
+  it('assumes online when navigator not available', () => {
+    const original = (global as any).navigator;
+    // @ts-ignore
+    delete (global as any).navigator;
+    expect(detectNetworkStatus()).toBe(true);
+    (global as any).navigator = original;
+  });
+});
+
+describe('verifyConnectivity', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns false when offline', async () => {
+    vi.spyOn(navigator, 'onLine', 'get').mockReturnValueOnce(false);
+    const result = await verifyConnectivity();
+    expect(result).toBe(false);
+  });
+
+  it('pings health endpoint', async () => {
+    vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(true);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchMock as any;
+    const result = await verifyConnectivity();
+    expect(fetchMock).toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+});
+
+describe('NetworkDetector', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('emits state changes based on connectivity', async () => {
+    vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(true);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchMock as any;
+    vi.spyOn(Date, 'now').mockReturnValueOnce(0).mockReturnValueOnce(100);
+
+    const detector = new NetworkDetector(1000);
+    const handler = vi.fn();
+    detector.onChange(handler);
+
+    await (detector as any).updateState();
+    expect(detector.getState()).toBe('strong');
+    expect(detector.getLatency()).toBe(100);
+    expect(handler).toHaveBeenCalledWith('strong');
+    detector.stopHeartbeat();
+  });
+});

--- a/src/lib/offline/network-detector.ts
+++ b/src/lib/offline/network-detector.ts
@@ -1,0 +1,93 @@
+export function detectNetworkStatus(): boolean {
+  if (typeof navigator !== 'undefined' && 'onLine' in navigator) {
+    return navigator.onLine;
+  }
+  return true;
+}
+
+export async function verifyConnectivity(): Promise<boolean> {
+  if (!detectNetworkStatus()) return false;
+  try {
+    const response = await fetch('/api/health/ping?_=' + Date.now(), {
+      method: 'HEAD',
+      cache: 'no-store',
+      headers: { 'Cache-Control': 'no-cache' },
+      mode: 'cors',
+    } as RequestInit);
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+export type ConnectivityState = 'strong' | 'weak' | 'offline';
+export type ConnectivityListener = (state: ConnectivityState) => void;
+
+export class NetworkDetector {
+  private listeners = new Set<ConnectivityListener>();
+  private heartbeatId?: ReturnType<typeof setInterval>;
+  private latency = 0;
+  private state: ConnectivityState = detectNetworkStatus() ? 'strong' : 'offline';
+
+  constructor(private heartbeatInterval = 30000) {
+    if (typeof window !== 'undefined') {
+      window.addEventListener('online', this.handleOnline);
+      window.addEventListener('offline', this.handleOffline);
+      this.startHeartbeat();
+    }
+  }
+
+  private handleOnline = () => {
+    this.updateState();
+  };
+
+  private handleOffline = () => {
+    this.changeState('offline');
+  };
+
+  private changeState(state: ConnectivityState) {
+    if (this.state !== state) {
+      this.state = state;
+      this.listeners.forEach(cb => cb(this.state));
+    }
+  }
+
+  private async updateState() {
+    const start = Date.now();
+    const ok = await verifyConnectivity();
+    this.latency = Date.now() - start;
+    if (!ok) {
+      this.changeState('offline');
+    } else {
+      const quality = this.latency < 300 ? 'strong' : 'weak';
+      this.changeState(quality);
+    }
+  }
+
+  startHeartbeat() {
+    this.stopHeartbeat();
+    this.heartbeatId = setInterval(() => this.updateState(), this.heartbeatInterval);
+  }
+
+  stopHeartbeat() {
+    if (this.heartbeatId) {
+      clearInterval(this.heartbeatId);
+      this.heartbeatId = undefined;
+    }
+  }
+
+  onChange(listener: ConnectivityListener) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  getState() {
+    return this.state;
+  }
+
+  getLatency() {
+    return this.latency;
+  }
+}
+
+export const networkDetector = typeof window !== 'undefined' ? new NetworkDetector() : undefined;


### PR DESCRIPTION
## Summary
- add new network-detector utility with connectivity metrics and heartbeat
- test network detection and metrics

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683eb3d63fb083318927bfd249a25a54