### PR TITLE
Add offline status hook with queue management

### DIFF
--- a/src/hooks/__tests__/useOfflineStatus.test.tsx
+++ b/src/hooks/__tests__/useOfflineStatus.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useOfflineStatus } from '../useOfflineStatus';
+import * as queueService from '@/lib/services/offline-queue.service';
+
+describe('useOfflineStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // restore navigator.onLine if modified
+    delete (navigator as any).onLine;
+  });
+
+  it('initializes based on navigator.onLine', () => {
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    const { result } = renderHook(() => useOfflineStatus());
+    expect(result.current.isOffline).toBe(true);
+  });
+
+  it('updates queue length when queue changes', () => {
+    const listeners: ((n: number) => void)[] = [];
+    vi.spyOn(queueService, 'subscribeToQueueUpdates').mockImplementation(cb => {
+      listeners.push(cb);
+    });
+    vi.spyOn(queueService, 'unsubscribeFromQueueUpdates').mockImplementation(cb => {
+      const idx = listeners.indexOf(cb);
+      if (idx >= 0) listeners.splice(idx, 1);
+    });
+    const { result } = renderHook(() => useOfflineStatus());
+    act(() => listeners.forEach(l => l(2)));
+    expect(result.current.queueLength).toBe(2);
+  });
+
+  it('processes queue when online and connectivity verified', async () => {
+    vi.spyOn(queueService, 'verifyConnectivity').mockResolvedValue(true);
+    const proc = vi.spyOn(queueService, 'processQueue').mockResolvedValue();
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    const { result } = renderHook(() => useOfflineStatus());
+    Object.defineProperty(navigator, 'onLine', { value: true });
+    act(() => {
+      window.dispatchEvent(new Event('online'));
+    });
+    expect(result.current.isOffline).toBe(false);
+    await waitFor(() => expect(proc).toHaveBeenCalled());
+  });
+});

--- a/src/hooks/useOfflineStatus.ts
+++ b/src/hooks/useOfflineStatus.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import {
+  clearQueue,
+  processQueue,
+  subscribeToQueueUpdates,
+  unsubscribeFromQueueUpdates,
+  verifyConnectivity,
+} from '@/lib/services/offline-queue.service';
+
+function getConnectionQuality(): string {
+  const connection = (navigator as any).connection;
+  if (!connection) return 'unknown';
+  const type = connection.effectiveType;
+  if (['slow-2g', '2g'].includes(type)) return 'poor';
+  if (type === '3g') return 'fair';
+  if (type === '4g') return 'good';
+  return 'unknown';
+}
+
+export function useOfflineStatus() {
+  const [isOffline, setIsOffline] = useState<boolean>(!navigator.onLine);
+  const [isReconnecting, setIsReconnecting] = useState<boolean>(false);
+  const [queueLength, setQueueLength] = useState<number>(0);
+  const [connectionQuality, setConnectionQuality] = useState<string>(getConnectionQuality());
+
+  useEffect(() => {
+    const handleOffline = () => setIsOffline(true);
+    const handleOnline = () => {
+      setIsOffline(false);
+      setIsReconnecting(true);
+      verifyConnectivity().then(isConnected => {
+        setIsReconnecting(!isConnected);
+        if (isConnected) {
+          processQueue().catch(console.error);
+        }
+      });
+    };
+
+    const handleQueueUpdate = (length: number) => setQueueLength(length);
+    const handleConnChange = () => setConnectionQuality(getConnectionQuality());
+
+    window.addEventListener('offline', handleOffline);
+    window.addEventListener('online', handleOnline);
+    const conn = (navigator as any).connection;
+    conn?.addEventListener('change', handleConnChange);
+    subscribeToQueueUpdates(handleQueueUpdate);
+
+    return () => {
+      window.removeEventListener('offline', handleOffline);
+      window.removeEventListener('online', handleOnline);
+      conn?.removeEventListener('change', handleConnChange);
+      unsubscribeFromQueueUpdates(handleQueueUpdate);
+    };
+  }, []);
+
+  return {
+    isOffline,
+    isReconnecting,
+    queueLength,
+    connectionQuality,
+    processQueue: () => processQueue(),
+    cancelQueue: () => clearQueue(),
+  };
+}

