### PR TITLE
Migrate avatar & settings routes to service injection

### DIFF
--- a/app/api/profile/avatar/route.ts
+++ b/app/api/profile/avatar/route.ts
@@ -6,13 +6,10 @@ import {
   createSuccessResponse,
   createNoContentResponse,
 } from '@/lib/api/common';
-import { withErrorHandling } from '@/middleware/error-handling';
-import { withValidation } from '@/middleware/validation';
-import { withRouteAuth } from '@/middleware/auth';
+import { createApiHandler, emptySchema } from '@/lib/api/route-helpers';
+import type { UserService } from '@/core/user/interfaces';
 
 import { createUserUpdateFailedError } from '@/lib/api/user/error-handler';
-
-import { getApiUserService } from '@/services/user/factory';
 
 // Schema for avatar upload request body (supports both custom uploads and predefined avatars)
 const AvatarUploadSchema = z.object({
@@ -45,11 +42,11 @@ async function handleGetAvatars() {
 }
 
 async function handleUploadAvatar(
-  req: NextRequest,
+  _req: NextRequest,
   userId: string,
-  data: z.infer<typeof AvatarUploadSchema>
+  data: z.infer<typeof AvatarUploadSchema>,
+  userService: UserService
 ) {
-  const userService = getApiUserService();
   let avatarUrl: string | undefined;
 
   if (data.avatarId) {
@@ -104,8 +101,7 @@ async function handleUploadAvatar(
   });
 }
 
-async function handleDeleteAvatar(userId: string) {
-  const userService = getApiUserService();
+async function handleDeleteAvatar(userId: string, userService: UserService) {
   const result = await userService.deleteProfilePicture(userId);
   if (!result.success) {
     throw createUserUpdateFailedError(result.error);
@@ -113,21 +109,22 @@ async function handleDeleteAvatar(userId: string) {
   return createNoContentResponse();
 }
 
-export async function GET(request: NextRequest) {
-  return withErrorHandling(handleGetAvatars, request);
-}
+export const GET = createApiHandler(
+  emptySchema,
+  async () => handleGetAvatars(),
+  { requireAuth: false }
+);
 
-export async function POST(request: NextRequest) {
-  return withErrorHandling(
-    (req) =>
-      withRouteAuth((r, auth) => withValidation(AvatarUploadSchema, (r2, data) => handleUploadAvatar(r2, auth.userId!, data), r), req),
-    request
-  );
-}
+export const POST = createApiHandler(
+  AvatarUploadSchema,
+  async (req, { userId }, data, services) =>
+    handleUploadAvatar(req, userId!, data, services.user),
+  { requireAuth: true }
+);
 
-export async function DELETE(request: NextRequest) {
-  return withErrorHandling(
-    (req) => withRouteAuth((r, auth) => handleDeleteAvatar(auth.userId!), req),
-    request
-  );
-}
+export const DELETE = createApiHandler(
+  emptySchema,
+  async (_req, { userId }, _data, services) =>
+    handleDeleteAvatar(userId!, services.user),
+  { requireAuth: true }
+);


### PR DESCRIPTION
## Summary
- refactor `/api/profile/avatar` route to use `createApiHandler`
- refactor `/api/settings` route to new service container approach
- update related API tests to configure services for auth/user mocks

## Testing
- `npx vitest run --coverage` *(fails: Adapter 'user' not registered, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_683f61a7da848331b025f9f645b007d6