### PR TITLE
Add permission audit API endpoint

### DIFF
--- a/src/pages/api/audit/__tests__/audit.test.ts
+++ b/src/pages/api/audit/__tests__/audit.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import handler from '../[...audit]';
+import { getApiAuditService } from '@/services/audit/factory';
+import { testGet } from '@/tests/utils/api-testing-utils';
+
+vi.mock('@/services/audit/factory', () => ({ getApiAuditService: vi.fn() }));
+
+describe('GET /api/audit/permission (pages)', () => {
+  const mockService = { getLogs: vi.fn() };
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getApiAuditService as unknown as vi.Mock).mockReturnValue(mockService);
+    mockService.getLogs.mockResolvedValue({ logs: [], count: 0 });
+  });
+
+  it('filters permission related actions', async () => {
+    const logs = [
+      { id: '1', createdAt: '2023-01-01', action: 'ROLE_ASSIGNED', status: 'SUCCESS' },
+      { id: '2', createdAt: '2023-01-02', action: 'LOGIN_SUCCESS', status: 'SUCCESS' }
+    ];
+    mockService.getLogs.mockResolvedValue({ logs, count: logs.length });
+    const { status, data } = await testGet(handler, { query: { audit: ['permission'] } });
+    expect(status).toBe(200);
+    expect(data.data.logs).toHaveLength(1);
+    expect(data.data.logs[0].action).toBe('ROLE_ASSIGNED');
+  });
+
+  it('returns 500 on invalid query', async () => {
+    const { status } = await testGet(handler, { query: { audit: ['permission'], limit: 'bad' } });
+    expect(status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- extend audit API to provide /api/audit/permission endpoint
- filter permission events to ROLE_* and PERMISSION_*
- add unit tests covering new endpoint

## Testing
- `npx vitest run --coverage src/pages/api/audit/__tests__/audit.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_683ec5b89d8883319aa8749f8a152248