### PR TITLE
Add error reporter abstraction

### DIFF
--- a/src/lib/telemetry/__tests__/error-reporting.test.ts
+++ b/src/lib/telemetry/__tests__/error-reporting.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ErrorReporter } from '../error-reporting';
+import { errorLogger } from '@/lib/monitoring/error-logger';
+
+vi.mock('@/lib/monitoring/error-logger', () => ({
+  errorLogger: { error: vi.fn() },
+}));
+
+describe('ErrorReporter', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    (ErrorReporter as any).instance = undefined;
+  });
+
+  it('returns singleton instance', () => {
+    const a = ErrorReporter.getInstance();
+    const b = ErrorReporter.getInstance();
+    expect(a).toBe(b);
+  });
+
+  it('adds breadcrumbs up to the limit', () => {
+    const reporter = ErrorReporter.getInstance();
+    reporter.initialize();
+    for (let i = 0; i < 25; i++) {
+      reporter.addBreadcrumb(`b${i}`, 'test');
+    }
+    reporter.captureError(new Error('fail'));
+    const ctx = (errorLogger.error as any).mock.calls[0][1];
+    expect(ctx.breadcrumbs).toHaveLength(20);
+  });
+
+  it('captures error with user context', () => {
+    const reporter = ErrorReporter.getInstance();
+    reporter.initialize();
+    reporter.setUserContext({ id: 'u1' });
+    reporter.addBreadcrumb('clicked', 'ui');
+    const id = reporter.captureError(new Error('boom'), { requestId: 'r1' });
+    expect(typeof id).toBe('string');
+    expect(errorLogger.error).toHaveBeenCalled();
+    const ctx = (errorLogger.error as any).mock.calls[0][1];
+    expect(ctx.user.id).toBe('u1');
+    expect(ctx.requestId).toBe('r1');
+    expect(ctx.breadcrumbs.length).toBe(1);
+  });
+});

