### PR TITLE
Implement resumable export error handling

### DIFF
--- a/src/core/common/__tests__/errors.test.ts
+++ b/src/core/common/__tests__/errors.test.ts
@@ -116,3 +116,13 @@ describe("utility functions", () => {
     expect(other.message).toBe("Unknown error");
   });
 });
+
+describe('DataExportError', () => {
+  it('creates and identifies export errors', () => {
+    const err = new DataExportError(EXPORT_ERROR.EXPORT_001, 'fail', { step: 2 });
+    expect(err).toBeInstanceOf(ApplicationError);
+    expect(isDataExportError(err)).toBe(true);
+    expect(err.code).toBe(EXPORT_ERROR.EXPORT_001);
+    expect(err.details).toEqual({ step: 2 });
+  });
+});

--- a/src/core/common/error-codes.ts
+++ b/src/core/common/error-codes.ts
@@ -69,13 +69,23 @@ export enum SSO_ERROR {
   SSO_004 = 'SSO_004',
 }
 
+export enum EXPORT_ERROR {
+  /** Export generation failed */
+  EXPORT_001 = 'EXPORT_001',
+  /** Export integrity validation failed */
+  EXPORT_002 = 'EXPORT_002',
+  /** Export record not found */
+  EXPORT_003 = 'EXPORT_003',
+}
+
 export type ErrorCode =
   | AUTH_ERROR
   | USER_ERROR
   | TEAM_ERROR
   | SERVER_ERROR
   | RELATIONSHIP_ERROR
-  | SSO_ERROR;
+  | SSO_ERROR
+  | EXPORT_ERROR;
 
 // Unified ERROR_CODES object for backward compatibility
 export const ERROR_CODES = {
@@ -115,6 +125,9 @@ export const ERROR_CODES = {
   SSO_CONFIGURATION_ERROR: SSO_ERROR.SSO_002,
   SSO_FEDERATION_ERROR: SSO_ERROR.SSO_003,
   SSO_AUTHENTICATION_ERROR: SSO_ERROR.SSO_004,
+  EXPORT_FAILED: EXPORT_ERROR.EXPORT_001,
+  EXPORT_INTEGRITY_ERROR: EXPORT_ERROR.EXPORT_002,
+  EXPORT_NOT_FOUND: EXPORT_ERROR.EXPORT_003,
 } as const;
 
 // Optional descriptions for mapping codes to human readable text
@@ -144,5 +157,8 @@ export const ERROR_CODE_DESCRIPTIONS: Record<ErrorCode, string> = {
   [SSO_ERROR.SSO_002]: 'SSO configuration error',
   [SSO_ERROR.SSO_003]: 'SSO federation error',
   [SSO_ERROR.SSO_004]: 'SSO authentication error',
+  [EXPORT_ERROR.EXPORT_001]: 'Export generation failed',
+  [EXPORT_ERROR.EXPORT_002]: 'Export integrity validation failed',
+  [EXPORT_ERROR.EXPORT_003]: 'Export not found',
 };
 

--- a/src/core/common/errors.ts
+++ b/src/core/common/errors.ts
@@ -172,6 +172,14 @@ export class ExternalServiceError extends ApplicationError {
   }
 }
 
