### PR TITLE
Add permission audit export endpoint

### DIFF
--- a/app/api/audit/permission/__tests__/export.test.ts
+++ b/app/api/audit/permission/__tests__/export.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GET } from '../export/route';
+import { withRouteAuth } from '@/middleware/auth';
+import { setTableMockData, resetSupabaseMock } from '@/tests/mocks/supabase';
+import { NextResponse } from 'next/server';
+import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
+
+vi.mock('@/middleware/auth', () => ({
+  withRouteAuth: vi.fn((handler: any) => async (req: any) => handler(req, { userId: 'u1' }))
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetSupabaseMock();
+});
+
+describe('GET /api/audit/permission/export', () => {
+  it('returns 401 when unauthenticated', async () => {
+    vi.mocked(withRouteAuth).mockResolvedValueOnce(new NextResponse('unauth', { status: 401 }));
+    const res = await GET(createAuthenticatedRequest('GET', 'http://localhost/api/audit/permission/export', undefined, null));
+    expect(res.status).toBe(401);
+  });
+
+  it('validates query parameters', async () => {
+    const res = await GET(createAuthenticatedRequest('GET', 'http://localhost/api/audit/permission/export?format=bad'));
+    expect(res.status).toBe(400);
+  });
+
+  it('exports logs', async () => {
+    setTableMockData('user_actions_log', {
+      data: [
+        { id: '1', created_at: '2023-01-01', user_id: 'u1', action: 'PERMISSION_ADDED', target_resource_type: 'permission' }
+      ],
+      error: null
+    });
+    const res = await GET(createAuthenticatedRequest('GET', 'http://localhost/api/audit/permission/export?format=json'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Disposition')).toBe('attachment; filename="audit-logs.json"');
+  });
+});

--- a/app/api/audit/permission/export/route.ts
+++ b/app/api/audit/permission/export/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { createAuditProvider } from '@/adapters/audit/factory';
+import { middleware } from '@/middleware';
+
+const querySchema = z.object({
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  userId: z.string().uuid().optional(),
+  action: z.string().optional(),
+  status: z.enum(['SUCCESS','FAILURE','INITIATED','COMPLETED']).optional(),
+  ipAddress: z.string().optional(),
+  userAgent: z.string().optional(),
+  search: z.string().optional(),
+  sortBy: z.string().optional(),
+  sortOrder: z.enum(['asc','desc']).optional(),
+  format: z.enum(['csv','json','xlsx','pdf']).default('json')
+});
+
+export const GET = middleware(['cors','csrf','rateLimit'], async (req: NextRequest) => {
+  try {
+    const user = (req as any).user;
+    if(!user){
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const searchParams = Object.fromEntries(new URL(req.url).searchParams);
+    const params = querySchema.parse(searchParams);
+    const provider = createAuditProvider({
+      type: 'supabase',
+      options: {
+        supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',
+        supabaseKey: process.env.SUPABASE_SERVICE_ROLE_KEY || ''
+      }
+    });
+    const blob = await provider.exportLogs({
+      ...params,
+      page: 1,
+      limit: 1000,
+      resourceType: 'permission'
+    });
+    return new NextResponse(blob, {
+      status: 200,
+      headers: {
+        'Content-Type': blob.type,
+        'Content-Disposition': `attachment; filename="audit-logs.${params.format}"`
+      }
+    });
+  } catch (error) {
+    console.error('Permission audit export error:', error);
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: 'Invalid query' }, { status: 400 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+});

--- a/src/lib/utils/routes.ts
+++ b/src/lib/utils/routes.ts
@@ -171,6 +171,7 @@ export const API_ROUTES = {
   // Audit domain
   AUDIT: {
     USER_ACTIONS: '/api/audit/user-actions',
+    PERMISSION_EXPORT: '/api/audit/permission/export',
   },
 
   // Admin domain


### PR DESCRIPTION
## Summary
- implement `/api/audit/permission/export` API route
- add tests for the new endpoint
- expose export path in route utilities

## Testing
- `npm run lint`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_b_683ec5e60cfc8331b0f519c0da02a744