### PR TITLE
refactor team routes to new handler pattern

### DIFF
--- a/app/api/team/route.ts
+++ b/app/api/team/route.ts
@@ -1,47 +1,40 @@
-import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { getApiTeamService } from '@/services/team/factory';
+import { createApiHandler, emptySchema } from '@/lib/api/route-helpers';
 import {
-  createMiddlewareChain,
-  errorHandlingMiddleware,
-  routeAuthMiddleware,
-  validationMiddleware
-} from '@/middleware/createMiddlewareChain';
-import type { RouteAuthContext } from '@/middleware/auth';
+  createSuccessResponse,
+  createCreatedResponse,
+  ApiError,
+  ERROR_CODES
+} from '@/lib/api/common';
+import type { AuthContext, ServiceContainer } from '@/core/config/interfaces';
 
 const CreateTeamSchema = z.object({
   name: z.string().min(1),
   description: z.string().optional()
 });
 
-async function handleGet(_req: NextRequest, auth: RouteAuthContext) {
-  const service = getApiTeamService();
-  const teams = await service.getUserTeams(auth.userId!);
-  return NextResponse.json({ teams });
+async function handleGet(
+  _req: Request,
+  auth: AuthContext,
+  _data: unknown,
+  services: ServiceContainer
+) {
+  const teams = await services.team.getUserTeams(auth.userId!);
+  return createSuccessResponse({ teams });
 }
 
 async function handlePost(
-  _req: NextRequest,
-  auth: RouteAuthContext,
-  data: z.infer<typeof CreateTeamSchema>
+  _req: Request,
+  auth: AuthContext,
+  data: z.infer<typeof CreateTeamSchema>,
+  services: ServiceContainer
 ) {
-  const result = await getApiTeamService().createTeam(auth.userId!, data);
+  const result = await services.team.createTeam(auth.userId!, data);
   if (!result.success || !result.team) {
-    return NextResponse.json({ error: result.error || 'Failed to create team' }, { status: 400 });
+    throw new ApiError(ERROR_CODES.INVALID_REQUEST, result.error || 'Failed to create team', 400);
   }
-  return NextResponse.json({ team: result.team }, { status: 201 });
+  return createCreatedResponse({ team: result.team });
 }
 
-const getMiddleware = createMiddlewareChain([
-  errorHandlingMiddleware(),
-  routeAuthMiddleware()
-]);
-
-const postMiddleware = createMiddlewareChain([
-  errorHandlingMiddleware(),
-  routeAuthMiddleware(),
-  validationMiddleware(CreateTeamSchema)
-]);
-
-export const GET = getMiddleware(handleGet);
-export const POST = postMiddleware(handlePost);
+export const GET = createApiHandler(emptySchema, handleGet, { requireAuth: true });
+export const POST = createApiHandler(CreateTeamSchema, handlePost, { requireAuth: true });


### PR DESCRIPTION
## Summary
- migrate /api/team routes to service-injected `createApiHandler`

## Testing
- `npx vitest run --coverage` *(fails: Adapter not registered, act warnings, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_683f621a53248331af2059be4db01c45