### PR TITLE
Implement SSO error handling

### DIFF
--- a/docs/SSO_Troubleshooting.md
+++ b/docs/SSO_Troubleshooting.md
@@ -1,0 +1,21 @@
+# SSO Troubleshooting Guide
+
+This guide provides common steps to diagnose Single Sign-On (SSO) issues when integrating the User Management Module.
+
+## Common Configuration Problems
+
+- **Invalid metadata URL** – ensure the identity provider metadata URL is reachable and contains valid XML.
+- **Missing client credentials** – for OIDC providers, verify `clientId` and `clientSecret` are configured correctly.
+- **SAML certificate errors** – confirm the certificate is in PEM format and matches the IdP configuration.
+
+## Federation Failures
+
+Federation errors often occur when the IdP rejects the authentication request or returns malformed assertions. Check the provider logs and verify that the service provider entity ID and ACS URLs match the values configured in the IdP.
+
+## Diagnostic Logs
+
+The `DefaultSsoService` logs structured errors for every failed operation. Inspect the server logs for entries containing the `SSO_` error codes. These messages include the stage of the authentication process where the failure occurred.
+
+## Further Assistance
+
+If issues persist, enable verbose logging in your identity provider and compare timestamps with the application logs. Most configuration problems can be resolved by ensuring that the metadata and credentials used by both sides match exactly.

--- a/src/core/common/error-codes.ts
+++ b/src/core/common/error-codes.ts
@@ -58,12 +58,24 @@ export enum SERVER_ERROR {
   SERVER_005 = 'SERVER_005',
 }
 
+export enum SSO_ERROR {
+  /** Generic SSO failure */
+  SSO_001 = 'SSO_001',
+  /** Provider configuration error */
+  SSO_002 = 'SSO_002',
+  /** Federation or metadata issue */
+  SSO_003 = 'SSO_003',
+  /** Authentication stage failure */
+  SSO_004 = 'SSO_004',
+}
+
 export type ErrorCode =
   | AUTH_ERROR
   | USER_ERROR
   | TEAM_ERROR
   | SERVER_ERROR
-  | RELATIONSHIP_ERROR;
+  | RELATIONSHIP_ERROR
+  | SSO_ERROR;
 
 // Unified ERROR_CODES object for backward compatibility
 export const ERROR_CODES = {
@@ -97,6 +109,12 @@ export const ERROR_CODES = {
   EXTERNAL_SERVICE_ERROR: SERVER_ERROR.SERVER_003,
   CONFLICT_ERROR: SERVER_ERROR.SERVER_004,
   RATE_LIMIT_ERROR: SERVER_ERROR.SERVER_005,
+
+  // SSO codes
+  SSO_GENERIC_ERROR: SSO_ERROR.SSO_001,
+  SSO_CONFIGURATION_ERROR: SSO_ERROR.SSO_002,
+  SSO_FEDERATION_ERROR: SSO_ERROR.SSO_003,
+  SSO_AUTHENTICATION_ERROR: SSO_ERROR.SSO_004,
 } as const;
 
 // Optional descriptions for mapping codes to human readable text
@@ -122,5 +140,9 @@ export const ERROR_CODE_DESCRIPTIONS: Record<ErrorCode, string> = {
   [SERVER_ERROR.SERVER_003]: 'External service error',
   [SERVER_ERROR.SERVER_004]: 'Conflict',
   [SERVER_ERROR.SERVER_005]: 'Rate limit exceeded',
+  [SSO_ERROR.SSO_001]: 'SSO failure',
+  [SSO_ERROR.SSO_002]: 'SSO configuration error',
+  [SSO_ERROR.SSO_003]: 'SSO federation error',
+  [SSO_ERROR.SSO_004]: 'SSO authentication error',
 };
 

--- a/src/core/common/errors.ts
+++ b/src/core/common/errors.ts
@@ -282,7 +282,6 @@ export function isPartialRelationshipError(
 ): value is PartialRelationshipError {
   return value instanceof PartialRelationshipError;
 }
-}
 
 // Utility functions
 

