### PR TITLE
Add telemetry error metrics system

### DIFF
--- a/src/lib/telemetry/__tests__/error-metrics.test.ts
+++ b/src/lib/telemetry/__tests__/error-metrics.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ErrorMetrics, ErrorMetricDimensions } from '../error-metrics';
+
+describe('ErrorMetrics', () => {
+  let metrics: ErrorMetrics;
+  const base: ErrorMetricDimensions = {
+    errorCode: 'E1',
+    serviceName: 'svc',
+    environment: 'prod',
+    severity: 'high',
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    metrics = new ErrorMetrics();
+  });
+
+  it('increments and queries counts with partial dimensions', () => {
+    metrics.incrementErrorCount(base);
+    metrics.incrementErrorCount({ ...base, serviceName: 'svc2' });
+    metrics.incrementErrorCount(base);
+
+    expect(metrics.getErrorCount(base)).toBe(2);
+    expect(metrics.getErrorCount({ serviceName: 'svc' })).toBe(2);
+    expect(metrics.getErrorCount({ environment: 'prod' })).toBe(3);
+  });
+
+  it('calculates error rate and detects spikes', () => {
+    metrics.incrementErrorCount(base); // t=0
+    vi.advanceTimersByTime(200);
+    metrics.incrementErrorCount(base); // t=200
+    vi.advanceTimersByTime(100);
+    metrics.incrementErrorCount(base); // t=300
+    const rate = metrics.getErrorRate(base, 1000);
+    expect(rate).toBeCloseTo(3, 5);
+    const spike = metrics.detectSpike(base, 200, 1.5);
+    expect(spike).toBe(true);
+  });
+
+  it('tracks timing metrics', () => {
+    metrics.incrementErrorCount(base); // t=0
+    vi.advanceTimersByTime(300);
+    metrics.incrementErrorCount(base); // t=300
+    vi.advanceTimersByTime(200);
+    metrics.resolveError(base); // t=500
+    expect(metrics.getImpactDuration(base)).toBe(500);
+    expect(metrics.getTimeToResolution(base)).toBe(200);
+    expect(metrics.getDiscoveryTime(base)).toBe(0);
+  });
+
+  it('aggregates and provides frequency data', () => {
+    metrics.incrementErrorCount(base);
+    metrics.incrementErrorCount({ ...base, serviceName: 'svc2' });
+    metrics.incrementErrorCount({ ...base, serviceName: 'svc2' });
+    const agg = metrics.aggregateBy({}, 'serviceName');
+    expect(agg.get('svc')).toBe(1);
+    expect(agg.get('svc2')).toBe(2);
+    const freq = metrics.getFrequency({ serviceName: 'svc2' }, 1000, 2000);
+    expect(freq.reduce((a,b) => a+b, 0)).toBe(2);
+  });
+});

