### PR TITLE
Update roles api permission check

### DIFF
--- a/app/api/roles/route.ts
+++ b/app/api/roles/route.ts
@@ -48,7 +48,7 @@ export const POST = createProtectedHandler(
     withSecurity(async (r) => {
       const body = await r.json();
       return withErrorHandling(
-        (r3) => withValidation(createSchema, (r2, data) => handlePost(r2, ctx?.userId, data), r3, body),
+        (r3) => withValidation(createSchema, (r2, data) => handlePost(r2, ctx.userId, data), r3, body),
         r
       );
     })(req),


### PR DESCRIPTION
## Summary
- ensure POST roles API uses non-optional user id for permission checks

## Testing
- `npx vitest run --coverage` *(fails: EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_683ecf58cc648331ba5a9a0dc7308197