--- a/src/lib/utils/error.ts
+++ b/src/lib/utils/error.ts
@@ -12,7 +12,11 @@ const ERROR_TRANSLATIONS: Record<string, string> = {
   RATE_LIMIT_EXCEEDED: 'Too many requests. Please try again later.',
   MFA_REQUIRED: 'Multi-factor authentication required.',
   TEAM_NOT_FOUND: 'Team not found.',
-  USER_NOT_FOUND: 'User not found.'
+  USER_NOT_FOUND: 'User not found.',
+  SSO_GENERIC_ERROR: 'Single sign-on failed.',
+  SSO_CONFIGURATION_ERROR: 'SSO configuration error.',
+  SSO_FEDERATION_ERROR: 'Federation with identity provider failed.',
+  SSO_AUTHENTICATION_ERROR: 'Authentication with identity provider failed.'
 };
 
 /**

--- a/src/services/sso/__tests__/default-sso.service.test.ts
+++ b/src/services/sso/__tests__/default-sso.service.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DefaultSsoService } from '../default-sso.service';
+import type { SsoDataProvider } from '@/core/sso/ISsoDataProvider';
+
+vi.mock('@/services/common/service-error-handler', () => ({
+  logServiceError: vi.fn(),
+}));
+vi.mock('@/lib/utils/error', () => ({
+  translateError: (e: any) => e.message,
+}));
+
+describe('DefaultSsoService error handling', () => {
+  let provider: SsoDataProvider;
+  let service: DefaultSsoService;
+
+  beforeEach(() => {
+    provider = {
+      listProviders: vi.fn(async () => { throw new Error('fail'); }),
+      upsertProvider: vi.fn(async () => ({ success: false, error: 'bad' })),
+      getProvider: vi.fn(async () => { throw new Error('oops'); }),
+      deleteProvider: vi.fn(async () => { throw new Error('del'); })
+    } as unknown as SsoDataProvider;
+    service = new DefaultSsoService(provider);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('returns empty list on getProviders error', async () => {
+    const res = await service.getProviders('1');
+    expect(res).toEqual([]);
+  });
+
+  it('translates upsert errors', async () => {
+    const res = await service.upsertProvider({
+      organizationId: '1',
+      providerType: 'saml',
+      providerName: 'okta',
+      config: {}
+    });
+    expect(res.success).toBe(false);
+    expect(res.error).toBeDefined();
+  });
+});

--- a/src/services/sso/__tests__/error-mapper.test.ts
+++ b/src/services/sso/__tests__/error-mapper.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { translateSsoError } from '../error-mapper';
+import { SSO_ERROR } from '@/core/common/error-codes';
+
+describe('translateSsoError', () => {
+  it('wraps plain error with stage code', () => {
+    const err = new Error('boom');
+    const res = translateSsoError('authentication', err);
+    expect(res.code).toBe(SSO_ERROR.SSO_004);
+    expect(res.message).toBe('boom');
+  });
+
+  it('passes through ApplicationError', () => {
+    const err = translateSsoError('configuration', new Error('oops'));
+    const same = translateSsoError('configuration', err);
+    expect(same).toBe(err);
+  });
+});

--- a/src/services/sso/default-sso.service.ts
+++ b/src/services/sso/default-sso.service.ts
@@ -5,23 +5,81 @@
 import { SsoService } from '@/core/sso/interfaces';
 import { SsoDataProvider } from '@/core/sso/ISsoDataProvider';
 import { SsoProvider, SsoProviderPayload } from '@/core/sso/models';
+import { translateError } from '@/lib/utils/error';
+import { logServiceError } from '@/services/common/service-error-handler';
+import { translateSsoError } from './error-mapper';
 
 export class DefaultSsoService implements SsoService {
   constructor(private readonly provider: SsoDataProvider) {}
 
   async getProviders(organizationId: string): Promise<SsoProvider[]> {
-    return this.provider.listProviders(organizationId);
+    try {
+      return await this.provider.listProviders(organizationId);
+    } catch (err) {
+      const appErr = translateSsoError('discovery', err);
+      logServiceError(appErr, {
+        service: 'DefaultSsoService',
+        method: 'getProviders',
+        resourceType: 'organization',
+        resourceId: organizationId,
+      });
+      return [];
+    }
   }
 
   async upsertProvider(payload: SsoProviderPayload): Promise<{ success: boolean; provider?: SsoProvider; error?: string }> {
-    return this.provider.upsertProvider(payload);
+    try {
+      const result = await this.provider.upsertProvider(payload);
+      if (!result.success) {
+        const appErr = translateSsoError('configuration', new Error(result.error || 'SSO provider error'));
+        logServiceError(appErr, {
+          service: 'DefaultSsoService',
+          method: 'upsertProvider',
+          resourceType: 'organization',
+          resourceId: payload.organizationId,
+        });
+        return { success: false, error: translateError(appErr) };
+      }
+      return result;
+    } catch (err) {
+      const appErr = translateSsoError('configuration', err);
+      logServiceError(appErr, {
+        service: 'DefaultSsoService',
+        method: 'upsertProvider',
+        resourceType: 'organization',
+        resourceId: payload.organizationId,
+      });
+      return { success: false, error: translateError(appErr) };
+    }
   }
 
   async getProvider(organizationId: string, providerId: string): Promise<SsoProvider | null> {
-    return this.provider.getProvider(organizationId, providerId);
+    try {
+      return await this.provider.getProvider(organizationId, providerId);
+    } catch (err) {
+      const appErr = translateSsoError('discovery', err);
+      logServiceError(appErr, {
+        service: 'DefaultSsoService',
+        method: 'getProvider',
+        resourceType: 'organization',
+        resourceId: organizationId,
+      });
+      return null;
+    }
   }
 
   async deleteProvider(providerId: string): Promise<{ success: boolean; error?: string }> {
-    return this.provider.deleteProvider(providerId);
+    try {
+      return await this.provider.deleteProvider(providerId);
+    } catch (err) {
+      const appErr = translateSsoError('configuration', err);
+      logServiceError(appErr, {
+        service: 'DefaultSsoService',
+        method: 'deleteProvider',
+        resourceType: 'ssoProvider',
+        resourceId: providerId,
+      });
+      return { success: false, error: translateError(appErr) };
+    }
   }
 }

--- a/src/services/sso/error-mapper.ts
+++ b/src/services/sso/error-mapper.ts
@@ -1,0 +1,26 @@
+import { createError, ApplicationError, isApplicationError } from '@/core/common/errors';
+import { SSO_ERROR } from '@/core/common/error-codes';
+
+export type SsoAuthStage = 'configuration' | 'discovery' | 'authentication' | 'federation' | 'token';
+
+/**
+ * Translate provider specific errors into ApplicationError instances.
+ */
+export function translateSsoError(stage: SsoAuthStage, err: unknown): ApplicationError {
+  if (isApplicationError(err)) {
+    return err;
+  }
+
+  const message = err instanceof Error ? err.message : 'SSO error';
+
+  const code =
+    stage === 'configuration'
+      ? SSO_ERROR.SSO_002
+      : stage === 'federation'
+      ? SSO_ERROR.SSO_003
+      : stage === 'authentication'
+      ? SSO_ERROR.SSO_004
+      : SSO_ERROR.SSO_001;
+
+  return createError(code, message, { stage }, err);
+}


### PR DESCRIPTION
## Summary
- define `SSO_ERROR` codes and translations
- map provider errors with `translateSsoError`
- log and translate SSO errors in default service
- document troubleshooting steps for SSO
- add unit tests for new error handling

## Testing
- `npx vitest run src/services/sso/__tests__/error-mapper.test.ts src/services/sso/__tests__/default-sso.service.test.ts --coverage --silent`

------
https://chatgpt.com/codex/tasks/task_b_683ed07dae808331bc9878951d9b0997