### PR TITLE
Implement configurable auth middleware

### DIFF
--- a/src/lib/api/__tests__/auth-middleware.test.ts
+++ b/src/lib/api/__tests__/auth-middleware.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+import { createAuthMiddleware } from '../auth-middleware';
+
+const request = new NextRequest('http://test');
+
+describe('createAuthMiddleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when auth required and no user', async () => {
+    const authService = { getCurrentUser: vi.fn().mockResolvedValue(null) } as any;
+    const middleware = createAuthMiddleware({ authService });
+    const handler = vi.fn().mockResolvedValue(new NextResponse('ok'));
+    const wrapped = middleware(handler);
+
+    const res = await wrapped(request);
+    expect(res.status).toBe(401);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('invokes handler when authenticated', async () => {
+    const authService = { getCurrentUser: vi.fn().mockResolvedValue({ id: '1' }) } as any;
+    const middleware = createAuthMiddleware({ authService });
+    const handler = vi.fn().mockResolvedValue(new NextResponse('ok'));
+    const wrapped = middleware(handler);
+
+    const res = await wrapped(request);
+    expect(res.status).toBe(200);
+    expect(handler).toHaveBeenCalledWith(request, expect.objectContaining({ userId: '1', authenticated: true }));
+  });
+
+  it('checks permissions when required', async () => {
+    const authService = { getCurrentUser: vi.fn().mockResolvedValue({ id: '1' }) } as any;
+    const permissionService = {
+      getUserRoles: vi.fn().mockResolvedValue([{ roleId: 'r1' }]),
+      getRoleById: vi.fn().mockResolvedValue({ permissions: ['EDIT'] })
+    } as any;
+    const middleware = createAuthMiddleware({
+      authService,
+      permissionService,
+      requiredPermissions: ['EDIT']
+    });
+    const handler = vi.fn().mockResolvedValue(new NextResponse('ok'));
+    const wrapped = middleware(handler);
+
+    const res = await wrapped(request);
+    expect(res.status).toBe(200);
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('returns 403 when permission missing', async () => {
+    const authService = { getCurrentUser: vi.fn().mockResolvedValue({ id: '1' }) } as any;
+    const permissionService = {
+      getUserRoles: vi.fn().mockResolvedValue([{ roleId: 'r1' }]),
+      getRoleById: vi.fn().mockResolvedValue({ permissions: [] })
+    } as any;
+    const middleware = createAuthMiddleware({
+      authService,
+      permissionService,
+      requiredPermissions: ['EDIT']
+    });
+    const handler = vi.fn().mockResolvedValue(new NextResponse('ok'));
+    const wrapped = middleware(handler);
+
+    const res = await wrapped(request);
+    expect(res.status).toBe(403);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/api/auth-middleware.ts
+++ b/src/lib/api/auth-middleware.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server';
+import type { AuthService } from '@/core/auth/interfaces';
+import type { PermissionService } from '@/core/permission/interfaces';
+import type { AuthContext } from '@/lib/auth/types';
+
+export interface AuthMiddlewareConfig {
+  authService: AuthService;
+  permissionService?: PermissionService;
+  requireAuth?: boolean;
+  requiredPermissions?: string[];
+}
+
+export type AuthHandler = (
+  req: NextRequest,
+  context: AuthContext
+) => Promise<NextResponse> | NextResponse;
+
+export function createAuthMiddleware(config: AuthMiddlewareConfig) {
+  const { authService, permissionService, requireAuth = true, requiredPermissions } = config;
+
+  return (handler: AuthHandler) => {
+    return async (req: NextRequest) => {
+      let context: AuthContext = {
+        userId: '',
+        permissions: [],
+        authenticated: false,
+      };
+
+      try {
+        const user = await authService.getCurrentUser();
+
+        if (user) {
+          context = {
+            userId: user.id,
+            authenticated: true,
+            permissions: [],
+          };
+
+          if (requiredPermissions?.length && permissionService) {
+            const roles = await permissionService.getUserRoles(user.id);
+            const permsSet = new Set<string>();
+            for (const r of roles) {
+              const role = await permissionService.getRoleById(r.roleId);
+              role?.permissions.forEach(p => permsSet.add(p));
+            }
+            const perms = Array.from(permsSet);
+            context.permissions = perms;
+
+            const hasAll = requiredPermissions.every(p => perms.includes(p));
+            if (!hasAll) {
+              return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+            }
+          }
+        } else if (requireAuth) {
+          return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+        }
+      } catch (error) {
+        console.error('Auth middleware error:', error);
+        if (requireAuth) {
+          return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+        }
+      }
+
+      return handler(req, context);
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- add `createAuthMiddleware` to allow configurable auth and permissions
- test middleware behavior for auth and permission scenarios

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683f51d4e07c833180f0d02ddf2d472b