### PR TITLE
Improve error messaging and recovery options

### DIFF
--- a/src/components/ui/__tests__/QueryError.test.tsx
+++ b/src/components/ui/__tests__/QueryError.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { QueryError } from '../QueryError';
+
+vi.useFakeTimers();
+
+describe('QueryError', () => {
+  it('calls retry automatically when autoRetry is true', async () => {
+    const retry = vi.fn().mockResolvedValue(undefined);
+    render(<QueryError error="fail" onRetry={retry} autoRetry maxRetries={1} />);
+    await act(() => {
+      vi.runAllTimers();
+    });
+    expect(retry).toHaveBeenCalled();
+  });
+
+  it('renders help link when provided', () => {
+    render(<QueryError error="fail" helpUrl="/help" />);
+    const link = screen.getByRole('link', { name: /need help/i });
+    expect(link).toHaveAttribute('href', '/help');
+  });
+
+  it('triggers retry on button click', async () => {
+    const retry = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<QueryError error="fail" onRetry={retry} />);
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    expect(retry).toHaveBeenCalled();
+  });
+});

--- a/src/locales/en/errors.json
+++ b/src/locales/en/errors.json
@@ -1,6 +1,6 @@
 {
   "auth": {
-    "unauthorized": "Authentication required.",
+    "unauthorized": "You need to log in to continue.",
     "forbidden": "Access denied.",
     "invalid_credentials": "Invalid email or password.",
     "email_not_verified": "Email not verified.",
@@ -39,10 +39,10 @@
     "invalid_format": "Invalid format for {{field}}."
   },
   "server": {
-    "internal_error": "Internal server error.",
-    "service_unavailable": "Service is currently unavailable.",
-    "database_error": "Database error.",
-    "operation_failed": "Operation failed.",
-    "retrieval_failed": "Data retrieval failed."
+    "internal_error": "Something went wrong on our end. Please try again later.",
+    "service_unavailable": "We're updating our service. Please retry in a moment.",
+    "database_error": "A database error occurred. Please try again later.",
+    "operation_failed": "We couldn't complete the operation.",
+    "retrieval_failed": "We couldn't load the requested data."
   }
 }


### PR DESCRIPTION
## Summary
- make `QueryError` retryable with optional help link and auto retry feedback
- refresh English error messages with friendlier language
- add tests for the enhanced `QueryError`

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683ebd02649c83318ba276d77e3eac84