### PR TITLE
Use hook for role panel permissions

### DIFF
--- a/app/admin/permissions/UserRoleAssignmentPanel.tsx
+++ b/app/admin/permissions/UserRoleAssignmentPanel.tsx
@@ -2,13 +2,25 @@
 import { useEffect } from 'react';
 import { useAdminUsers } from '@/hooks/admin/useAdminUsers';
 import RoleManagementPanel from '@/ui/styled/admin/RoleManagementPanel';
+import { usePermission } from '@/hooks/permission/usePermissions';
+import { PermissionValues } from '@/core/permission/models';
 
 export default function UserRoleAssignmentPanel() {
   const { users, searchUsers } = useAdminUsers();
+  const { hasPermission, isLoading } = usePermission({
+    required: PermissionValues.MANAGE_ROLES,
+  });
 
   useEffect(() => {
     searchUsers({});
   }, [searchUsers]);
+  if (isLoading) {
+    return <div className="animate-pulse">Loading permissions...</div>;
+  }
+
+  if (!hasPermission) {
+    return null;
+  }
 
   return <RoleManagementPanel users={users} />;
 }

--- a/app/admin/permissions/__tests__/UserRoleAssignmentPanel.test.tsx
+++ b/app/admin/permissions/__tests__/UserRoleAssignmentPanel.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import UserRoleAssignmentPanel from '../UserRoleAssignmentPanel';
+import { useAdminUsers } from '@/hooks/admin/useAdminUsers';
+import { usePermission } from '@/hooks/permission/usePermissions';
+
+vi.mock('@/hooks/admin/useAdminUsers');
+vi.mock('@/hooks/permission/usePermissions');
+
+describe('UserRoleAssignmentPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading state while permission check in progress', () => {
+    vi.mocked(usePermission).mockReturnValue({ hasPermission: false, isLoading: true } as any);
+    vi.mocked(useAdminUsers).mockReturnValue({ users: [], searchUsers: vi.fn() } as any);
+    render(<UserRoleAssignmentPanel />);
+    expect(screen.getByText(/loading permissions/i)).toBeInTheDocument();
+  });
+
+  it('renders nothing when permission denied', () => {
+    vi.mocked(usePermission).mockReturnValue({ hasPermission: false, isLoading: false } as any);
+    vi.mocked(useAdminUsers).mockReturnValue({ users: [], searchUsers: vi.fn() } as any);
+    const { container } = render(<UserRoleAssignmentPanel />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders role management panel when permission granted', () => {
+    const searchUsers = vi.fn();
+    vi.mocked(usePermission).mockReturnValue({ hasPermission: true, isLoading: false } as any);
+    vi.mocked(useAdminUsers).mockReturnValue({ users: [{ id: '1', email: 'test' }], searchUsers } as any);
+    render(<UserRoleAssignmentPanel />);
+    expect(screen.getByText('User Role Management')).toBeInTheDocument();
+    expect(searchUsers).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- gate `UserRoleAssignmentPanel` behind permission check
- test permission behavior for UserRoleAssignmentPanel

## Testing
- `npx vitest run --coverage app/admin/permissions/__tests__/UserRoleAssignmentPanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_683ede0ae9448331ae9c577b7f4bdc2d