### PR TITLE
Implement service-aware API handler

### DIFF
--- a/src/lib/api/__tests__/route-helpers.test.ts
+++ b/src/lib/api/__tests__/route-helpers.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+vi.mock('../../auth/unified-auth.middleware', () => ({
+  createAuthMiddleware: vi.fn((opts: any) => (handler: any) => handler)
+}));
+
+const { createAuthMiddleware } = await import('../../auth/unified-auth.middleware');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createApiHandler', () => {
+  it('passes services to handler and calls auth middleware with options', async () => {
+    const schema = z.object({ name: z.string() });
+    const handler = vi.fn().mockResolvedValue(new NextResponse('ok'));
+    const { createApiHandler } = await import('../route-helpers');
+    const mockAuth = {} as any;
+    const mockUser = {} as any;
+    const apiHandler = createApiHandler(schema, handler, {
+      requireAuth: true,
+      services: { auth: mockAuth, user: mockUser }
+    });
+    const req = new NextRequest(new Request('http://test', { method: 'POST', body: JSON.stringify({ name: 'A' }) }));
+    const res = await apiHandler(req);
+    expect(createAuthMiddleware).toHaveBeenCalledWith(expect.objectContaining({ authService: mockAuth, requireAuth: true }));
+    expect(handler).toHaveBeenCalledWith(
+      req,
+      expect.any(Object),
+      { name: 'A' },
+      expect.objectContaining({ auth: mockAuth, user: mockUser })
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('returns validation error for invalid data', async () => {
+    const schema = z.object({ name: z.string() });
+    const handler = vi.fn();
+    const { createApiHandler } = await import('../route-helpers');
+    const apiHandler = createApiHandler(schema, handler);
+    const req = new NextRequest(new Request('http://test', { method: 'POST', body: JSON.stringify({}) }));
+    const res = await apiHandler(req);
+    expect(res.status).toBe(400);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/auth/unified-auth.middleware.ts
+++ b/src/lib/auth/unified-auth.middleware.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { AuthContext } from './types';
 import { getServiceSupabase } from '@/lib/database/supabase';
 import { getApiPermissionService } from '@/services/permission/factory';
+import type { AuthService } from '@/core/auth/interfaces';
 
 export type AuthHandler = (
   req: NextRequest,
@@ -13,10 +14,11 @@ export const createAuthMiddleware = (options?: {
   requireAuth?: boolean;
   requiredPermissions?: string[];
   includeUser?: boolean;
+  authService?: AuthService;
 }) => {
   return (handler: AuthHandler) => {
     return async (req: NextRequest) => {
-      const supabase = getServiceSupabase();
+      const supabase = options?.authService ? null : getServiceSupabase();
       const authHeader = req.headers.get('authorization');
       let token: string | null = null;
       
@@ -40,28 +42,36 @@ export const createAuthMiddleware = (options?: {
       
       if (token) {
         try {
-          const { data, error } = await supabase.auth.getUser(token);
-          
-          if (error || !data.user) {
-            throw error || new Error('User not found');
+          let user: any;
+          if (options?.authService && (options.authService as any).getSession) {
+            const session = await (options.authService as any).getSession(token);
+            user = session?.user;
+            if (!user) throw new Error('User not found');
+          } else if (supabase) {
+            const { data, error } = await supabase.auth.getUser(token);
+            if (error || !data.user) {
+              throw error || new Error('User not found');
+            }
+            user = data.user;
+          } else {
+            throw new Error('No auth service available');
           }
-          
-          const userId = data.user.id;
+
+          const userId = user.id;
           context = {
             userId,
             authenticated: true,
             permissions: []
           };
-          
-          // Include full user object if requested
+
           if (options?.includeUser) {
             context.user = {
               id: userId,
-              email: data.user.email || '',
-              role: data.user.app_metadata?.role || data.user.user_metadata?.role,
+              email: user.email || '',
+              role: (user as any).app_metadata?.role || (user as any).user_metadata?.role,
               metadata: {
-                ...data.user.app_metadata,
-                ...data.user.user_metadata
+                ...(user as any).app_metadata,
+                ...(user as any).user_metadata
               }
             };
           }


### PR DESCRIPTION
## Summary
- support dependency injection in auth middleware
- extend api route helpers with service container
- add tests for new route helpers

## Testing
- `npm run test:coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683f51f5161883318ac8ffce2f90b9c5