### PR TITLE
Add permission gating for admin panels

### DIFF
--- a/app/admin/permissions/ResourcePermissionPanel.tsx
+++ b/app/admin/permissions/ResourcePermissionPanel.tsx
@@ -5,6 +5,8 @@ import { Button } from '@/ui/primitives/button';
 import { Select } from '@/ui/primitives/select';
 import { UserManagementConfiguration } from '@/core/config';
 import type { PermissionService } from '@/core/permission/interfaces';
+import { usePermission } from '@/hooks/permission/usePermissions';
+import { PermissionValues } from '@/core/permission/models';
 
 interface ResourcePermission {
   userId: string;
@@ -12,6 +14,10 @@ interface ResourcePermission {
 }
 
 export default function ResourcePermissionPanel() {
+  const { hasPermission, isLoading } = usePermission({
+    required: PermissionValues.MANAGE_ROLES,
+  });
+
   const permissionService =
     UserManagementConfiguration.getServiceProvider<PermissionService>('permissionService');
 
@@ -45,8 +51,18 @@ export default function ResourcePermissionPanel() {
   };
 
   useEffect(() => {
-    fetchPermissions();
-  }, [resourceType, resourceId]);
+    if (hasPermission) {
+      fetchPermissions();
+    }
+  }, [resourceType, resourceId, hasPermission]);
+
+  if (isLoading) {
+    return <div className="animate-pulse">Loading permissions...</div>;
+  }
+
+  if (!hasPermission) {
+    return null;
+  }
 
   return (
     <div className="space-y-4">

--- a/app/admin/permissions/RoleManagementPanel.tsx
+++ b/app/admin/permissions/RoleManagementPanel.tsx
@@ -1,6 +1,20 @@
 'use client';
 import { RoleManager } from '@/ui/styled/permission/RoleManager';
+import { usePermission } from '@/hooks/permission/usePermissions';
+import { PermissionValues } from '@/core/permission/models';
 
 export default function RoleManagementPanel() {
+  const { hasPermission, isLoading } = usePermission({
+    required: PermissionValues.MANAGE_ROLES,
+  });
+
+  if (isLoading) {
+    return <div className="animate-pulse">Loading permissions...</div>;
+  }
+
+  if (!hasPermission) {
+    return null;
+  }
+
   return <RoleManager />;
 }

--- a/app/admin/permissions/__tests__/ResourcePermissionPanel.test.tsx
+++ b/app/admin/permissions/__tests__/ResourcePermissionPanel.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ResourcePermissionPanel from '../ResourcePermissionPanel';
+import { usePermission } from '@/hooks/permission/usePermissions';
+import { UserManagementConfiguration } from '@/core/config';
+
+vi.mock('@/hooks/permission/usePermissions');
+vi.mock('@/ui/primitives/input', () => ({ Input: (props: any) => <input {...props} /> }));
+vi.mock('@/ui/primitives/button', () => ({ Button: (props: any) => <button {...props}>{props.children}</button> }));
+vi.mock('@/ui/primitives/select', () => ({ Select: (props: any) => <select {...props}>{props.children}</select> }));
+vi.mock('@/core/config', () => ({ UserManagementConfiguration: { getServiceProvider: vi.fn() } }));
+
+describe('ResourcePermissionPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (UserManagementConfiguration.getServiceProvider as unknown as vi.Mock).mockReturnValue(undefined);
+  });
+
+  it('shows loading state while permission check in progress', () => {
+    vi.mocked(usePermission).mockReturnValue({ hasPermission: false, isLoading: true } as any);
+    render(<ResourcePermissionPanel />);
+    expect(screen.getByText(/loading permissions/i)).toBeInTheDocument();
+  });
+
+  it('renders nothing when permission denied', () => {
+    vi.mocked(usePermission).mockReturnValue({ hasPermission: false, isLoading: false } as any);
+    const { container } = render(<ResourcePermissionPanel />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders panel when permission granted', () => {
+    vi.mocked(usePermission).mockReturnValue({ hasPermission: true, isLoading: false } as any);
+    render(<ResourcePermissionPanel />);
+    expect(screen.getByText('Resource Permissions')).toBeInTheDocument();
+  });
+});

--- a/app/admin/permissions/__tests__/RoleManagementPanel.test.tsx
+++ b/app/admin/permissions/__tests__/RoleManagementPanel.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import RoleManagementPanel from '../RoleManagementPanel';
+import { usePermission } from '@/hooks/permission/usePermissions';
+
+vi.mock('@/hooks/permission/usePermissions');
+vi.mock('@/ui/styled/permission/RoleManager', () => ({
+  RoleManager: () => <div>role manager</div>,
+}));
+
+describe('RoleManagementPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading state while permission check in progress', () => {
+    vi.mocked(usePermission).mockReturnValue({ hasPermission: false, isLoading: true } as any);
+    render(<RoleManagementPanel />);
+    expect(screen.getByText(/loading permissions/i)).toBeInTheDocument();
+  });
+
+  it('renders nothing when permission denied', () => {
+    vi.mocked(usePermission).mockReturnValue({ hasPermission: false, isLoading: false } as any);
+    const { container } = render(<RoleManagementPanel />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders role manager when permission granted', () => {
+    vi.mocked(usePermission).mockReturnValue({ hasPermission: true, isLoading: false } as any);
+    render(<RoleManagementPanel />);
+    expect(screen.getByText(/role manager/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- enforce permission checks in admin resource and role panels
- add matching unit tests for new permission gates

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683ef4e745c88331a23168ba15313863