### PR TITLE
Refactor profile API route

### DIFF
--- a/app/api/profile/__tests__/route.test.ts
+++ b/app/api/profile/__tests__/route.test.ts
@@ -1,20 +1,20 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { GET, PATCH } from '../route';
-import { getApiUserService } from '@/services/user/factory';
-import { withRouteAuth } from '@/middleware/auth';
+import { getConfiguredUserService } from '@/services/user';
+import { createAuthMiddleware } from '@/lib/auth/unified-auth.middleware';
 import createMockUserService from '@/tests/mocks/user.service.mock';
 import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
 
-vi.mock('@/services/user/factory', () => ({ getApiUserService: vi.fn() }));
-vi.mock('@/middleware/auth', () => ({
-  withRouteAuth: vi.fn((handler: any) => async (req: any) => handler(req, { userId: 'user-1', role: 'user', permissions: [] })),
+vi.mock('@/services/user', () => ({ getConfiguredUserService: vi.fn() }));
+vi.mock('@/lib/auth/unified-auth.middleware', () => ({
+  createAuthMiddleware: vi.fn(() => (handler: any) => (req: any) => handler(req, { userId: 'user-1', permissions: [], authenticated: true })),
 }));
 
 const service = createMockUserService();
 
 beforeEach(() => {
   vi.clearAllMocks();
-  (getApiUserService as unknown as vi.Mock).mockReturnValue(service);
+  (getConfiguredUserService as unknown as vi.Mock).mockReturnValue(service);
 });
 
 describe('/api/profile GET', () => {

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -9,6 +9,9 @@ import { UserService } from '@/core/user/interfaces';
 import { DefaultUserService } from './default-user.service';
 export { RepositoryUserService } from './repository-user.service';
 export { ApiUserService, getApiUserService } from './api-user.service';
+import { AdapterRegistry } from '@/adapters/registry';
+import { UserManagementConfiguration } from '@/core/config';
+import type { IUserDataProvider } from '@/core/user/IUserDataProvider';
 import type { UserDataProvider } from '@/core/user/IUserDataProvider';
 
 /**
@@ -37,3 +40,23 @@ export function createUserService(config: UserServiceConfig): UserService {
 export default {
   createUserService
 };
+
+/**
+ * Retrieve the configured UserService instance.
+ *
+ * This helper checks the global UserManagementConfiguration for a registered
+ * `userService` implementation. If none is found, it falls back to creating a
+ * DefaultUserService using the adapter registry.
+ */
+export function getConfiguredUserService(): UserService {
+  const configured =
+    UserManagementConfiguration.getServiceProvider<UserService>('userService');
+  if (configured) {
+    return configured;
+  }
+
+  const provider = AdapterRegistry.getInstance().getAdapter<IUserDataProvider>(
+    'user'
+  );
+  return createUserService({ userDataProvider: provider });
+}


### PR DESCRIPTION
## Summary
- support service injection in `createApiHandler`
- add `getConfiguredUserService` helper
- refactor `app/api/profile/route.ts` to use injectable services
- update profile route tests for new handler

## Testing
- `npx vitest run --coverage` *(fails: environment limits)*

------
https://chatgpt.com/codex/tasks/task_b_683f52259630833188fd0bbfd84409bc