+/** Error thrown when a data export fails. */
+export class DataExportError extends ApplicationError {
+  constructor(code: ErrorCode, message: string, details?: Record<string, any>) {
+    super(code, message, 500, details);
+    this.name = "DataExportError";
+  }
+}
+
 export class RelationshipHierarchyError extends ApplicationError {
   constructor(message: string, details?: Record<string, any>) {
     super(RELATIONSHIP_ERROR.REL_001, message, 400, details);
@@ -247,6 +255,10 @@ export function isExternalServiceError(
   value: unknown,
 ): value is ExternalServiceError {
   return value instanceof ExternalServiceError;
+}
+
+export function isDataExportError(value: unknown): value is DataExportError {
+  return value instanceof DataExportError;
 }
 
 export function isTokenRefreshError(value: unknown): value is TokenRefreshError {

--- a/src/lib/exports/__tests__/resumable-export.service.test.ts
+++ b/src/lib/exports/__tests__/resumable-export.service.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { supabase, resetSupabaseMock } from '@/tests/mocks/supabase';
+import * as exportService from '../export.service';
+import { processUserExportResumable } from '../resumable-export.service';
+import { ExportFormat, ExportStatus, DataExportStorageBucket } from '../types';
+import { DataExportError } from '@/core/common/errors';
+import { EXPORT_ERROR } from '@/core/common/error-codes';
+
+describe('processUserExportResumable', () => {
+  beforeEach(() => {
+    resetSupabaseMock();
+    vi.restoreAllMocks();
+  });
+
+  it('completes a user export', async () => {
+    vi.spyOn(exportService, 'getUserDataExportById').mockResolvedValue({
+      id: 'exp1',
+      userId: 'u1',
+      format: ExportFormat.JSON,
+      status: ExportStatus.PENDING,
+      isLargeDataset: false,
+    } as any);
+    vi.spyOn(exportService, 'getUserExportData').mockResolvedValue({ profile: {} });
+
+    await processUserExportResumable('exp1', 'u1');
+
+    const upload = (supabase.storage.from as any).mock.results[0].value.upload;
+    expect(upload).toHaveBeenCalled();
+    const remove = (supabase.storage.from as any).mock.results[0].value.remove;
+    expect(remove).not.toHaveBeenCalled();
+
+    const update = (supabase.from as any).mock.results[0].value.update;
+    const finalCall = update.mock.calls.pop()[0];
+    expect(finalCall.status).toBe(ExportStatus.COMPLETED);
+    expect(finalCall.progress).toBe(100);
+  });
+
+  it('cleans up when upload fails', async () => {
+    vi.spyOn(exportService, 'getUserDataExportById').mockResolvedValue({
+      id: 'exp2',
+      userId: 'u1',
+      format: ExportFormat.JSON,
+      status: ExportStatus.PENDING,
+      isLargeDataset: false,
+    } as any);
+    vi.spyOn(exportService, 'getUserExportData').mockResolvedValue({ profile: {} });
+
+    // Force upload failure
+    const storage = (supabase.storage.from as any).mock.results[0].value;
+    storage.upload.mockResolvedValueOnce({ data: null, error: new Error('fail') });
+
+    await expect(processUserExportResumable('exp2', 'u1')).rejects.toBeInstanceOf(DataExportError);
+
+    const remove = storage.remove;
+    expect(remove).toHaveBeenCalled();
+    const err = await processUserExportResumable('exp2', 'u1').catch(e => e);
+    expect(err.code).toBe(EXPORT_ERROR.EXPORT_001);
+  });
+});

--- a/src/lib/exports/resumable-export.service.ts
+++ b/src/lib/exports/resumable-export.service.ts
@@ -1,0 +1,256 @@
+import { createHash } from 'crypto';
+import Papa from 'papaparse';
+import { supabase } from '@/lib/supabase';
+import {
+  ExportFormat,
+  ExportStatus,
+  DataExportStorageBucket,
+  UserExportData,
+  CompanyExportData,
+} from './types';
+import {
+  getUserExportData,
+  getUserDataExportById,
+  getCompanyExportData,
+  getCompanyDataExportById,
+} from './export.service';
+import { DataExportError } from '@/core/common/errors';
+import { EXPORT_ERROR } from '@/core/common/error-codes';
+
+const LARGE_THRESHOLD = 5 * 1024 * 1024; // 5MB
+
+function flattenObject(obj: Record<string, any>, prefix = ''): Record<string, any> {
+  const out: Record<string, any> = {};
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const newKey = prefix ? `${prefix}.${key}` : key;
+      if (typeof obj[key] === 'object' && obj[key] !== null && !Array.isArray(obj[key])) {
+        Object.assign(out, flattenObject(obj[key], newKey));
+      } else if (Array.isArray(obj[key])) {
+        out[newKey] = JSON.stringify(obj[key]);
+      } else {
+        out[newKey] = obj[key];
+      }
+    }
+  }
+  return out;
+}
+
+function flattenUserData(data: UserExportData): Array<Record<string, any>> {
+  const result: Array<Record<string, any>> = [];
+  if (data.profile) {
+    result.push({ record_type: 'profile', ...flattenObject(data.profile) });
+  }
+  if (data.preferences) {
+    result.push({ record_type: 'preferences', ...flattenObject(data.preferences) });
+  }
+  if (data.activityLogs) {
+    data.activityLogs.forEach((log, i) => {
+      result.push({ record_type: 'activity_log', log_index: i, ...flattenObject(log) });
+    });
+  }
+  return result;
+}
+
+function flattenCompanyData(data: CompanyExportData): Array<Record<string, any>> {
+  const result: Array<Record<string, any>> = [];
+  if (data.companyProfile) {
+    result.push({ record_type: 'company_profile', ...flattenObject(data.companyProfile) });
+  }
+  if (data.companyMembers) {
+    data.companyMembers.forEach((m, i) => {
+      result.push({ record_type: 'company_member', member_index: i, ...flattenObject(m) });
+    });
+  }
+  if (data.companyRoles) {
+    data.companyRoles.forEach((r, i) => {
+      result.push({ record_type: 'company_role', role_index: i, ...flattenObject(r) });
+    });
+  }
+  if (data.activityLogs) {
+    data.activityLogs.forEach((log, i) => {
+      result.push({ record_type: 'activity_log', log_index: i, ...flattenObject(log) });
+    });
+  }
+  return result;
+}
+
+async function updateExport(table: string, id: string, fields: Record<string, any>) {
+  await supabase.from(table).update(fields).eq('id', id);
+}
+
+export async function processUserExportResumable(exportId: string, userId: string): Promise<void> {
+  let progress = 0;
+  let filePath: string | undefined;
+  try {
+    const record = await getUserDataExportById(exportId);
+    if (!record) {
+      throw new DataExportError(EXPORT_ERROR.EXPORT_003, 'Export not found');
+    }
+    await updateExport('user_data_exports', exportId, {
+      status: ExportStatus.PROCESSING,
+      progress,
+      error_message: null,
+    });
+
+    const data = await getUserExportData(userId);
+    progress = 25;
+    await updateExport('user_data_exports', exportId, { progress });
+
+    let fileContent = JSON.stringify(data);
+    let fileExtension = '.json';
+    let contentType = 'application/json';
+    if (record.format === ExportFormat.CSV) {
+      fileContent = Papa.unparse(flattenUserData(data));
+      fileExtension = '.csv';
+      contentType = 'text/csv';
+    }
+    progress = 50;
+    await updateExport('user_data_exports', exportId, { progress });
+
+    filePath = `${userId}/user_export_${new Date().toISOString().replace(/[:.]/g, '-')}${fileExtension}`;
+    const { error: uploadError } = await supabase.storage
+      .from(DataExportStorageBucket.USER_EXPORTS)
+      .upload(filePath, fileContent, { contentType, upsert: true });
+    if (uploadError) throw uploadError;
+
+    progress = 75;
+    await updateExport('user_data_exports', exportId, { progress });
+
+    const { data: dl, error: dlError } = await supabase.storage
+      .from(DataExportStorageBucket.USER_EXPORTS)
+      .download(filePath);
+    if (dlError) throw dlError;
+    const dlBuffer = await dl.arrayBuffer();
+    const checksum = createHash('sha256').update(fileContent).digest('hex');
+    const verify = createHash('sha256').update(Buffer.from(dlBuffer)).digest('hex');
+    if (checksum !== verify) {
+      throw new DataExportError(EXPORT_ERROR.EXPORT_002, 'Checksum mismatch');
+    }
+
+    progress = 90;
+    await updateExport('user_data_exports', exportId, { progress });
+
+    await updateExport('user_data_exports', exportId, {
+      status: ExportStatus.COMPLETED,
+      file_path: filePath,
+      completed_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      file_size_bytes: fileContent.length,
+      is_large_dataset: fileContent.length > LARGE_THRESHOLD,
+      checksum,
+      progress: 100,
+    });
+  } catch (err: any) {
+    await updateExport('user_data_exports', exportId, {
+      status: ExportStatus.FAILED,
+      error_message: err?.message || 'Unknown error',
+      updated_at: new Date().toISOString(),
+      progress,
+    });
+    if (filePath) {
+      await supabase.storage
+        .from(DataExportStorageBucket.USER_EXPORTS)
+        .remove([filePath]);
+    }
+    if (err instanceof DataExportError) throw err;
+    throw new DataExportError(EXPORT_ERROR.EXPORT_001, err?.message || 'Export failed');
+  }
+}
+
+export async function resumeUserExport(exportId: string, userId: string) {
+  const record = await getUserDataExportById(exportId);
+  if (!record) {
+    throw new DataExportError(EXPORT_ERROR.EXPORT_003, 'Export not found');
+  }
+  if (record.status === ExportStatus.COMPLETED) return;
+  await processUserExportResumable(exportId, userId);
+}
+
+export async function processCompanyExportResumable(exportId: string, companyId: string, userId: string): Promise<void> {
+  let progress = 0;
+  let filePath: string | undefined;
+  try {
+    const record = await getCompanyDataExportById(exportId);
+    if (!record) {
+      throw new DataExportError(EXPORT_ERROR.EXPORT_003, 'Export not found');
+    }
+    await updateExport('company_data_exports', exportId, {
+      status: ExportStatus.PROCESSING,
+      progress,
+      error_message: null,
+    });
+
+    const data = await getCompanyExportData(companyId);
+    progress = 25;
+    await updateExport('company_data_exports', exportId, { progress });
+
+    let fileContent = JSON.stringify(data);
+    let fileExtension = '.json';
+    let contentType = 'application/json';
+    if (record.format === ExportFormat.CSV) {
+      fileContent = Papa.unparse(flattenCompanyData(data));
+      fileExtension = '.csv';
+      contentType = 'text/csv';
+    }
+    progress = 50;
+    await updateExport('company_data_exports', exportId, { progress });
+
+    filePath = `${companyId}/company_export_${new Date().toISOString().replace(/[:.]/g, '-')}${fileExtension}`;
+    const { error: uploadError } = await supabase.storage
+      .from(DataExportStorageBucket.COMPANY_EXPORTS)
+      .upload(filePath, fileContent, { contentType, upsert: true });
+    if (uploadError) throw uploadError;
+
+    progress = 75;
+    await updateExport('company_data_exports', exportId, { progress });
+
+    const { data: dl, error: dlError } = await supabase.storage
+      .from(DataExportStorageBucket.COMPANY_EXPORTS)
+      .download(filePath);
+    if (dlError) throw dlError;
+    const dlBuffer = await dl.arrayBuffer();
+    const checksum = createHash('sha256').update(fileContent).digest('hex');
+    const verify = createHash('sha256').update(Buffer.from(dlBuffer)).digest('hex');
+    if (checksum !== verify) {
+      throw new DataExportError(EXPORT_ERROR.EXPORT_002, 'Checksum mismatch');
+    }
+
+    progress = 90;
+    await updateExport('company_data_exports', exportId, { progress });
+
+    await updateExport('company_data_exports', exportId, {
+      status: ExportStatus.COMPLETED,
+      file_path: filePath,
+      completed_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      file_size_bytes: fileContent.length,
+      is_large_dataset: fileContent.length > LARGE_THRESHOLD,
+      checksum,
+      progress: 100,
+    });
+  } catch (err: any) {
+    await updateExport('company_data_exports', exportId, {
+      status: ExportStatus.FAILED,
+      error_message: err?.message || 'Unknown error',
+      updated_at: new Date().toISOString(),
+      progress,
+    });
+    if (filePath) {
+      await supabase.storage
+        .from(DataExportStorageBucket.COMPANY_EXPORTS)
+        .remove([filePath]);
+    }
+    if (err instanceof DataExportError) throw err;
+    throw new DataExportError(EXPORT_ERROR.EXPORT_001, err?.message || 'Export failed');
+  }
+}
+
+export async function resumeCompanyExport(exportId: string, companyId: string, userId: string) {
+  const record = await getCompanyDataExportById(exportId);
+  if (!record) {
+    throw new DataExportError(EXPORT_ERROR.EXPORT_003, 'Export not found');
+  }
+  if (record.status === ExportStatus.COMPLETED) return;
+  await processCompanyExportResumable(exportId, companyId, userId);
+}

--- a/supabase/migrations/20240702000000_add_export_progress.sql
+++ b/supabase/migrations/20240702000000_add_export_progress.sql
@@ -1,0 +1,9 @@
+-- Migration: add progress and checksum tracking for data exports
+
+ALTER TABLE user_data_exports
+  ADD COLUMN IF NOT EXISTS progress INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS checksum TEXT;
+
+ALTER TABLE company_data_exports
+  ADD COLUMN IF NOT EXISTS progress INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS checksum TEXT;


### PR DESCRIPTION
## Summary
- add new `EXPORT_ERROR` codes
- implement `DataExportError` class
- create resumable export service with progress tracking and checksum validation
- migration for progress & checksum columns
- tests for new error and resumable export logic

## Testing
- `npm run test:coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683edd378f188331a770fb885955911b