### PR TITLE
Implement basic alert manager

### DIFF
--- a/src/lib/telemetry/__tests__/alert-manager.test.ts
+++ b/src/lib/telemetry/__tests__/alert-manager.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AlertManager, AlertRule } from '../alert-manager';
+import { NotificationChannel } from '@/core/notification/models';
+import { ApplicationError } from '@/core/common/errors';
+import { SERVER_ERROR } from '@/core/common/error-codes';
+import * as email from '@/lib/email/sendEmail';
+import * as sms from '@/lib/sms/sendSms';
+
+vi.mock('@/lib/email/sendEmail');
+vi.mock('@/lib/sms/sendSms');
+
+describe('AlertManager', () => {
+  let manager: AlertManager;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    manager = new AlertManager({ bufferSize: 5 });
+    vi.clearAllMocks();
+    vi.mocked(email.sendEmail).mockResolvedValue({ success: true, provider: 'mock' });
+    vi.mocked(sms.sendSms).mockResolvedValue({ success: true, provider: 'mock' });
+  });
+
+  it('triggers alert when threshold exceeded', async () => {
+    const rule: AlertRule = {
+      id: 'r1',
+      name: 'DB Errors',
+      errorPatterns: ['SERVER_002'],
+      threshold: 2,
+      timeWindowMs: 1000,
+      cooldownMs: 1000,
+      severity: 'critical',
+      channels: [NotificationChannel.EMAIL],
+    };
+    manager.addRule(rule);
+
+    manager.registerError(new ApplicationError(SERVER_ERROR.SERVER_002, 'fail')); 
+    manager.registerError(new ApplicationError(SERVER_ERROR.SERVER_002, 'fail')); 
+
+    expect(email.sendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects cooldown period', () => {
+    const rule: AlertRule = {
+      id: 'r2',
+      name: 'Auth Errors',
+      errorPatterns: ['AUTH_001'],
+      threshold: 1,
+      timeWindowMs: 1000,
+      cooldownMs: 5000,
+      severity: 'high',
+      channels: [NotificationChannel.EMAIL],
+    };
+    manager.addRule(rule);
+
+    manager.registerError(new ApplicationError(SERVER_ERROR.SERVER_001, 'other')); // not match
+    manager.registerError(new ApplicationError(SERVER_ERROR.SERVER_001, 'other')); // not match
+
+    // Should not trigger
+    expect(email.sendEmail).toHaveBeenCalledTimes(0);
+
+    manager.registerError(new ApplicationError('AUTH_001' as any, 'auth fail'));
+    expect(email.sendEmail).toHaveBeenCalledTimes(1);
+
+    manager.registerError(new ApplicationError('AUTH_001' as any, 'auth again'));
+    expect(email.sendEmail).toHaveBeenCalledTimes(1); // cooldown
+
+    vi.advanceTimersByTime(5000);
+    manager.registerError(new ApplicationError('AUTH_001' as any, 'auth again'));
+    expect(email.sendEmail).toHaveBeenCalledTimes(2);
+  });
+
+  it('supports sms channel', () => {
+    const rule: AlertRule = {
+      id: 'r3',
+      name: 'SMS Rule',
+      errorPatterns: ['SMS_ERR'],
+      threshold: 1,
+      timeWindowMs: 1000,
+      cooldownMs: 1000,
+      severity: 'high',
+      channels: [NotificationChannel.SMS],
+    };
+    manager.addRule(rule);
+    manager.registerError(new ApplicationError('SMS_ERR' as any, 'boom'));
+    expect(sms.sendSms).toHaveBeenCalledTimes(1);
+  });
+
+  it('generates rule id and handles buffer overflow', () => {
+    const rule: AlertRule = {
+      id: '',
+      name: 'Overflow',
+      errorPatterns: ['OF'],
+      threshold: 3,
+      timeWindowMs: 1000,
+      cooldownMs: 1000,
+      severity: 'low',
+      channels: [NotificationChannel.EMAIL],
+    };
+    const id = manager.addRule(rule);
+    expect(id).toBeTruthy();
+    for (let i = 0; i < 7; i++) {
+      manager.registerError(new ApplicationError('OF' as any, 'err')); 
+    }
+    expect(email.sendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs for unknown channel', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const rule: AlertRule = {
+      id: 'r4',
+      name: 'Other',
+      errorPatterns: ['X'],
+      threshold: 1,
+      timeWindowMs: 1000,
+      cooldownMs: 1000,
+      severity: 'low',
+      channels: ['other' as unknown as NotificationChannel],
+    };
+    manager.addRule(rule);
+    manager.registerError(new ApplicationError('X' as any, 'x'));
+    expect(log).toHaveBeenCalled();
+    log.mockRestore();
+  });
+});

