### PR TITLE
Add simple usePermission hook

### DIFF
--- a/src/hooks/__tests__/usePermissionFetch.test.tsx
+++ b/src/hooks/__tests__/usePermissionFetch.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { usePermission } from '../usePermission';
+import { useAuth } from '@/hooks/auth/useAuth';
+
+vi.mock('@/hooks/auth/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('usePermission (fetch)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns false when no user', async () => {
+    vi.mocked(useAuth).mockReturnValue({ user: null } as any);
+    const { result } = renderHook(() => usePermission('perm.read'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.hasPermission).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('checks permissions and sets value', async () => {
+    vi.mocked(useAuth).mockReturnValue({ user: { id: '1' } } as any);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({ data: { results: [{ hasPermission: true }] } }),
+    } as Response);
+
+    const { result } = renderHook(() => usePermission('perm.read'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockFetch).toHaveBeenCalled();
+    expect(result.current.hasPermission).toBe(true);
+  });
+
+  it('handles fetch failure', async () => {
+    vi.mocked(useAuth).mockReturnValue({ user: { id: '1' } } as any);
+    mockFetch.mockRejectedValueOnce(new Error('fail'));
+
+    const { result } = renderHook(() => usePermission('perm.read'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.hasPermission).toBe(false);
+  });
+});

--- a/src/hooks/usePermission.ts
+++ b/src/hooks/usePermission.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/hooks/auth/useAuth';
+import type { PermissionValues } from '@/core/permission/models';
+
+export function usePermission(permission: PermissionValues | PermissionValues[]) {
+  const { user } = useAuth();
+  const [hasPermission, setHasPermission] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user) {
+      setHasPermission(false);
+      setLoading(false);
+      return;
+    }
+
+    const permissionsToCheck = Array.isArray(permission)
+      ? permission
+      : [permission];
+
+    async function checkPermissions() {
+      setLoading(true);
+      try {
+        const response = await fetch('/api/auth/check-permissions', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            checks: permissionsToCheck.map((p) => ({ permission: p })),
+          }),
+        });
+
+        if (!response.ok) throw new Error('Permission check failed');
+
+        const data = await response.json();
+        const hasAnyPermission = data.data.results.some(
+          (r: any) => r.hasPermission,
+        );
+        setHasPermission(hasAnyPermission);
+      } catch (error) {
+        console.error('Permission check error:', error);
+        setHasPermission(false);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    checkPermissions();
+  }, [user, permission]);
+
+  return { hasPermission, loading };
+}


### PR DESCRIPTION
## Summary
- implement a lightweight `usePermission` hook that queries `/api/auth/check-permissions`
- add tests for new hook

## Testing
- `npx vitest run --coverage src/hooks/__tests__/usePermissionFetch.test.tsx`

------
https://chatgpt.com/codex/tasks/task_b_683ede37a2b88331ace04bfceea6d1b1