### PR TITLE
Standardize login route error handling

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -4,9 +4,8 @@ import { withSecurity } from '@/middleware/with-security';
 import { logUserAction } from '@/lib/audit/auditLogger';
 import { getApiAuthService } from '@/services/auth/factory';
 import { LoginPayload } from '@/core/auth/models';
-import { createSuccessResponse } from '@/lib/api/response/api-response';
-import { handleApiError } from '@/lib/api/middleware/error-handler.middleware';
-import { ApiError, ERROR_CODES } from '@/lib/api/common';
+import { createSuccessResponse, ApiError, ERROR_CODES } from '@/lib/api/common';
+import { withErrorHandling } from '@/middleware/error-handling';
 import {
   createMiddlewareChain,
   validationMiddleware,
@@ -117,5 +116,5 @@ const middleware = createMiddlewareChain([
 ]);
 
 export const POST = withSecurity((request: NextRequest) =>
-  withApiErrorHandling(middleware(handleLogin), request)
+  withErrorHandling(middleware(handleLogin), request)
 );


### PR DESCRIPTION
## Summary
- align `/api/auth/login` route with common error handler

## Testing
- `npm run test:coverage` *(fails: environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_683efcb6ad048331961c52e6dae75401