### PR TITLE
Update permission hooks

### DIFF
--- a/app/admin/permissions/RoleManagementPanel.tsx
+++ b/app/admin/permissions/RoleManagementPanel.tsx
@@ -1,6 +1,14 @@
 'use client';
 import { RoleManager } from '@/ui/styled/permission/RoleManager';
+import { usePermission } from '@/hooks/usePermission';
+import { PermissionValues } from '@/core/permission/models';
+import { Spinner } from '@/ui/primitives/spinner';
 
 export default function RoleManagementPanel() {
+  const { hasPermission, isLoading } = usePermission({ required: PermissionValues.MANAGE_ROLES });
+
+  if (isLoading) return <Spinner />;
+  if (!hasPermission) return <div>Access denied: insufficient permissions.</div>;
+
   return <RoleManager />;
 }

--- a/src/hooks/usePermission.ts
+++ b/src/hooks/usePermission.ts
@@ -1,0 +1,1 @@
+export { usePermission } from './permission/usePermissions';

--- a/src/ui/styled/team/TeamMembersList.tsx
+++ b/src/ui/styled/team/TeamMembersList.tsx
@@ -28,7 +28,7 @@ import {
   ArrowUpDown,
   UserPlus,
 } from 'lucide-react';
-import { usePermission } from '@/hooks/permission/usePermissions';
+import { usePermission } from "@/hooks/usePermission";
 import { Skeleton } from '@/ui/primitives/skeleton';
 import { Progress } from '@/ui/primitives/progress';
 


### PR DESCRIPTION
## Summary
- add `usePermission` alias for convenience
- restrict RoleManagementPanel by MANAGE_ROLES permission
- switch TeamMembersList to new permission hook import

## Testing
- `npx vitest run --coverage` *(fails: missing env or network access)*

------
https://chatgpt.com/codex/tasks/task_b_683ede516ae083319b47b8244d292e68