### PR TITLE
Add account deletion request with MFA

### DIFF
--- a/app/api/gdpr/request-deletion/route.ts
+++ b/app/api/gdpr/request-deletion/route.ts
@@ -1,0 +1,69 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getServiceSupabase } from '@/lib/database/supabase';
+import { getApiGDPRService } from '@/services/gdpr/factory';
+import { getApiAuthService } from '@/services/auth/factory';
+import { logUserAction } from '@/lib/audit/auditLogger';
+
+const RequestDeletionSchema = z.object({
+  mfaCode: z.string().min(6),
+});
+
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+  const token = authHeader.split(' ')[1];
+
+  const supabaseService = getServiceSupabase();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabaseService.auth.getUser(token);
+
+  if (userError || !user) {
+    return NextResponse.json({ error: userError?.message || 'Invalid token' }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const parse = RequestDeletionSchema.safeParse(body);
+  if (!parse.success) {
+    return NextResponse.json({ error: 'Invalid confirmation data' }, { status: 400 });
+  }
+
+  try {
+    const authService = getApiAuthService();
+    const verifyRes = await authService.verifyMFA(parse.data.mfaCode);
+    if (!verifyRes.success) {
+      return NextResponse.json({ error: verifyRes.error || 'Invalid MFA code' }, { status: 401 });
+    }
+
+    const gdprService = getApiGDPRService();
+    const scheduledDeletionAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    const result = await gdprService.requestAccountDeletion(user.id, scheduledDeletionAt);
+    if (!result.success || !result.request) {
+      throw new Error(result.error || 'Failed to create deletion request');
+    }
+
+    await logUserAction({
+      userId: user.id,
+      action: 'ACCOUNT_DELETION_REQUESTED',
+      status: 'SUCCESS',
+      targetResourceType: 'user',
+      targetResourceId: user.id,
+    });
+
+    return NextResponse.json(result.request);
+  } catch (error) {
+    await logUserAction({
+      userId: user.id,
+      action: 'ACCOUNT_DELETION_REQUEST_FAILED',
+      status: 'FAILURE',
+      targetResourceType: 'user',
+      targetResourceId: user.id,
+      details: { error: error instanceof Error ? error.message : String(error) },
+    });
+    return NextResponse.json({ error: 'Failed to request account deletion' }, { status: 500 });
+  }
+}

--- a/app/settings/account/DeleteAccountDialog.tsx
+++ b/app/settings/account/DeleteAccountDialog.tsx
@@ -23,13 +23,14 @@ const CONFIRMATION_TEXT = 'DELETE';
 
 const DeleteAccountDialog: React.FC<DeleteAccountDialogProps> = ({ open, onClose }) => {
   const [confirmText, setConfirmText] = useState('');
+  const [mfaCode, setMfaCode] = useState('');
   const { deleteAccount, isLoading, error } = useDeleteAccount();
 
-  const isConfirmed = confirmText === CONFIRMATION_TEXT;
+  const isConfirmed = confirmText === CONFIRMATION_TEXT && mfaCode.length >= 6;
 
   const handleDeleteAccount = async () => {
     if (isConfirmed) {
-      await deleteAccount();
+      await deleteAccount({ mfaCode });
       if (!error) {
         onClose();
       }
@@ -57,11 +58,9 @@ const DeleteAccountDialog: React.FC<DeleteAccountDialogProps> = ({ open, onClose
           )}
 
           <div className="space-y-2">
-            <Label htmlFor="confirm-deletion">
-              Confirm deletion
-            </Label>
+            <Label htmlFor="confirm-deletion">Confirm deletion</Label>
             <p className="text-sm text-muted-foreground">
-              Please type &quot;DELETE&quot; to confirm you want to delete your account
+              Please type "DELETE" to confirm you want to delete your account
             </p>
             <Input
               id="confirm-deletion"
@@ -72,6 +71,23 @@ const DeleteAccountDialog: React.FC<DeleteAccountDialogProps> = ({ open, onClose
               disabled={isLoading}
             />
           </div>
+          <div className="space-y-2">
+            <Label htmlFor="mfa-code">MFA Code</Label>
+            <p className="text-sm text-muted-foreground">
+              Enter the code from your authenticator app
+            </p>
+            <Input
+              id="mfa-code"
+              aria-label="MFA code"
+              value={mfaCode}
+              onChange={(e) => setMfaCode(e.target.value)}
+              placeholder="123456"
+              disabled={isLoading}
+            />
+          </div>
+          <p className="text-sm text-muted-foreground">
+            You can <a className="underline" href="/api/gdpr/export">download your data</a> before deletion. Your account will be permanently removed after a 7 day cooling-off period.
+          </p>
         </div>
 
         <DialogFooter>

--- a/src/adapters/gdpr/supabase/supabase-gdpr.provider.ts
+++ b/src/adapters/gdpr/supabase/supabase-gdpr.provider.ts
@@ -139,13 +139,17 @@ export class SupabaseGdprProvider implements IGdprDataProvider {
   }
 
   /** @inheritdoc */
-  async requestAccountDeletion(userId: string): Promise<{ success: boolean; request?: DeletionRequest; error?: string }> {
+  async requestAccountDeletion(
+    userId: string,
+    scheduledDeletionAt: string,
+  ): Promise<{ success: boolean; request?: DeletionRequest; error?: string }> {
     const { data, error } = await this.supabase
       .from('deletion_requests')
       .insert({
         user_id: userId,
         status: 'pending',
         requested_at: new Date().toISOString(),
+        scheduled_deletion_at: scheduledDeletionAt,
       })
       .select()
       .single();
@@ -254,6 +258,7 @@ export class SupabaseGdprProvider implements IGdprDataProvider {
       status: record.status,
       requestedAt: record.requested_at,
       completedAt: record.completed_at ?? undefined,
+      scheduledDeletionAt: record.scheduled_deletion_at ?? undefined,
       message: record.message ?? undefined,
     };
   }

--- a/src/core/gdpr/IGdprDataProvider.ts
+++ b/src/core/gdpr/IGdprDataProvider.ts
@@ -70,6 +70,7 @@ export interface IGdprDataProvider {
    */
   requestAccountDeletion(
     userId: string,
+    scheduledDeletionAt: string,
   ): Promise<{ success: boolean; request?: DeletionRequest; error?: string }>;
 
   /**

--- a/src/core/gdpr/interfaces.ts
+++ b/src/core/gdpr/interfaces.ts
@@ -4,7 +4,7 @@
  * Defines the operations related to data privacy such as exporting
  * a user's personal data and deleting a user's account.
  */
-import { UserDataExport, AccountDeletionResult } from "./models";
+import { UserDataExport, AccountDeletionResult, DeletionRequest } from "./models";
 
 /**
  * Service responsible for GDPR related user data operations.
@@ -25,4 +25,12 @@ export interface GdprService {
    * @returns Result of the deletion request
    */
   deleteUserData(userId: string): Promise<AccountDeletionResult>;
+
+  /**
+   * Create a deletion request with a cooling-off period.
+   */
+  requestAccountDeletion(
+    userId: string,
+    scheduledDeletionAt: string,
+  ): Promise<{ success: boolean; request?: DeletionRequest; error?: string }>;
 }

--- a/src/core/gdpr/models.ts
+++ b/src/core/gdpr/models.ts
@@ -51,6 +51,8 @@ export interface DeletionRequest {
   requestedAt: string;
   /** When the request was completed */
   completedAt?: string;
+  /** When the account will be permanently deleted */
+  scheduledDeletionAt?: string;
   /** Optional message or error */
   message?: string;
 }

--- a/src/services/gdpr/default-gdpr.service.ts
+++ b/src/services/gdpr/default-gdpr.service.ts
@@ -2,7 +2,7 @@
  * Default GDPR Service Implementation
  */
 import { GdprService } from '@/core/gdpr/interfaces';
-import { UserDataExport, AccountDeletionResult } from '@/core/gdpr/models';
+import { UserDataExport, AccountDeletionResult, DeletionRequest } from '@/core/gdpr/models';
 import type { GdprDataProvider } from '@/core/gdpr/IGdprDataProvider';
 
 export class DefaultGdprService implements GdprService {
@@ -14,5 +14,12 @@ export class DefaultGdprService implements GdprService {
 
   deleteAccount(userId: string): Promise<AccountDeletionResult> {
     return this.provider.deleteUserData(userId);
+  }
+
+  requestAccountDeletion(
+    userId: string,
+    scheduledDeletionAt: string,
+  ): Promise<{ success: boolean; request?: DeletionRequest; error?: string }> {
+    return this.provider.requestAccountDeletion(userId, scheduledDeletionAt);
   }
 }


### PR DESCRIPTION
## Summary
- add scheduled deletion date to DeletionRequest model
- support requesting account deletion with cooling‑off in GDPR service and provider
- expose new API route `/api/gdpr/request-deletion`
- update delete account dialog to require MFA and mention cooling off
- update hook to call new endpoint

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683f04faa6a48331b0efb8886ec1ef11