### PR TITLE
Add standard API middleware chain

### DIFF
--- a/docs/api/middleware-chain.md
+++ b/docs/api/middleware-chain.md
@@ -15,6 +15,18 @@ The module exposes helpers that adapt existing utilities to the chain pattern:
 
 Import these helpers from the same file alongside `createMiddlewareChain`.
 
+### Standard Compositions
+
+Common middleware stacks are provided for convenience. The most frequently used
+is `standardApiMiddleware`, which applies rate limiting, error handling,
+authentication and validation in that order.
+
+```ts
+import { standardApiMiddleware } from '@/middleware/createMiddlewareChain';
+
+const middleware = standardApiMiddleware(mySchema);
+```
+
 ## Example
 
 ```ts

--- a/src/middleware/__tests__/createMiddlewareChain.test.ts
+++ b/src/middleware/__tests__/createMiddlewareChain.test.ts
@@ -30,6 +30,7 @@ import {
   routeAuthMiddleware,
   validationMiddleware,
   rateLimitMiddleware,
+  standardApiMiddleware,
   createMiddlewareChainFromConfig,
   type RouteMiddleware,
 } from '../createMiddlewareChain';
@@ -149,6 +150,19 @@ describe('createMiddlewareChain', () => {
     expect(res.status).toBe(200);
     expect(withRouteAuth).toHaveBeenCalled();
     expect(withErrorHandling).toHaveBeenCalled();
+  });
+
+  it('exposes a standard auth middleware composition', async () => {
+    const chain = standardApiMiddleware({} as any);
+    const handler = vi.fn().mockResolvedValue(new NextResponse('ok'));
+    const res = await chain(handler)(req);
+
+    expect(res.status).toBe(200);
+    expect(createRateLimit).toHaveBeenCalled();
+    expect(withErrorHandling).toHaveBeenCalled();
+    expect(withRouteAuth).toHaveBeenCalled();
+    expect(withValidation).toHaveBeenCalled();
+    expect(handler).toHaveBeenCalled();
   });
 
   it('throws on invalid config', () => {

--- a/src/middleware/createMiddlewareChain.ts
+++ b/src/middleware/createMiddlewareChain.ts
@@ -121,3 +121,18 @@ export function createMiddlewareChainFromConfig(
 
   return createMiddlewareChain(mws);
 }
+
+/**
+ * Standard middleware composition for authenticated API routes.
+ * Applies rate limiting, error handling, authentication and
+ * optional request validation in that order.
+ */
+export const standardApiMiddleware = <T>(
+  schema: ZodSchema<T>
+): RouteMiddleware =>
+  createMiddlewareChain([
+    rateLimitMiddleware(),
+    errorHandlingMiddleware(),
+    routeAuthMiddleware(),
+    validationMiddleware(schema)
+  ]);


### PR DESCRIPTION
## Summary
- provide `standardApiMiddleware` helper
- document standard middleware compositions
- test new middleware composition

## Testing
- `npx vitest run src/middleware/__tests__/createMiddlewareChain.test.ts`
- `npx vitest run src/middleware/__tests__/createMiddlewareChain.test.ts --coverage`

------
https://chatgpt.com/codex/tasks/task_b_683efde0e3c88331a81b5844501f1678