### PR TITLE
Add transaction manager with rollback and logging

### DIFF
--- a/src/lib/database/__tests__/transaction-manager.test.ts
+++ b/src/lib/database/__tests__/transaction-manager.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { executeTransaction, classifyFailure } from '../transaction-manager';
+import { ApplicationError } from '@/core/common/errors';
+
+function createTx() {
+  return {
+    begin: vi.fn().mockResolvedValue(undefined),
+    commit: vi.fn().mockResolvedValue(undefined),
+    rollback: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('executeTransaction', () => {
+  it('commits when all steps succeed', async () => {
+    const tx = createTx();
+    const logger = { debug: vi.fn(), error: vi.fn() };
+    const step1 = vi.fn().mockResolvedValue(1);
+    const step2 = vi.fn().mockResolvedValue(2);
+    const result = await executeTransaction(tx, [step1, step2], logger);
+    expect(result).toEqual([1, 2]);
+    expect(tx.begin).toHaveBeenCalled();
+    expect(tx.commit).toHaveBeenCalled();
+    expect(tx.rollback).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith('transaction.begin');
+    expect(logger.debug).toHaveBeenCalledWith('transaction.commit');
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('rolls back on error and rethrows', async () => {
+    const tx = createTx();
+    const logger = { debug: vi.fn(), error: vi.fn() };
+    const err = new ApplicationError('USER_GENERAL_003', 'fail', 400);
+    const step1 = vi.fn().mockResolvedValue('ok');
+    const step2 = vi.fn().mockRejectedValue(err);
+
+    await expect(executeTransaction(tx, [step1, step2], logger)).rejects.toThrow(err);
+    expect(tx.begin).toHaveBeenCalled();
+    expect(tx.rollback).toHaveBeenCalled();
+    expect(tx.commit).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith('transaction.rollback', { failureType: 'permanent' });
+  });
+});
+
+describe('classifyFailure', () => {
+  it('returns transient for server errors', () => {
+    const err = new ApplicationError('SERVER_GENERAL_003', 'db', 500);
+    expect(classifyFailure(err)).toBe('transient');
+  });
+
+  it('returns permanent for client errors', () => {
+    const err = new ApplicationError('USER_GENERAL_003', 'bad', 400);
+    expect(classifyFailure(err)).toBe('permanent');
+  });
+
+  it('handles non-ApplicationError', () => {
+    expect(classifyFailure(new Error('oops'))).toBe('transient');
+  });
+});

--- a/src/lib/database/transaction-manager.ts
+++ b/src/lib/database/transaction-manager.ts
@@ -1,0 +1,34 @@
+import { TransactionInterface } from '@/core/database/interfaces';
+import { ApplicationError } from '@/core/common/errors';
+import { errorLogger } from '@/lib/monitoring/error-logger';
+
+export type FailureCategory = 'transient' | 'permanent';
+
+export function classifyFailure(error: unknown): FailureCategory {
+  if (error instanceof ApplicationError) {
+    return error.httpStatus >= 500 ? 'transient' : 'permanent';
+  }
+  return 'transient';
+}
+
+export async function executeTransaction<R>(
+  tx: TransactionInterface,
+  steps: Array<(t: TransactionInterface) => Promise<R>>,
+  logger: Pick<typeof errorLogger, 'debug' | 'error'> = errorLogger,
+): Promise<R[]> {
+  await tx.begin();
+  logger.debug('transaction.begin');
+  try {
+    const results: R[] = [];
+    for (const step of steps) {
+      results.push(await step(tx));
+    }
+    await tx.commit();
+    logger.debug('transaction.commit');
+    return results;
+  } catch (err) {
+    await tx.rollback();
+    logger.error('transaction.rollback', { failureType: classifyFailure(err) });
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `executeTransaction` helper and transient/permanent classification
- log transaction lifecycle and auto-rollback on failure
- add unit tests for transaction manager

## Testing
- `npm run test:coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683ecce8c0948331a7ca5b768c039963