### PR TITLE
Implement permission cache service and metrics

### DIFF
--- a/app/admin/cache/page.tsx
+++ b/app/admin/cache/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function CacheMetricsPage() {
+  const [metrics, setMetrics] = useState<any>(null);
+
+  useEffect(() => {
+    fetch('/api/cache/metrics').then(async res => {
+      if (res.ok) {
+        const data = await res.json();
+        setMetrics(data.data);
+      }
+    });
+  }, []);
+
+  return (
+    <div className="container py-6 space-y-6">
+      <h1 className="text-3xl font-bold tracking-tight">Cache Metrics</h1>
+      {!metrics ? <p>Loading...</p> : (
+        <pre className="bg-muted p-4 rounded">
+          {JSON.stringify(metrics, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/app/api/cache/metrics/route.ts
+++ b/app/api/cache/metrics/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { permissionCacheService } from '@/services/permission/permission-cache.service';
+
+export async function GET() {
+  const metrics = permissionCacheService.getMetrics();
+  return NextResponse.json({ data: metrics });
+}

--- a/src/lib/cache/__tests__/memory-cache.test.ts
+++ b/src/lib/cache/__tests__/memory-cache.test.ts
@@ -39,4 +39,13 @@ describe('MemoryCache', () => {
     expect(v2).toBe(5);
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
+
+  it('deleteWhere removes matching keys', () => {
+    const cache = new MemoryCache<string, number>({ ttl: 1000 });
+    cache.set('a:1', 1);
+    cache.set('b:1', 2);
+    cache.deleteWhere(k => k.startsWith('a'));
+    expect(cache.get('a:1')).toBeUndefined();
+    expect(cache.get('b:1')).toBe(2);
+  });
 });

--- a/src/lib/cache/__tests__/multi-level-cache-delete.test.ts
+++ b/src/lib/cache/__tests__/multi-level-cache-delete.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MemoryCache, MultiLevelCache, RedisCache } from '@/lib/cache';
+import { Redis } from '@upstash/redis';
+
+vi.mock('@upstash/redis', () => ({ Redis: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), del: vi.fn() })) }));
+
+describe('MultiLevelCache deleteWhere', () => {
+  let redis: any;
+  let cache: MultiLevelCache<string, number>;
+
+  beforeEach(() => {
+    redis = new Redis({ url: 'x', token: 'x' });
+    const redisCache = new RedisCache<number>(redis, { prefix: 't:' });
+    cache = new MultiLevelCache(new MemoryCache({ ttl: 1000 }), redisCache, 1000);
+  });
+
+  it('removes keys from both caches', async () => {
+    await cache.set('a:1', 1);
+    await cache.set('b:1', 2);
+    await cache.deleteWhere(k => k.startsWith('a'));
+    expect(await cache.get('a:1')).toBeUndefined();
+    expect(await cache.get('b:1')).toBe(2);
+    expect(redis.del).toHaveBeenCalled();
+  });
+});

--- a/src/lib/cache/memory-cache.ts
+++ b/src/lib/cache/memory-cache.ts
@@ -42,6 +42,18 @@ export class MemoryCache<K, V> {
     this.cache.delete(key);
   }
 
+  keys(): IterableIterator<K> {
+    return this.cache.keys();
+  }
+
+  deleteWhere(predicate: (key: K) => boolean): void {
+    for (const key of this.cache.keys()) {
+      if (predicate(key)) {
+        this.cache.delete(key);
+      }
+    }
+  }
+
   async getOrCreate(key: K, fetcher: () => Promise<V>, ttl: number = this.ttl): Promise<V> {
     const cached = this.get(key);
     if (cached !== undefined) return cached;

--- a/src/lib/cache/multi-level-cache.ts
+++ b/src/lib/cache/multi-level-cache.ts
@@ -42,6 +42,15 @@ export class MultiLevelCache<K extends string, V> {
     if (this.redis) await this.redis.delete(key);
   }
 
+  async deleteWhere(predicate: (key: K) => boolean): Promise<void> {
+    for (const key of this.memory.keys()) {
+      if (predicate(key)) {
+        this.memory.delete(key);
+        if (this.redis) await this.redis.delete(key);
+      }
+    }
+  }
+
   async getOrCreate(key: K, fetcher: () => Promise<V>, ttl = this.ttl): Promise<V> {
     const existing = await this.get(key);
     if (existing !== undefined) return existing;

--- a/src/lib/services/resource-relationship.service.ts
+++ b/src/lib/services/resource-relationship.service.ts
@@ -1,3 +1,5 @@
+import { permissionCacheService } from '@/services/permission/permission-cache.service';
+
 export class ResourceRelationshipService {
   constructor(private db: any) {}
 
@@ -9,7 +11,7 @@ export class ResourceRelationshipService {
     relationshipType: string;
     createdBy?: string;
   }) {
-    return this.db
+    const result = await this.db
       .from('resource_relationships')
       .insert({
         parent_type: relationship.parentType,
@@ -21,6 +23,8 @@ export class ResourceRelationshipService {
       })
       .select()
       .single();
+    await permissionCacheService.clearResource(relationship.childType, relationship.childId);
+    return result;
   }
 
   async getParentResources(resourceType: string, resourceId: string) {
@@ -49,7 +53,7 @@ export class ResourceRelationshipService {
     childType: string,
     childId: string
   ) {
-    return this.db
+    const result = await this.db
       .from('resource_relationships')
       .delete()
       .match({
@@ -58,5 +62,7 @@ export class ResourceRelationshipService {
         child_type: childType,
         child_id: childId
       });
+    await permissionCacheService.clearResource(childType, childId);
+    return result;
   }
 }

--- a/src/services/permission/__tests__/permission-cache.service.test.ts
+++ b/src/services/permission/__tests__/permission-cache.service.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { PermissionCacheService } from '../permission-cache.service';
+import { Redis } from '@upstash/redis';
+
+vi.mock('@upstash/redis', () => ({ Redis: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), del: vi.fn() })) }));
+
+describe('PermissionCacheService', () => {
+  let service: PermissionCacheService;
+  beforeEach(() => {
+    service = new PermissionCacheService();
+  });
+
+  it('tracks hit and miss metrics', async () => {
+    await service.userRoles.set('u1', []);
+    await service.userRoles.get('u1');
+    await service.userRoles.get('u2');
+    const metrics = service.getMetrics();
+    expect(metrics.userRoles.hits).toBe(1);
+    expect(metrics.userRoles.misses).toBe(1);
+  });
+});

--- a/src/services/permission/__tests__/service/default-permission.service.test.ts
+++ b/src/services/permission/__tests__/service/default-permission.service.test.ts
@@ -3,6 +3,7 @@ import { DefaultPermissionService } from "../../default-permission.service";
 import { PermissionValues, UserRole } from "@/core/permission/models";
 import { MemoryCache, MultiLevelCache, RedisCache } from '@/lib/cache';
 import { Redis } from '@upstash/redis';
+import { permissionCacheService } from '../../permission-cache.service';
 
 vi.mock('@upstash/redis', () => ({ Redis: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), del: vi.fn() })) }));
 import { ResourcePermissionResolver } from '@/lib/services/resource-permission-resolver.service';
