### PR TITLE
Update resource permission checks

### DIFF
--- a/app/api/company/domains/[id]/__tests__/route.test.ts
+++ b/app/api/company/domains/[id]/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { DELETE, PATCH } from '../route';
 import { getServiceSupabase } from '@/lib/database/supabase';
 import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
+import { checkPermission } from '@/lib/auth/permissionCheck';
 
 vi.mock('@/middleware/rate-limit', () => ({ checkRateLimit: vi.fn().mockResolvedValue(false) }));
 vi.mock('@/lib/database/supabase', () => {
@@ -16,6 +17,7 @@ vi.mock('@/lib/database/supabase', () => {
   return { getServiceSupabase: vi.fn(() => client) };
 });
 vi.mock("@/middleware/auth", () => ({ withRouteAuth: vi.fn((h: any, r: any) => h(r, { userId: "user-1" })) }));
+vi.mock('@/lib/auth/permissionCheck', () => ({ checkPermission: vi.fn() }));
 
 describe('Company Domain By ID API', () => {
   const id = 'domain-1';
@@ -35,6 +37,7 @@ describe('Company Domain By ID API', () => {
       data: { id, is_primary: false, company_profiles: { id: 'c', user_id: 'user-1' } },
       error: null
     });
+    (checkPermission as unknown as vi.Mock).mockResolvedValue(true);
   });
 
   it('deletes a domain successfully', async () => {

--- a/app/api/resources/[type]/[id]/permissions/__tests__/route.test.ts
+++ b/app/api/resources/[type]/[id]/permissions/__tests__/route.test.ts
@@ -2,18 +2,21 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GET } from '../route';
 import { withRouteAuth } from '@/middleware/auth';
 import { getApiPermissionService } from '@/services/permission/factory';
+import { checkPermission } from '@/lib/auth/permissionCheck';
 
 vi.mock('@/middleware/auth', () => ({
   withRouteAuth: vi.fn((handler: any, req: any) => handler(req, { userId: 'u1' })),
 }));
 vi.mock('@/middleware/with-security', () => ({ withSecurity: (h: any) => h }));
 vi.mock('@/services/permission/factory', () => ({ getApiPermissionService: vi.fn() }));
+vi.mock('@/lib/auth/permissionCheck', () => ({ checkPermission: vi.fn() }));
 
 const mockService = { getPermissionsForResource: vi.fn() };
 
 beforeEach(() => {
   vi.clearAllMocks();
   (getApiPermissionService as unknown as vi.Mock).mockReturnValue(mockService);
+  (checkPermission as unknown as vi.Mock).mockResolvedValue(true);
 });
 
 describe('resource permissions list API', () => {

--- a/app/api/resources/permissions/__tests__/route.test.ts
+++ b/app/api/resources/permissions/__tests__/route.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST, DELETE } from '../route';
 import { withRouteAuth } from '@/middleware/auth';
 import { getApiPermissionService } from '@/services/permission/factory';
+import { checkPermission } from '@/lib/auth/permissionCheck';
 
 vi.mock('@/middleware/with-security', () => ({ withSecurity: (h: any) => h }));
 vi.mock('@/middleware/auth', () => ({
   withRouteAuth: vi.fn((handler: any, req: any) => handler(req, { userId: 'u1' })),
 }));
 vi.mock('@/services/permission/factory', () => ({ getApiPermissionService: vi.fn() }));
+vi.mock('@/lib/auth/permissionCheck', () => ({ checkPermission: vi.fn() }));
 
 const mockService = {
   assignResourcePermission: vi.fn(),
@@ -17,6 +19,7 @@ const mockService = {
 beforeEach(() => {
   vi.clearAllMocks();
   (getApiPermissionService as unknown as vi.Mock).mockReturnValue(mockService);
+  (checkPermission as unknown as vi.Mock).mockResolvedValue(true);
 });
 
 describe('resource permission API', () => {


### PR DESCRIPTION
## Summary
- enforce resource-aware permissions for listing a resource's permissions
- add similar checks for assigning and deleting resource permissions
- validate domain update/delete actions with a resource-based permission
- adjust tests accordingly

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683ef4bf047c8331b846fd556156bd47