### PR TITLE
Add permission audit dashboard

### DIFF
--- a/app/admin/permissions/PermissionAuditDashboard.tsx
+++ b/app/admin/permissions/PermissionAuditDashboard.tsx
@@ -1,0 +1,6 @@
+'use client';
+import { PermissionAuditDashboard as Dashboard } from '@/ui/styled/audit/PermissionAuditDashboard';
+
+export default function PermissionAuditDashboard() {
+  return <Dashboard />;
+}

--- a/app/admin/permissions/page.tsx
+++ b/app/admin/permissions/page.tsx
@@ -4,6 +4,7 @@ import RoleManagementPanel from './RoleManagementPanel';
 import UserRoleAssignmentPanel from './UserRoleAssignmentPanel';
 import ResourcePermissionPanel from './ResourcePermissionPanel';
 import AuditLogViewer from './AuditLogViewer';
+import PermissionAuditDashboard from './PermissionAuditDashboard';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/primitives/tabs';
 
 export const metadata: Metadata = {
@@ -32,7 +33,10 @@ export default function PermissionDashboardPage() {
           <ResourcePermissionPanel />
         </TabsContent>
         <TabsContent value="audit">
-          <AuditLogViewer />
+          <div className="space-y-6">
+            <AuditLogViewer />
+            <PermissionAuditDashboard />
+          </div>
         </TabsContent>
       </Tabs>
     </div>

--- a/src/hooks/audit/usePermissionAuditLogs.ts
+++ b/src/hooks/audit/usePermissionAuditLogs.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useAuditLogViewer } from '@/ui/headless/audit/AuditLogViewer';
+
+export interface UsePermissionAuditLogsOptions {
+  userId?: string;
+  resourceType?: string;
+  resourceId?: string;
+}
+
+export function usePermissionAuditLogs(options: UsePermissionAuditLogsOptions = {}) {
+  const viewer = useAuditLogViewer({ isAdmin: true });
+  const { userId, resourceType, resourceId } = options;
+
+  useEffect(() => {
+    if (userId) viewer.handleFilterChange('userId', userId);
+    if (resourceType) viewer.handleFilterChange('resourceType', resourceType);
+    if (resourceId) viewer.handleFilterChange('resourceId', resourceId);
+    viewer.handleFilterChange('search', 'PERMISSION');
+  }, [userId, resourceType, resourceId]);
+
+  return viewer;
+}

--- a/src/ui/headless/audit/PermissionAuditDashboard.tsx
+++ b/src/ui/headless/audit/PermissionAuditDashboard.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import type { AuditLogEntry } from '@/core/audit/models';
+import { usePermissionAuditLogs, UsePermissionAuditLogsOptions } from '@/hooks/audit/usePermissionAuditLogs';
+
+export interface PermissionAuditDashboardProps extends UsePermissionAuditLogsOptions {
+  children: (props: { logs: AuditLogEntry[]; isLoading: boolean; }) => React.ReactNode;
+}
+
+export function PermissionAuditDashboard({ children, ...options }: PermissionAuditDashboardProps) {
+  const { data, isLoading } = usePermissionAuditLogs(options);
+  return <>{children({ logs: data?.logs ?? [], isLoading })}</>;
+}

--- a/src/ui/styled/audit/PermissionAuditDashboard.tsx
+++ b/src/ui/styled/audit/PermissionAuditDashboard.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { PermissionAuditDashboard as Headless } from '@/ui/headless/audit/PermissionAuditDashboard';
+import { PermissionLogTimeline } from './PermissionLogTimeline';
+import { PermissionHistoryView } from './PermissionHistoryView';
+import { PermissionDiffViewer } from './PermissionDiffViewer';
+import { PermissionSummary } from './PermissionSummary';
+import type { PermissionAuditDashboardProps } from '@/ui/headless/audit/PermissionAuditDashboard';
+
+export function PermissionAuditDashboard(props: Omit<PermissionAuditDashboardProps, 'children'>) {
+  return (
+    <Headless {...props}>
+      {({ logs }) => (
+        <div className="space-y-4">
+          <PermissionSummary logs={logs} />
+          <PermissionLogTimeline logs={logs} />
+          <PermissionHistoryView logs={logs} />
+          {logs.length >= 2 && (
+            <PermissionDiffViewer
+              before={logs[0].details?.before ?? logs[0].details?.after}
+              after={logs[logs.length - 1].details?.after ?? logs[logs.length - 1].details?.before}
+            />
+          )}
+        </div>
+      )}
+    </Headless>
+  );
+}

--- a/src/ui/styled/audit/__tests__/PermissionAuditDashboard.test.tsx
+++ b/src/ui/styled/audit/__tests__/PermissionAuditDashboard.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { TestWrapper } from '../../../../tests/utils/test-wrapper';
+import PermissionAuditDashboard from '../../PermissionAuditDashboard';
+
+const mockLogs = [
+  {
+    id: '1',
+    timestamp: '2024-06-01T10:00:00Z',
+    method: 'POST',
+    path: '/api',
+    user_id: 'u1',
+    status_code: 200,
+    response_time: 50,
+    action: 'ROLE_ASSIGNED',
+    status: 'SUCCESS',
+    details: { after: { roleId: 'r1' } }
+  },
+  {
+    id: '2',
+    timestamp: '2024-06-01T11:00:00Z',
+    method: 'POST',
+    path: '/api',
+    user_id: 'u1',
+    status_code: 200,
+    response_time: 40,
+    action: 'PERMISSION_ADDED',
+    status: 'SUCCESS',
+    details: { after: { permission: 'EDIT_USER_PROFILES' } }
+  }
+];
+
+const server = setupServer(
+  http.get('/api/audit/user-actions', () =>
+    HttpResponse.json({ logs: mockLogs, pagination: { page:1, limit:20, total:2, totalPages:1 } })
+  )
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function renderComponent() {
+  return render(
+    <TestWrapper authenticated>
+      <PermissionAuditDashboard />
+    </TestWrapper>
+  );
+}
+
+describe('PermissionAuditDashboard', () => {
+  it('renders summary and timeline', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText(/Total changes:/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText('ROLE_ASSIGNED')).toBeInTheDocument();
+    expect(screen.getByText('PERMISSION_ADDED')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add `usePermissionAuditLogs` hook
- add headless/styled `PermissionAuditDashboard` components
- add client wrapper and integrate into admin permissions page
- test permission audit dashboard

## Testing
- `npx vitest run --coverage`

------
https://chatgpt.com/codex/tasks/task_b_683ec62db0908331a471f652752afafe