### PR TITLE
Add permission checks for admin pages

### DIFF
--- a/app/admin/roles/page.tsx
+++ b/app/admin/roles/page.tsx
@@ -1,11 +1,33 @@
-import { Metadata } from 'next';
-import RolesManagementPageClient from './ClientPage';
+import { Metadata } from "next";
+import { redirect } from "next/navigation";
+import RolesManagementPageClient from "./ClientPage";
+import { getSupabaseServerClient } from "@/lib/auth";
+import type { User as SupabaseUser } from "@supabase/supabase-js";
+import { hasPermission } from "@/lib/auth/hasPermission";
+import { PermissionValues } from "@/core/permission/models";
 
 export const metadata: Metadata = {
-  title: 'Role Management',
-  description: 'Manage user roles and permissions',
+  title: "Role Management",
+  description: "Manage user roles and permissions",
 };
 
-export default function RolesManagementPage(): JSX.Element {
+export default async function RolesManagementPage(): Promise<JSX.Element> {
+  const supabase = getSupabaseServerClient();
+  const { data, error } = await supabase.auth.getUser();
+  const user: SupabaseUser | null = data.user;
+
+  if (error || !user) {
+    redirect("/auth/login");
+  }
+
+  const canManageRoles = await hasPermission(
+    user.id,
+    PermissionValues.MANAGE_ROLES,
+  );
+
+  if (!canManageRoles) {
+    redirect("/dashboard/overview");
+  }
+
   return <RolesManagementPageClient />;
 }

--- a/app/admin/users/ClientPage.tsx
+++ b/app/admin/users/ClientPage.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { useState, useEffect } from "react";
+import { UserSearch } from "./UserSearch";
+import { SavedSearches } from "./SavedSearches";
+import { ExportOptions } from "./ExportOptions";
+import { Card, CardContent, CardHeader, CardTitle } from "@/ui/primitives/card";
+import { RealtimeStatus } from "@/components/ui/RealtimeStatus";
+import { useAdminRealtimeChannel } from "@/hooks/admin/useAdminRealtimeChannel";
+
+export default function AdminUsersPageClient() {
+  const [currentSearchParams, setCurrentSearchParams] = useState<
+    Record<string, any>
+  >({});
+  const { isConnected, addUserChangeListener } = useAdminRealtimeChannel();
+
+  const handleSearch = (params: Record<string, any>) => {
+    setCurrentSearchParams(params);
+  };
+
+  const handleSelectSavedSearch = (params: Record<string, any>) => {
+    setCurrentSearchParams(params);
+  };
+
+  useEffect(() => {
+    const handleUserChange = () => {
+      if (currentSearchParams && Object.keys(currentSearchParams).length > 0) {
+        handleSearch(currentSearchParams);
+      }
+    };
+    const remove = addUserChangeListener(handleUserChange);
+    return () => remove();
+  }, [addUserChangeListener, handleSearch, currentSearchParams]);
+
+  return (
+    <div className="container py-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h1 className="text-3xl font-bold tracking-tight">User Management</h1>
+          <RealtimeStatus isConnected={isConnected} />
+        </div>
+        <ExportOptions searchParams={currentSearchParams} />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+        <div className="md:col-span-1">
+          <Card>
+            <CardHeader>
+              <CardTitle>Saved Searches</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <SavedSearches
+                onSelectSearch={handleSelectSavedSearch}
+                currentSearchParams={currentSearchParams}
+              />
+            </CardContent>
+          </Card>
+        </div>
+        <div className="md:col-span-3">
+          <UserSearch
+            initialSearchParams={currentSearchParams}
+            onSearch={handleSearch}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- enhance `/admin` layout to verify user has `ADMIN_ACCESS` and can view the admin dashboard
- enforce `EDIT_USER_PROFILES` permission on the users page
- enforce `MANAGE_ROLES` permission on the roles page
- split users page into server/client components for permission check

## Testing
- `npm run test:coverage --silent` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683ef4d929808331beac64070eebb193