--- a/src/lib/telemetry/error-reporting.ts
+++ b/src/lib/telemetry/error-reporting.ts
@@ -1,0 +1,195 @@
+export interface ErrorReporterOptions {
+  environment: string;
+  release: string;
+  serverName?: string;
+  maxBreadcrumbs?: number;
+}
+
+import { v4 as uuidv4 } from 'uuid';
+import { ApplicationError, createErrorFromUnknown } from '@/core/common/errors';
+import { errorLogger } from '@/lib/monitoring/error-logger';
+
+interface Breadcrumb {
+  message: string;
+  category: string;
+  data?: Record<string, any>;
+  timestamp: string;
+}
+
+interface ErrorPayload {
+  id: string;
+  error: ApplicationError;
+  context: Record<string, any>;
+  breadcrumbs: Breadcrumb[];
+}
+
+type Integration = (payload: ErrorPayload) => void | Promise<void>;
+
+export class ErrorReporter {
+  private static instance: ErrorReporter;
+  private initialized = false;
+  private options: ErrorReporterOptions;
+  private breadcrumbs: Breadcrumb[] = [];
+  private integrations: Integration[] = [];
+  private userContext: Record<string, any> = {};
+
+  private constructor(options: ErrorReporterOptions) {
+    this.options = { maxBreadcrumbs: 20, ...options };
+  }
+
+  public static getInstance(): ErrorReporter {
+    if (!ErrorReporter.instance) {
+      ErrorReporter.instance = new ErrorReporter({
+        environment: process.env.NODE_ENV || 'development',
+        release: process.env.VERSION || '0.0.0',
+      });
+    }
+    return ErrorReporter.instance;
+  }
+
+  public initialize(): void {
+    if (this.initialized) return;
+
+    if (typeof window !== 'undefined') {
+      this.initializeBrowserReporting();
+    } else {
+      this.initializeServerReporting();
+    }
+
+    this.initialized = true;
+  }
+
+  public setUserContext(context: Record<string, any>) {
+    this.userContext = { ...context };
+  }
+
+  public addBreadcrumb(message: string, category: string, data?: Record<string, any>): void {
+    const breadcrumb: Breadcrumb = {
+      message,
+      category,
+      data,
+      timestamp: new Date().toISOString(),
+    };
+    this.breadcrumbs.push(breadcrumb);
+    const max = this.options.maxBreadcrumbs ?? 20;
+    if (this.breadcrumbs.length > max) {
+      this.breadcrumbs.splice(0, this.breadcrumbs.length - max);
+    }
+  }
+
+  public captureError(error: Error | ApplicationError, context: Record<string, any> = {}): string {
+    const appError = createErrorFromUnknown(error);
+    const id = uuidv4();
+    const systemState = typeof process !== 'undefined' && typeof process.uptime === 'function' ? { uptime: process.uptime() } : {};
+    const payload: ErrorPayload = {
+      id,
+      error: appError,
+      context: {
+        environment: this.options.environment,
+        release: this.options.release,
+        serverName: this.options.serverName,
+        ...systemState,
+        ...(this.userContext && { user: this.userContext }),
+        ...context,
+      },
+      breadcrumbs: [...this.breadcrumbs],
+    };
+
+    for (const integration of this.integrations) {
+      try {
+        integration(payload);
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error('Error reporting integration failed', e);
+      }
+    }
+
+    return id;
+  }
+
+  /* istanbul ignore next -- environment specific */
+  private initializeBrowserReporting(): void {
+    /* istanbul ignore next -- integration optional */
+    if ((window as any).Sentry && process.env.NEXT_PUBLIC_SENTRY_DSN) {
+      try {
+        (window as any).Sentry.init({
+          dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+          environment: this.options.environment,
+          release: this.options.release,
+        });
+        this.integrations.push(payload => {
+          (window as any).Sentry.captureException(payload.error, { extra: payload });
+        });
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('Sentry initialization failed', err);
+      }
+    }
+
+    /* istanbul ignore next -- runtime integration */
+    if (process.env.NEXT_PUBLIC_ERROR_ENDPOINT) {
+      this.integrations.push(payload => {
+        fetch(process.env.NEXT_PUBLIC_ERROR_ENDPOINT!, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+          keepalive: true,
+        }).catch(() => {});
+      });
+    }
+
+    this.integrations.push(payload => {
+      errorLogger.error(payload.error.message, {
+        ...payload.context,
+        breadcrumbs: payload.breadcrumbs,
+        stack: payload.error.stack,
+        id: payload.id,
+      });
+    });
+  }
+
+  /* istanbul ignore next -- environment specific */
+  private async initializeServerReporting(): Promise<void> {
+    /* istanbul ignore next -- integration optional */
+    if (process.env.SENTRY_DSN) {
+      try {
+        const mod = '@sentry/node';
+        const Sentry = await import(/* @vite-ignore */ mod);
+        Sentry.init({
+          dsn: process.env.SENTRY_DSN,
+          environment: this.options.environment,
+          release: this.options.release,
+          serverName: this.options.serverName,
+        });
+        this.integrations.push(payload => {
+          Sentry.captureException(payload.error, { extra: payload });
+        });
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('Sentry initialization failed', err);
+      }
+    }
+
+    /* istanbul ignore next -- runtime integration */
+    if (process.env.ERROR_ENDPOINT) {
+      this.integrations.push(payload => {
+        fetch(process.env.ERROR_ENDPOINT!, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        }).catch(() => {});
+      });
+    }
+
+    this.integrations.push(payload => {
+      errorLogger.error(payload.error.message, {
+        ...payload.context,
+        breadcrumbs: payload.breadcrumbs,
+        stack: payload.error.stack,
+        id: payload.id,
+      });
+    });
+  }
+}
+
+export default ErrorReporter;

--- a/src/lib/telemetry/index.ts
+++ b/src/lib/telemetry/index.ts
@@ -1,0 +1,2 @@
+export { ErrorReporter } from './error-reporting';
+export type { ErrorReporterOptions } from './error-reporting';


### PR DESCRIPTION
## Summary
- add telemetry error reporter with Sentry and custom backend hooks
- expose reporter from telemetry index
- test breadcrumb handling and logging

## Testing
- `npx vitest run --coverage src/lib/telemetry/__tests__/error-reporting.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_683eb53edb38833188ac44077c8ee163