### PR TITLE
Fix security middleware usage in company API

### DIFF
--- a/app/api/company/documents/route.ts
+++ b/app/api/company/documents/route.ts
@@ -10,6 +10,7 @@ import {
   rateLimitMiddleware,
   validationMiddleware,
 } from "@/middleware/createMiddlewareChain";
+import { withSecurity } from "@/middleware/with-security";
 import {
   createCreatedResponse,
   createPaginatedResponse,
@@ -133,7 +134,7 @@ async function handlePost(
 }
 
 // --- GET Handler for fetching company documents ---
-async function handleGet(_request: NextRequest, auth: RouteAuthContext) {
+async function handleGet(request: NextRequest, auth: RouteAuthContext) {
   try {
     const supabaseService = getServiceSupabase();
     const userId = auth.userId!;
@@ -247,5 +248,10 @@ async function handleGet(_request: NextRequest, auth: RouteAuthContext) {
   }
 }
 
-export const POST = postMiddleware(handlePost);
-export const GET = baseMiddleware(handleGet);
+export const POST = withSecurity((req: NextRequest) =>
+  postMiddleware((r, auth, data) => handlePost(r, auth, data))(req)
+);
+
+export const GET = withSecurity((req: NextRequest) =>
+  baseMiddleware((r, auth) => handleGet(r, auth))(req)
+);

--- a/app/api/company/domains/route.ts
+++ b/app/api/company/domains/route.ts
@@ -8,6 +8,7 @@ import {
   rateLimitMiddleware,
   validationMiddleware,
 } from "@/middleware/createMiddlewareChain";
+import { withSecurity } from "@/middleware/with-security";
 import { z } from "zod";
 
 // Validation schema for adding a new domain
@@ -170,5 +171,10 @@ async function handlePost(
   }
 }
 
-export const GET = baseMiddleware(handleGet);
-export const POST = postMiddleware(handlePost);
+export const GET = withSecurity((req: NextRequest) =>
+  baseMiddleware((r, auth) => handleGet(r, auth))(req)
+);
+
+export const POST = withSecurity((req: NextRequest) =>
+  postMiddleware((r, auth, data) => handlePost(r, auth, data))(req)
+);

--- a/app/api/company/profile/route.ts
+++ b/app/api/company/profile/route.ts
@@ -11,6 +11,7 @@ import {
   rateLimitMiddleware,
   validationMiddleware,
 } from "@/middleware/createMiddlewareChain";
+import { withSecurity } from "@/middleware/with-security";
 
 // Company Profile Schema
 const CompanyProfileSchema = z.object({
@@ -169,7 +170,9 @@ const postMiddleware = createMiddlewareChain([
   validationMiddleware(CompanyProfileSchema),
 ]);
 
-export const POST = postMiddleware(handlePost);
+export const POST = withSecurity((req: NextRequest) =>
+  postMiddleware((r, auth, data) => handlePost(r, auth, data))(req)
+);
 
 async function handleGet(_request: NextRequest, auth: RouteAuthContext) {
   try {
@@ -194,7 +197,9 @@ async function handleGet(_request: NextRequest, auth: RouteAuthContext) {
   }
 }
 
-export const GET = baseMiddleware(handleGet);
+export const GET = withSecurity((req: NextRequest) =>
+  baseMiddleware((r, auth) => handleGet(r, auth))(req)
+);
 
 async function handlePut(
   request: NextRequest,
@@ -312,7 +317,9 @@ const putMiddleware = createMiddlewareChain([
   validationMiddleware(CompanyProfileUpdateSchema),
 ]);
 
-export const PUT = putMiddleware(handlePut);
+export const PUT = withSecurity((req: NextRequest) =>
+  putMiddleware((r, auth, data) => handlePut(r, auth, data))(req)
+);
 
 async function handleDelete(request: NextRequest, auth: RouteAuthContext) {
   // Get IP and User Agent early
@@ -447,4 +454,6 @@ async function handleDelete(request: NextRequest, auth: RouteAuthContext) {
   }
 }
 
-export const DELETE = baseMiddleware(handleDelete);
+export const DELETE = withSecurity((req: NextRequest) =>
+  baseMiddleware((r, auth) => handleDelete(r, auth))(req)
+);


### PR DESCRIPTION
## Summary
- wrap company routes with `withSecurity` for consistent security headers and CSRF protection
- refactor address routes to use middleware chain and add security wrapper
- fix incorrect request variable in documents GET handler

## Testing
- `npm run test` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683ef4b3d03c83319fdfb6d64a6d7e41