@@ -33,14 +34,19 @@ describe("DefaultPermissionService", () => {
     resolver = { getEffectivePermissions: vi.fn().mockResolvedValue([]) } as ResourcePermissionResolver;
     service = new DefaultPermissionService(provider, { getEffectivePermissions: vi.fn() } as any, resolver);
     const redis = new Redis({ url: 'x', token: 'x' });
-    (DefaultPermissionService as any).roleCache = new MultiLevelCache(
+    permissionCacheService.userRoles = new MultiLevelCache(
       new MemoryCache({ ttl: 30000 }),
       new RedisCache<UserRole[]>(redis, { prefix: 'role:' }),
       30000,
     );
-    (DefaultPermissionService as any).resourceCache = new MultiLevelCache(
+    permissionCacheService.resourcePermissions = new MultiLevelCache(
       new MemoryCache({ ttl: 30000 }),
       new RedisCache<boolean>(redis, { prefix: 'res:' }),
+      30000,
+    );
+    permissionCacheService.userPermissions = new MultiLevelCache(
+      new MemoryCache({ ttl: 30000 }),
+      new RedisCache<boolean>(redis, { prefix: 'perm:' }),
       30000,
     );
   });
@@ -136,7 +142,7 @@ describe("DefaultPermissionService", () => {
     const mockRoleService = { getEffectivePermissions: vi.fn().mockResolvedValue([PermissionValues.MANAGE_ROLES]) } as any;
     service = new DefaultPermissionService(provider, mockRoleService);
     const redis = new Redis({ url: 'x', token: 'x' });
-    (DefaultPermissionService as any).userPermissionCache = new MultiLevelCache(
+    permissionCacheService.userPermissions = new MultiLevelCache(
       new MemoryCache({ ttl: 30000 }),
       new RedisCache<boolean>(redis, { prefix: 'perm:' }),
       30000,

--- a/src/services/permission/permission-cache.service.ts
+++ b/src/services/permission/permission-cache.service.ts
@@ -1,0 +1,55 @@
+import { MemoryCache, MultiLevelCache, RedisCache, getRedisClient } from '@/lib/cache';
+import type { UserRole } from '@/core/permission/models';
+
+export interface PermissionCacheMetrics {
+  userRoles: { hits: number; misses: number };
+  userPermissions: { hits: number; misses: number };
+  resourcePermissions: { hits: number; misses: number };
+}
+
+const TTL = 30_000;
+
+function createRedisCache<V>(prefix: string) {
+  const client = getRedisClient();
+  return client ? new RedisCache<V>(client, { prefix }) : undefined;
+}
+
+export class PermissionCacheService {
+  userRoles = new MultiLevelCache<string, UserRole[]>(
+    new MemoryCache({ ttl: TTL }),
+    createRedisCache('role:'),
+    TTL,
+  );
+
+  userPermissions = new MultiLevelCache<string, boolean>(
+    new MemoryCache({ ttl: TTL }),
+    createRedisCache('perm:'),
+    TTL,
+  );
+
+  resourcePermissions = new MultiLevelCache<string, boolean>(
+    new MemoryCache({ ttl: TTL }),
+    createRedisCache('res:'),
+    TTL,
+  );
+
+  getMetrics(): PermissionCacheMetrics {
+    return {
+      userRoles: this.userRoles.metrics,
+      userPermissions: this.userPermissions.metrics,
+      resourcePermissions: this.resourcePermissions.metrics,
+    };
+  }
+
+  async clearUser(userId: string) {
+    await this.userRoles.delete(userId);
+    await this.userPermissions.deleteWhere(k => k.startsWith(`${userId}:`));
+    await this.resourcePermissions.deleteWhere(k => k.startsWith(`${userId}:`));
+  }
+
+  async clearResource(resourceType: string, resourceId: string) {
+    await this.resourcePermissions.deleteWhere(k => k.includes(`:${resourceType}:${resourceId}`));
+  }
+}
+
+export const permissionCacheService = new PermissionCacheService();


### PR DESCRIPTION
## Summary
- add PermissionCacheService with multi-level caching
- extend MemoryCache and MultiLevelCache with helper methods
- cache resource hierarchy and add cache invalidation hooks
- expose cache metrics API and simple admin page
- add unit tests for new caching utilities

## Testing
- `npx vitest run src/lib/cache/__tests__/memory-cache.test.ts src/lib/cache/__tests__/multi-level-cache.test.ts src/lib/cache/__tests__/multi-level-cache-delete.test.ts src/services/permission/__tests__/permission-cache.service.test.ts src/services/permission/__tests__/service/default-permission.service.test.ts --coverage`

------
https://chatgpt.com/codex/tasks/task_b_683ebd3b80c88331a376eb337a6f473d