### PR TITLE
Add API service configuration

### DIFF
--- a/src/lib/config/api-config.ts
+++ b/src/lib/config/api-config.ts
@@ -1,0 +1,30 @@
+export interface ApiConfiguration {
+  authService?: import("@/core/auth/interfaces").AuthService;
+  userService?: import("@/core/user/interfaces").UserService;
+  permissionService?: import("@/core/permission/interfaces").PermissionService;
+}
+
+let apiConfig: ApiConfiguration = {};
+
+export function configureApiServices(config: ApiConfiguration): void {
+  apiConfig = { ...apiConfig, ...config };
+}
+
+export function resetApiServices(): void {
+  apiConfig = {};
+}
+
+export function getConfiguredAuthService(): import("@/core/auth/interfaces").AuthService {
+  const { getApiAuthService } = require("@/services/auth/factory");
+  return apiConfig.authService ?? getApiAuthService();
+}
+
+export function getConfiguredUserService(): import("@/core/user/interfaces").UserService {
+  const { getApiUserService } = require("@/services/user/factory");
+  return apiConfig.userService ?? getApiUserService();
+}
+
+export function getConfiguredPermissionService(): import("@/core/permission/interfaces").PermissionService {
+  const { getApiPermissionService } = require("@/services/permission/factory");
+  return apiConfig.permissionService ?? getApiPermissionService();
+}


### PR DESCRIPTION
## Summary
- add new config module for API service customization

## Testing
- `npx vitest run --coverage` *(fails: Cannot read properties of undefined (reading 'language'))*

------
https://chatgpt.com/codex/tasks/task_b_683f5286bab8833182888ed641390fc9