### PR TITLE
Add offline status UI

### DIFF
--- a/src/components/ui/feedback/OfflineStatusBar.tsx
+++ b/src/components/ui/feedback/OfflineStatusBar.tsx
@@ -1,0 +1,47 @@
+import { Loader2, WifiOff } from 'lucide-react';
+import useOfflineStatus from '@/hooks/utils/useOfflineStatus';
+
+interface OfflineStatusBarProps {
+  position?: 'top' | 'bottom';
+  queueLength?: number;
+  onRetry?: () => void;
+}
+
+export function OfflineStatusBar({
+  position = 'top',
+  queueLength = 0,
+  onRetry,
+}: OfflineStatusBarProps) {
+  const { isOffline, isReconnecting } = useOfflineStatus(queueLength);
+
+  if (!isOffline && !isReconnecting) return null;
+
+  return (
+    <div
+      className={`offline-status-bar ${position} ${
+        isReconnecting ? 'reconnecting' : 'offline'
+      } flex items-center gap-2 text-sm p-2 bg-muted`}
+    >
+      {isOffline ? (
+        <>
+          <WifiOff className="h-4 w-4" />
+          <span>
+            You are offline.{' '}
+            {queueLength > 0 && `${queueLength} operations pending.`}
+          </span>
+          {onRetry && (
+            <button onClick={onRetry} className="retry-button underline ml-2">
+              Try again
+            </button>
+          )}
+        </>
+      ) : (
+        <>
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span>Reconnecting...</span>
+        </>
+      )}
+    </div>
+  );
+}
+export default OfflineStatusBar;

--- a/src/components/ui/feedback/__tests__/OfflineStatusBar.test.tsx
+++ b/src/components/ui/feedback/__tests__/OfflineStatusBar.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import OfflineStatusBar from '../OfflineStatusBar';
+import useOfflineStatus from '@/hooks/utils/useOfflineStatus';
+
+vi.mock('@/hooks/utils/useOfflineStatus');
+
+const mockedStatus = useOfflineStatus as unknown as vi.Mock;
+
+describe('OfflineStatusBar', () => {
+  it('shows offline message with retry', async () => {
+    mockedStatus.mockReturnValue({ isOffline: true, isReconnecting: false });
+    const retry = vi.fn();
+    const user = userEvent.setup();
+    render(<OfflineStatusBar queueLength={2} onRetry={retry} />);
+    expect(screen.getByText(/you are offline/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+    expect(retry).toHaveBeenCalled();
+  });
+
+  it('shows reconnecting state', () => {
+    mockedStatus.mockReturnValue({ isOffline: false, isReconnecting: true });
+    render(<OfflineStatusBar />);
+    expect(screen.getByText(/reconnecting/i)).toBeInTheDocument();
+  });
+});

--- a/src/hooks/__tests__/useOptimistic.test.tsx
+++ b/src/hooks/__tests__/useOptimistic.test.tsx
@@ -20,5 +20,21 @@ describe('useOptimistic', () => {
       await result.current.run(fn, 2);
     });
     expect(result.current.data).toBe(2);
+    expect(result.current.queueLength).toBe(1);
+  });
+
+  it('flushes queue when online', async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(navigator, 'onLine', 'get').mockReturnValueOnce(false);
+    const { result } = renderHook(() => useOptimistic(0));
+    await act(async () => {
+      await result.current.run(fn, 3);
+    });
+    expect(result.current.queueLength).toBe(1);
+    vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(true);
+    await act(async () => {
+      await result.current.flushQueue();
+    });
+    expect(result.current.queueLength).toBe(0);
   });
 });

--- a/src/hooks/utils/__tests__/useOfflineStatus.test.tsx
+++ b/src/hooks/utils/__tests__/useOfflineStatus.test.tsx
@@ -1,0 +1,27 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import useOfflineStatus from '../useOfflineStatus';
+import useOfflineDetection from '../useOfflineDetection';
+
+vi.mock('../useOfflineDetection', () => ({
+  __esModule: true,
+  default: vi.fn()
+}));
+
+const mockedDetection = useOfflineDetection as unknown as vi.Mock;
+
+describe('useOfflineStatus', () => {
+  it('returns offline state', () => {
+    mockedDetection.mockReturnValue(true);
+    const { result } = renderHook(() => useOfflineStatus());
+    expect(result.current.isOffline).toBe(true);
+    expect(result.current.isReconnecting).toBe(false);
+  });
+
+  it('returns reconnecting when queue pending', () => {
+    mockedDetection.mockReturnValue(false);
+    const { result } = renderHook(() => useOfflineStatus(3));
+    expect(result.current.isOffline).toBe(false);
+    expect(result.current.isReconnecting).toBe(true);
+  });
+});

--- a/src/hooks/utils/useOfflineStatus.ts
+++ b/src/hooks/utils/useOfflineStatus.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import useOfflineDetection from './useOfflineDetection';
+
+export interface OfflineStatus {
+  isOffline: boolean;
+  isReconnecting: boolean;
+}
+
+export function useOfflineStatus(queueLength = 0): OfflineStatus {
+  const isOffline = useOfflineDetection();
+  const [isReconnecting, setIsReconnecting] = useState(false);
+
+  useEffect(() => {
+    if (isOffline) {
+      setIsReconnecting(false);
+      return;
+    }
+    if (queueLength > 0) {
+      setIsReconnecting(true);
+    } else {
+      setIsReconnecting(false);
+    }
+  }, [isOffline, queueLength]);
+
+  return { isOffline, isReconnecting };
+}
+export default useOfflineStatus;


### PR DESCRIPTION
## Summary
- implement `useOfflineStatus` hook for offline detection and reconnection state
- extend `useOptimistic` to expose queue length and flushing control
- add `OfflineStatusBar` component to show offline and reconnecting messages
- cover new utilities and component with tests

## Testing
- `npm run test:coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683eb44a2330833193484b4fb562fd6e