### PR TITLE
Implement error feedback and impact scoring

### DIFF
--- a/docs/Product documentation/Error Review Process.md
+++ b/docs/Product documentation/Error Review Process.md
@@ -1,0 +1,13 @@
+# Error Review Process
+
+This document outlines the regular process for analysing errors and planning improvements.
+
+## Weekly Review Cycle
+
+1. **Collect Metrics** – Use `ErrorDashboardData` and `ErrorMetrics` to gather counts, affected users and feedback for the last week.
+2. **Score Impact** – Calculate an impact score for each error using `getImpactScore`. Higher scores indicate larger user impact.
+3. **Prioritise Fixes** – Feed the scores into `ErrorPrioritizer` to produce a ranked list of issues.
+4. **Review Meeting** – The team reviews the ranked list every week and decides which errors to address.
+5. **Track Progress** – Create tasks for selected errors and monitor feedback to verify improvements.
+
+Following this process ensures the error handling system continuously evolves based on real‑world data.

--- a/src/lib/monitoring/__tests__/telemetry.test.ts
+++ b/src/lib/monitoring/__tests__/telemetry.test.ts
@@ -69,4 +69,12 @@ describe('Telemetry', () => {
     const high = telemetry.getHighestImpactErrors();
     expect(high[0]).toBe('B');
   });
+
+  it('collects error feedback', () => {
+    telemetry.recordFeedback('E1', true);
+    telemetry.recordFeedback('E1', false);
+    const m = telemetry.getMetrics('E1')!;
+    expect(m.feedbackTotal).toBe(2);
+    expect(m.feedbackHelpful).toBe(1);
+  });
 });

--- a/src/lib/monitoring/telemetry.ts
+++ b/src/lib/monitoring/telemetry.ts
@@ -36,6 +36,8 @@ interface ErrorMetrics {
   segmentImpact: Map<string, number>;
   actionCounts: Map<string, number>;
   events: number[];
+  feedbackHelpful: number;
+  feedbackTotal: number;
 }
 
 export type TelemetryEvent = { type: 'alert'; alert: TelemetryAlert };
@@ -76,6 +78,8 @@ export class Telemetry extends TypedEventEmitter<TelemetryEvent> {
         segmentImpact: new Map(),
         actionCounts: new Map(),
         events: [],
+        feedbackHelpful: 0,
+        feedbackTotal: 0,
       };
       this.metrics.set(event.type, m);
     }
@@ -115,6 +119,29 @@ export class Telemetry extends TypedEventEmitter<TelemetryEvent> {
     const now = Date.now();
     m.events = m.events.filter(t => now - t <= windowMs);
     return m.events.length / (windowMs / 1000);
+  }
+
+  recordFeedback(type: string, wasHelpful: boolean) {
+    let m = this.metrics.get(type);
+    if (!m) {
+      m = {
+        count: 0,
+        criticalCount: 0,
+        nonCriticalCount: 0,
+        firstSeen: Date.now(),
+        lastSeen: Date.now(),
+        resolutionTimes: [],
+        affectedUsers: new Set(),
+        segmentImpact: new Map(),
+        actionCounts: new Map(),
+        events: [],
+        feedbackHelpful: 0,
+        feedbackTotal: 0,
+      };
+      this.metrics.set(type, m);
+    }
+    m.feedbackTotal++;
+    if (wasHelpful) m.feedbackHelpful++;
   }
 
   getHighestImpactErrors(): string[] {

--- a/src/lib/telemetry/__tests__/error-metrics.test.ts
+++ b/src/lib/telemetry/__tests__/error-metrics.test.ts
@@ -59,4 +59,14 @@ describe('ErrorMetrics', () => {
     const freq = metrics.getFrequency({ serviceName: 'svc2' }, 1000, 2000);
     expect(freq.reduce((a,b) => a+b, 0)).toBe(2);
   });
+
+  it('calculates impact score', () => {
+    metrics.incrementErrorCount(base);
+    metrics.incrementErrorCount(base);
+    metrics.resolveError(base);
+    vi.advanceTimersByTime(1000);
+    metrics.resolveError(base);
+    const score = metrics.getImpactScore(base, { durationWeight: 0.01 });
+    expect(score).toBeGreaterThan(0);
+  });
 });

--- a/src/lib/telemetry/__tests__/prioritization.test.ts
+++ b/src/lib/telemetry/__tests__/prioritization.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { ErrorMetrics, ErrorMetricDimensions } from '../error-metrics';
+import { ErrorPrioritizer } from '../prioritization';
+
+const base: ErrorMetricDimensions = {
+  errorCode: 'E1',
+  serviceName: 'svc',
+  environment: 'prod',
+  severity: 'high',
+};
+
+describe('ErrorPrioritizer', () => {
+  it('sorts errors by impact score', () => {
+    const metrics = new ErrorMetrics();
+    metrics.incrementErrorCount(base);
+    metrics.incrementErrorCount(base);
+    metrics.incrementErrorCount({ ...base, errorCode: 'E2', severity: 'low' });
+
+    const prioritizer = new ErrorPrioritizer(metrics);
+    const sorted = prioritizer.getPriorities([
+      base,
+      { ...base, errorCode: 'E2', severity: 'low' },
+    ]);
+    expect(sorted[0].dim.errorCode).toBe('E1');
+    expect(sorted[0].score).toBeGreaterThan(sorted[1].score);
+  });
+});
+

--- a/src/lib/telemetry/prioritization.ts
+++ b/src/lib/telemetry/prioritization.ts
@@ -1,0 +1,17 @@
+export interface PrioritizedError {
+  dim: import('./error-metrics').ErrorMetricDimensions;
+  score: number;
+}
+
+import { ErrorMetrics, ErrorMetricDimensions } from './error-metrics';
+
+export class ErrorPrioritizer {
+  constructor(private metrics: ErrorMetrics) {}
+
+  getPriorities(dims: ErrorMetricDimensions[]): PrioritizedError[] {
+    return dims
+      .map(dim => ({ dim, score: this.metrics.getImpactScore(dim) }))
+      .sort((a, b) => b.score - a.score);
+  }
+}
+


### PR DESCRIPTION
## Summary
- collect user error feedback in telemetry
- add impact scoring helpers
- prioritize errors by impact
- document the error review process
- test feedback collection, impact scoring and prioritization

## Testing
- `npm run test:coverage`
- `npm run lint` *(fails: Warning or error output)*

------
https://chatgpt.com/codex/tasks/task_b_683ec4c97d648331a5e1c636adbdf0d7