### PR TITLE
Migrate team routes to new service injection pattern

### DIFF
--- a/app/api/team/__tests__/route.test.ts
+++ b/app/api/team/__tests__/route.test.ts
@@ -2,13 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import { GET, POST } from '../route';
 import { getApiTeamService } from '@/services/team/factory';
-import { withRouteAuth } from '@/middleware/auth';
+import { createAuthMiddleware } from '@/lib/auth/unified-auth.middleware';
 
 vi.mock('@/services/team/factory', () => ({
   getApiTeamService: vi.fn()
 }));
-vi.mock('@/middleware/auth', () => ({
-  withRouteAuth: vi.fn((handler: any) => async (req: any) => handler(req, { userId: 'u1', role: 'user' }))
+vi.mock('@/lib/auth/unified-auth.middleware', () => ({
+  createAuthMiddleware: vi.fn(() =>
+    (handler: any) => async (req: any) => handler(req, { userId: 'u1', permissions: [], authenticated: true })
+  )
 }));
 
 describe('team API', () => {

--- a/app/api/team/members/route.ts
+++ b/app/api/team/members/route.ts
@@ -2,14 +2,7 @@ import { type NextRequest } from 'next/server';
 import { prisma } from '@/lib/database/prisma';
 import { z } from 'zod';
 import { createSuccessResponse, ApiError, ERROR_CODES } from '@/lib/api/common';
-import { getApiTeamService } from '@/services/team/factory';
-import {
-  createMiddlewareChain,
-  errorHandlingMiddleware,
-  routeAuthMiddleware,
-  validationMiddleware
-} from '@/middleware/createMiddlewareChain';
-import type { RouteAuthContext } from '@/middleware/auth';
+import { createApiHandler } from '@/lib/api/route-helpers';
 import { Permission } from '@/lib/rbac/roles';
 
 const querySchema = z.object({
@@ -29,19 +22,10 @@ const addMemberSchema = z.object({
 
 async function handleTeamMembers(
   req: NextRequest,
-  auth: RouteAuthContext,
-  data?: z.infer<typeof querySchema>
+  auth: { userId?: string },
+  data: z.infer<typeof querySchema>
 ) {
-  let params;
-  
-  if (data) {
-    // New approach: validated data is passed from middleware
-    params = data;
-  } else {
-    // Legacy approach: parse and validate query params manually
-    const query = Object.fromEntries(new URL(req.url).searchParams.entries());
-    params = querySchema.parse(query);
-  }
+  const params = data;
   
   const { page, limit, search, status, sortBy, sortOrder } = params;
   const skip = (page - 1) * limit;
@@ -155,8 +139,9 @@ async function handleTeamMembers(
 
 async function handleAddMember(
   _req: NextRequest,
-  auth: RouteAuthContext,
-  data: z.infer<typeof addMemberSchema>
+  auth: { userId?: string },
+  data: z.infer<typeof addMemberSchema>,
+  services: { team: any }
 ) {
   const license = await prisma.teamLicense.findUnique({
     where: { id: data.teamId },
@@ -170,24 +155,21 @@ async function handleAddMember(
       400,
     );
   }
-  const service = getApiTeamService();
-  const result = await service.addTeamMember(data.teamId, data.userId, data.role);
+  const result = await services.team.addTeamMember(data.teamId, data.userId, data.role);
   if (!result.success || !result.member) {
     throw new ApiError(ERROR_CODES.INVALID_REQUEST, result.error || 'Failed');
   }
   return createSuccessResponse(result.member, 201);
 }
 
-const getMiddleware = createMiddlewareChain([
-  errorHandlingMiddleware(),
-  routeAuthMiddleware({ requiredPermissions: [Permission.VIEW_TEAM_MEMBERS] })
-]);
+export const GET = createApiHandler(
+  querySchema,
+  handleTeamMembers,
+  { requireAuth: true, requiredPermissions: [Permission.VIEW_TEAM_MEMBERS] }
+);
 
-const postMiddleware = createMiddlewareChain([
-  errorHandlingMiddleware(),
-  routeAuthMiddleware({ requiredPermissions: [Permission.INVITE_TEAM_MEMBER] }),
-  validationMiddleware(addMemberSchema)
-]);
-
-export const GET = getMiddleware(handleTeamMembers);
-export const POST = postMiddleware(handleAddMember);
+export const POST = createApiHandler(
+  addMemberSchema,
+  handleAddMember,
+  { requireAuth: true, requiredPermissions: [Permission.INVITE_TEAM_MEMBER] }
+);

--- a/src/core/config/interfaces.ts
+++ b/src/core/config/interfaces.ts
@@ -9,6 +9,7 @@
 import type { AuthService } from '@/core/auth/interfaces';
 import type { UserService } from '@/core/user/interfaces';
 import type { PermissionService } from '@/core/permission/interfaces';
+import type { TeamService } from '@/core/team/interfaces';
 
 /**
  * Service container interface that holds all available services
@@ -16,6 +17,7 @@ import type { PermissionService } from '@/core/permission/interfaces';
 export interface ServiceContainer {
   auth: AuthService;
   user: UserService;
+  team: TeamService;
   permission?: PermissionService;
   // Add other services as needed
 }
@@ -33,11 +35,16 @@ export interface ServiceConfig {
    * Custom user service implementation  
    */
   userService?: UserService;
-  
+
   /**
    * Custom permission service implementation
    */
   permissionService?: PermissionService;
+
+  /**
+   * Custom team service implementation
+   */
+  teamService?: TeamService;
   
   /**
    * Feature flags to enable/disable functionality

--- a/src/lib/config/service-container.ts
+++ b/src/lib/config/service-container.ts
@@ -14,10 +14,12 @@ import type {
 import type { AuthService } from '@/core/auth/interfaces';
 import type { UserService } from '@/core/user/interfaces';
 import type { PermissionService } from '@/core/permission/interfaces';
+import type { TeamService } from '@/core/team/interfaces';
 
 // Import existing service factories
 import { getApiAuthService } from '@/services/auth/factory';
 import { getApiUserService } from '@/services/user/factory';
+import { getApiTeamService } from '@/services/team/factory';
 
 /**
  * Global service configuration
@@ -67,6 +69,11 @@ export function getServiceContainer(overrides?: Partial<ServiceContainer>): Serv
   if (!serviceInstances.user) {
     serviceInstances.user = globalServiceConfig.userService || getApiUserService();
   }
+
+  // Create team service if not cached
+  if (!serviceInstances.team) {
+    serviceInstances.team = globalServiceConfig.teamService || getApiTeamService();
+  }
   
   // Create permission service if not cached (optional)
   if (!serviceInstances.permission && globalServiceConfig.permissionService) {
@@ -77,6 +84,7 @@ export function getServiceContainer(overrides?: Partial<ServiceContainer>): Serv
   return {
     auth: overrides?.auth || serviceInstances.auth!,
     user: overrides?.user || serviceInstances.user!,
+    team: overrides?.team || serviceInstances.team!,
     permission: overrides?.permission || serviceInstances.permission,
   };
 }
@@ -100,6 +108,13 @@ export function getConfiguredUserService(override?: UserService): UserService {
  */
 export function getConfiguredPermissionService(override?: PermissionService): PermissionService | undefined {
   return override || globalServiceConfig.permissionService;
+}
+
+/**
+ * Get a specific team service with fallback to global configuration
+ */
+export function getConfiguredTeamService(override?: TeamService): TeamService {
+  return override || globalServiceConfig.teamService || getApiTeamService();
 }
 
 /**


### PR DESCRIPTION
## Summary
- refactor team API routes to use `createApiHandler`
- inject TeamService via service container
- update service container and config interfaces for team service
- adjust unit tests for new auth middleware mocks

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_683f5e12a9c8833185ea9abd3b1aea12