--- a/src/lib/telemetry/error-metrics.ts
+++ b/src/lib/telemetry/error-metrics.ts
@@ -1,0 +1,141 @@
+export type ErrorMetricDimensions = {
+  errorCode: string;
+  serviceName: string;
+  environment: string;
+  severity: string;
+};
+
+interface TimingData {
+  firstSeen: number;
+  lastSeen: number;
+  resolutionTimes: number[];
+  impactDurations: number[];
+}
+
+function matches(dim: ErrorMetricDimensions, partial: Partial<ErrorMetricDimensions>): boolean {
+  return Object.entries(partial).every(([k, v]) => (dim as any)[k] === v);
+}
+
+class ErrorRateCalculator {
+  private events: { time: number; dim: ErrorMetricDimensions }[] = [];
+
+  recordError(dim: ErrorMetricDimensions) {
+    this.events.push({ time: Date.now(), dim });
+  }
+
+  getEventCount(dim: Partial<ErrorMetricDimensions>, windowMs: number, offsetMs = 0): number {
+    const now = Date.now() - offsetMs;
+    const start = now - windowMs;
+    return this.events.filter(e => e.time >= start && e.time <= now && matches(e.dim, dim)).length;
+  }
+
+  getErrorRate(dim: Partial<ErrorMetricDimensions>, windowMs: number): number {
+    const count = this.getEventCount(dim, windowMs);
+    return count / (windowMs / 1000);
+  }
+}
+
+export class ErrorMetrics {
+  private counters: Map<string, number> = new Map();
+  private timings: Map<string, TimingData> = new Map();
+  private rateCalculator: ErrorRateCalculator;
+
+  constructor() {
+    this.rateCalculator = new ErrorRateCalculator();
+  }
+
+  incrementErrorCount(dim: ErrorMetricDimensions): void {
+    const key = this.getDimensionKey(dim);
+    const count = this.counters.get(key) || 0;
+    this.counters.set(key, count + 1);
+
+    const now = Date.now();
+    let t = this.timings.get(key);
+    if (!t) {
+      t = { firstSeen: now, lastSeen: now, resolutionTimes: [], impactDurations: [] };
+      this.timings.set(key, t);
+    } else {
+      t.lastSeen = now;
+    }
+    this.rateCalculator.recordError(dim);
+  }
+
+  resolveError(dim: ErrorMetricDimensions): void {
+    const key = this.getDimensionKey(dim);
+    const t = this.timings.get(key);
+    if (!t) return;
+    const now = Date.now();
+    t.resolutionTimes.push(now - t.lastSeen);
+    t.impactDurations.push(now - t.firstSeen);
+  }
+
+  getErrorCount(dim: Partial<ErrorMetricDimensions>): number {
+    let total = 0;
+    for (const [k, c] of this.counters) {
+      if (matches(this.parseKey(k), dim)) total += c;
+    }
+    return total;
+  }
+
+  getErrorRate(dim: Partial<ErrorMetricDimensions>, timeWindowMs: number): number {
+    return this.rateCalculator.getErrorRate(dim, timeWindowMs);
+  }
+
+  getTimeToResolution(dim: ErrorMetricDimensions): number | undefined {
+    const t = this.timings.get(this.getDimensionKey(dim));
+    if (!t || t.resolutionTimes.length === 0) return undefined;
+    return t.resolutionTimes.reduce((a, b) => a + b, 0) / t.resolutionTimes.length;
+  }
+
+  getImpactDuration(dim: ErrorMetricDimensions): number | undefined {
+    const t = this.timings.get(this.getDimensionKey(dim));
+    if (!t || t.impactDurations.length === 0) return undefined;
+    return t.impactDurations.reduce((a, b) => a + b, 0) / t.impactDurations.length;
+  }
+
+  getDiscoveryTime(dim: ErrorMetricDimensions): number | undefined {
+    return this.timings.get(this.getDimensionKey(dim))?.firstSeen;
+  }
+
+  aggregateBy(dim: Partial<ErrorMetricDimensions>, groupBy: keyof ErrorMetricDimensions): Map<string, number> {
+    const map = new Map<string, number>();
+    for (const [k, c] of this.counters) {
+      const parsed = this.parseKey(k);
+      if (!matches(parsed, dim)) continue;
+      const keyVal = parsed[groupBy];
+      map.set(keyVal, (map.get(keyVal) || 0) + c);
+    }
+    return map;
+  }
+
+  getFrequency(dim: Partial<ErrorMetricDimensions>, bucketMs: number, totalWindowMs: number): number[] {
+    const buckets = Math.ceil(totalWindowMs / bucketMs);
+    const arr = Array(buckets).fill(0);
+    const now = Date.now();
+    for (const e of (this as any).rateCalculator.events as { time: number; dim: ErrorMetricDimensions }[]) {
+      if (!matches(e.dim, dim)) continue;
+      const diff = now - e.time;
+      if (diff < 0 || diff >= totalWindowMs) continue;
+      const index = Math.floor(diff / bucketMs);
+      const idx = buckets - index - 1;
+      arr[idx]++;
+    }
+    return arr;
+  }
+
+  detectSpike(dim: Partial<ErrorMetricDimensions>, timeWindowMs: number, multiplier = 2): boolean {
+    const current = this.rateCalculator.getEventCount(dim, timeWindowMs);
+    const previous = this.rateCalculator.getEventCount(dim, timeWindowMs, timeWindowMs);
+    if (previous === 0) return current > 0;
+    return current > previous * multiplier;
+  }
+
+  private getDimensionKey(dim: ErrorMetricDimensions): string {
+    return `${dim.environment}:${dim.serviceName}:${dim.errorCode}:${dim.severity}`;
+  }
+
+  private parseKey(key: string): ErrorMetricDimensions {
+    const [environment, serviceName, errorCode, severity] = key.split(':');
+    return { environment, serviceName, errorCode, severity };
+  }
+}


### PR DESCRIPTION
## Summary
- implement `ErrorMetrics` library for tracking error statistics
- support timing, aggregation, rate and spike detection
- add unit tests for the new metrics module

## Testing
- `npx vitest run src/lib/telemetry/__tests__/error-metrics.test.ts --coverage`

------
https://chatgpt.com/codex/tasks/task_b_683eb501c75c833189617b5ce7642d06