--- a/src/lib/telemetry/alert-manager.ts
+++ b/src/lib/telemetry/alert-manager.ts
@@ -1,0 +1,124 @@
+export interface AlertManagerOptions {
+  bufferSize?: number;
+}
+
+import { ApplicationError } from '@/core/common/errors';
+import { NotificationChannel } from '@/core/notification/models';
+import { sendEmail } from '@/lib/email/sendEmail';
+import { sendSms } from '@/lib/sms/sendSms';
+
+/** Simple fixed size circular buffer */
+class CircularBuffer<T extends { timestamp: string }> {
+  private buffer: T[] = [];
+  private pointer = 0;
+  private length = 0;
+
+  constructor(private size: number) {}
+
+  add(item: T) {
+    if (this.buffer.length < this.size) {
+      this.buffer.push(item);
+    } else {
+      this.buffer[this.pointer] = item;
+      this.pointer = (this.pointer + 1) % this.size;
+    }
+    if (this.length < this.size) this.length++;
+  }
+
+  getSince(timestamp: number): T[] {
+    const arr = this.toArray();
+    return arr.filter(e => Date.parse(e.timestamp) >= timestamp);
+  }
+
+  private toArray(): T[] {
+    if (this.buffer.length < this.size) return [...this.buffer];
+    return [...this.buffer.slice(this.pointer), ...this.buffer.slice(0, this.pointer)];
+  }
+}
+
+export type AlertChannel = NotificationChannel;
+
+export interface AlertRule {
+  id: string;
+  name: string;
+  errorPatterns: string[];
+  threshold: number;
+  timeWindowMs: number;
+  cooldownMs: number;
+  severity: 'low' | 'medium' | 'high' | 'critical';
+  channels: AlertChannel[];
+  lastTriggered?: number;
+}
+
+export class AlertManager {
+  private rules: AlertRule[] = [];
+  private errorBuffer: CircularBuffer<ApplicationError>;
+
+  constructor(options?: AlertManagerOptions) {
+    this.errorBuffer = new CircularBuffer(options?.bufferSize || 1000);
+    this.loadRules();
+  }
+
+  registerError(error: ApplicationError): void {
+    this.errorBuffer.add(error);
+    this.evaluateRules();
+  }
+
+  addRule(rule: AlertRule): string {
+    if (!rule.id) {
+      rule.id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    }
+    this.rules.push(rule);
+    return rule.id;
+  }
+
+  private evaluateRules(): void {
+    const now = Date.now();
+    for (const rule of this.rules) {
+      if (rule.lastTriggered && now - rule.lastTriggered < rule.cooldownMs) {
+        continue;
+      }
+      const matching = this.countMatchingErrors(rule, now - rule.timeWindowMs);
+      if (matching >= rule.threshold) {
+        this.triggerAlert(rule, matching);
+        rule.lastTriggered = now;
+      }
+    }
+  }
+
+  private countMatchingErrors(rule: AlertRule, since: number): number {
+    const errors = this.errorBuffer.getSince(since);
+    return errors.filter(e =>
+      rule.errorPatterns.some(p => e.message.includes(p) || e.code.includes(p))
+    ).length;
+  }
+
+  private async triggerAlert(rule: AlertRule, count: number): Promise<void> {
+    const subject = `[${rule.severity.toUpperCase()}] ${rule.name}`;
+    const message = `${rule.name} triggered with ${count} errors`;
+    for (const ch of rule.channels) {
+      switch (ch) {
+        case NotificationChannel.EMAIL:
+          await sendEmail({
+            to: process.env.ALERT_EMAIL_TO || 'alerts@example.com',
+            subject,
+            html: message,
+          });
+          break;
+        case NotificationChannel.SMS:
+          await sendSms({
+            to: process.env.ALERT_SMS_TO || '',
+            message,
+          });
+          break;
+        default:
+          console.log(`[${ch}] ${message}`);
+      }
+    }
+  }
+
+  private loadRules(): void {
+    // Placeholder for loading rules from configuration or storage
+    this.rules = [];
+  }
+}


### PR DESCRIPTION
## Summary
- add new telemetry alert manager utility
- support error buffering, rule evaluation and multiple channels
- cover alert manager with unit tests

## Testing
- `npx vitest run src/lib/telemetry/__tests__/alert-manager.test.ts --coverage`

------
https://chatgpt.com/codex/tasks/task_b_683eb55aba548331afba0b43c25b426c