### PR TITLE
Integrate monitoring alert system

### DIFF
--- a/app/RootLayoutClient.tsx
+++ b/app/RootLayoutClient.tsx
@@ -7,7 +7,7 @@ import { KeyboardShortcutsDialog } from '@/ui/styled/common/KeyboardShortcutsDia
 import dynamic from 'next/dynamic';
 import { useGlobalError } from '@/lib/state/errorStore';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
-import { initializeErrorSystem } from '@/lib/monitoring';
+import { initializeErrorSystem, initializeMonitoringSystem } from '@/lib/monitoring';
 
 const GlobalErrorDisplay = dynamic(
   () => import('@/ui/styled/common/GlobalErrorDisplay'),
@@ -26,6 +26,7 @@ export default function RootLayoutClient({
   });
   useEffect(() => {
     initializeErrorSystem();
+    initializeMonitoringSystem();
   }, []);
   return (
     <>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,10 @@
 import type { Metadata, Viewport } from 'next';
 import RootLayoutClient from './RootLayoutClient';
 import './globals.css';
-import { initializeErrorSystem } from '@/lib/monitoring';
+import { initializeErrorSystem, initializeMonitoringSystem } from '@/lib/monitoring';
 
 initializeErrorSystem();
+initializeMonitoringSystem();
 
 export const viewport: Viewport = {
   width: 'device-width',

--- a/src/lib/monitoring/__tests__/monitoring-system.test.ts
+++ b/src/lib/monitoring/__tests__/monitoring-system.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const addAlertNotifier = vi.fn();
+vi.mock('../error-system', () => ({ telemetry: { addAlertNotifier } }));
+
+const registerError = vi.fn();
+vi.mock('@/lib/telemetry/alert-manager', () => ({
+  AlertManager: vi.fn().mockImplementation(() => ({
+    addRule: vi.fn(),
+    registerError,
+  })),
+}));
+
+vi.mock('@/core/common/errors', async () => {
+  const actual = await vi.importActual('@/core/common/errors');
+  return { ...actual, ApplicationError: actual.ApplicationError };
+});
+
+const { initializeMonitoringSystem } = await import('../monitoring-system');
+
+describe('monitoring-system', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers alert notifier', () => {
+    initializeMonitoringSystem();
+    expect(addAlertNotifier).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards alerts to alert manager', () => {
+    initializeMonitoringSystem();
+    const cb = addAlertNotifier.mock.calls[0][0];
+    cb({ errorType: 'ERR', message: 'boom', severity: 'critical', count: 1 });
+    expect(registerError).toHaveBeenCalled();
+  });
+});

--- a/src/lib/monitoring/index.ts
+++ b/src/lib/monitoring/index.ts
@@ -1,2 +1,3 @@
 export * from './correlation-id';
 export * from './error-system';
+export * from './monitoring-system';

--- a/src/lib/monitoring/monitoring-system.ts
+++ b/src/lib/monitoring/monitoring-system.ts
@@ -1,0 +1,31 @@
+// Monitoring system integration for error aggregation and alerting
+import { telemetry } from './error-system';
+import { AlertManager, AlertRule } from '@/lib/telemetry/alert-manager';
+import { ApplicationError } from '@/core/common/errors';
+
+let initialized = false;
+export const alertManager = new AlertManager();
+
+export interface MonitoringConfig {
+  alertRules?: AlertRule[];
+}
+
+export function initializeMonitoringSystem(config: MonitoringConfig = {}): void {
+  if (initialized) return;
+  initialized = true;
+
+  if (config.alertRules) {
+    for (const rule of config.alertRules) {
+      alertManager.addRule(rule);
+    }
+  }
+
+  telemetry.addAlertNotifier(alert => {
+    const error = new ApplicationError(
+      alert.errorType as any,
+      alert.message,
+      alert.severity === 'critical' ? 500 : 400,
+    );
+    alertManager.registerError(error);
+  });
+}


### PR DESCRIPTION
## Summary
- integrate monitoring initialization for alerting
- aggregate and forward telemetry alerts to AlertManager
- expose monitoring system from library
- test monitoring integration

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_b_683efd3bd9288331835e6fe10062f53b