--- a/src/lib/services/__tests__/offline-queue.service.test.ts
+++ b/src/lib/services/__tests__/offline-queue.service.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  offlineQueue,
+  processQueue,
+  clearQueue,
+} from '../offline-queue.service';
+
+describe('OfflineQueueService', () => {
+  beforeEach(() => {
+    clearQueue();
+  });
+
+  it('enqueues and processes requests in priority order', async () => {
+    const results: number[] = [];
+    offlineQueue.enqueue(async () => results.push(1), 0);
+    offlineQueue.enqueue(async () => results.push(2), 2);
+    offlineQueue.enqueue(async () => results.push(3), 1);
+
+    await processQueue();
+
+    expect(results).toEqual([2, 3, 1]);
+  });
+
+  it('allows selective cancellation', async () => {
+    const results: number[] = [];
+    const id = offlineQueue.enqueue(async () => results.push(1));
+    offlineQueue.cancel(id);
+    await processQueue();
+    expect(results).toEqual([]);
+    expect(offlineQueue.getItems().length).toBe(0);
+  });
+});

--- a/src/lib/services/offline-queue.service.ts
+++ b/src/lib/services/offline-queue.service.ts
@@ -1,0 +1,118 @@
+import { TypedEventEmitter } from '@/lib/utils/typed-event-emitter';
+
+export interface OfflineQueueEvent {
+  type: 'update';
+  length: number;
+}
+
+export interface OfflineQueueItem {
+  id: string;
+  /**
+   * Function that executes the queued request.
+   */
+  run: () => Promise<void>;
+  /**
+   * Higher priority items are processed first.
+   */
+  priority: number;
+}
+
+/**
+ * Service managing queued network requests when offline.
+ */
+export class OfflineQueueService extends TypedEventEmitter<OfflineQueueEvent> {
+  private queue: OfflineQueueItem[] = [];
+
+  /** Enqueue a request to be processed later. */
+  enqueue(run: () => Promise<void>, priority = 0): string {
+    const id = `offline_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+    this.queue.push({ id, run, priority });
+    this.sortQueue();
+    this.emit({ type: 'update', length: this.queue.length });
+    return id;
+  }
+
+  /** Get queued items. */
+  getItems(): OfflineQueueItem[] {
+    return [...this.queue];
+  }
+
+  /** Prioritize a specific request. */
+  prioritize(id: string, priority: number): void {
+    const item = this.queue.find(q => q.id === id);
+    if (item) {
+      item.priority = priority;
+      this.sortQueue();
+      this.emit({ type: 'update', length: this.queue.length });
+    }
+  }
+
+  /** Cancel a specific queued request. */
+  cancel(id: string): void {
+    this.queue = this.queue.filter(q => q.id !== id);
+    this.emit({ type: 'update', length: this.queue.length });
+  }
+
+  /** Remove all queued requests. */
+  clear(): void {
+    this.queue = [];
+    this.emit({ type: 'update', length: 0 });
+  }
+
+  /** Process the queued requests in order. */
+  async process(): Promise<void> {
+    while (this.queue.length > 0) {
+      const item = this.queue.shift()!;
+      try {
+        await item.run();
+      } catch {
+        // Silently ignore individual failures
+      }
+      this.emit({ type: 'update', length: this.queue.length });
+    }
+  }
+
+  /** Subscribe to queue length updates. */
+  subscribe(cb: (length: number) => void): () => void {
+    return this.onType('update', e => cb(e.length));
+  }
+
+  private sortQueue() {
+    this.queue.sort((a, b) => b.priority - a.priority);
+  }
+}
+
+export const offlineQueue = new OfflineQueueService();
+
+export function subscribeToQueueUpdates(cb: (length: number) => void) {
+  const off = offlineQueue.subscribe(cb);
+  subscriptions.set(cb, off);
+}
+
+export function unsubscribeFromQueueUpdates(cb: (length: number) => void) {
+  const off = subscriptions.get(cb);
+  if (off) {
+    off();
+    subscriptions.delete(cb);
+  }
+}
+
+export async function processQueue() {
+  await offlineQueue.process();
+}
+
+export function clearQueue() {
+  offlineQueue.clear();
+}
+
+/** Map to track callbacks for subscription management */
+const subscriptions = new Map<(length: number) => void, () => void>();
+
+export async function verifyConnectivity(): Promise<boolean> {
+  try {
+    const res = await fetch('/api');
+    return res.ok;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- implement offline network queue service with priority & cancellation
- add `useOfflineStatus` hook for reconnection handling and network quality
- test queue service and hook

## Testing
- `npx vitest run --coverage src/lib/services/__tests__/offline-queue.service.test.ts src/hooks/__tests__/useOfflineStatus.test.tsx`

------
https://chatgpt.com/codex/tasks/task_b_683eb4ca6b38833191429f1c35ffdeec