### PR TITLE
Refactor profile avatar and settings routes

### DIFF
--- a/app/api/settings/__tests__/route.test.ts
+++ b/app/api/settings/__tests__/route.test.ts
@@ -1,20 +1,34 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { GET, PATCH } from '../route';
-import { getApiUserService } from '@/services/user/factory';
-import { withRouteAuth } from '@/middleware/auth';
+import {
+  configureServices,
+  resetServiceContainer,
+} from '@/lib/config/service-container';
+import type { UserService } from '@/core/user/interfaces';
+import type { AuthService } from '@/core/auth/interfaces';
 import createMockUserService from '@/tests/mocks/user.service.mock';
 import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
 
-vi.mock('@/services/user/factory', () => ({ getApiUserService: vi.fn() }));
-vi.mock('@/middleware/auth', () => ({
-  withRouteAuth: vi.fn((handler: any) => async (req: any) => handler(req, { userId: 'user-1', role: 'user', permissions: [] })),
+// Mock the service error handler to avoid compliance config issues
+vi.mock('@/services/common/service-error-handler', () => ({
+  logServiceError: vi.fn(),
+  handleServiceError: vi.fn(),
+  withErrorHandling: vi.fn((fn) => fn),
+  safeQuery: vi.fn(),
+  validateAndExecute: vi.fn(),
 }));
 
-const service = createMockUserService();
+const service: UserService = createMockUserService();
+const authService: Partial<AuthService> = { getCurrentUser: vi.fn() };
 
 beforeEach(() => {
   vi.clearAllMocks();
-  (getApiUserService as unknown as vi.Mock).mockReturnValue(service);
+  resetServiceContainer();
+  (authService.getCurrentUser as any).mockResolvedValue({ id: 'user-1' });
+  configureServices({
+    userService: service,
+    authService: authService as AuthService,
+  });
 });
 
 describe('/api/settings GET', () => {

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,11 +1,7 @@
-import { type NextRequest } from 'next/server';
 import { z } from 'zod';
-
+import type { UserService } from '@/core/user/interfaces';
 import { createSuccessResponse } from '@/lib/api/common';
-import { withErrorHandling } from '@/middleware/error-handling';
-import { withAuthRequest } from '@/middleware/auth';
-import { withValidation } from '@/middleware/validation';
-import { getApiUserService } from '@/services/user/factory';
+import { createApiHandler, emptySchema } from '@/lib/api/route-helpers';
 import { userPreferencesSchema } from '@/types/database';
 import { mapUserServiceError } from '@/lib/api/user/error-handler';
 
@@ -13,18 +9,16 @@ const UpdateSchema = userPreferencesSchema
   .omit({ id: true, userId: true, createdAt: true, updatedAt: true })
   .partial();
 
-async function handleGet(_req: NextRequest, userId: string) {
-  const userService = getApiUserService();
+async function handleGet(userId: string, userService: UserService) {
   const prefs = await userService.getUserPreferences(userId);
   return createSuccessResponse(prefs);
 }
 
 async function handlePatch(
-  _req: NextRequest,
   userId: string,
-  data: z.infer<typeof UpdateSchema>
+  data: z.infer<typeof UpdateSchema>,
+  userService: UserService
 ) {
-  const userService = getApiUserService();
   const result = await userService.updateUserPreferences(userId, data as any);
   if (!result.success || !result.preferences) {
     throw mapUserServiceError(new Error(result.error || 'update failed'));
@@ -32,19 +26,24 @@ async function handlePatch(
   return createSuccessResponse(result.preferences);
 }
 
-export async function GET(request: NextRequest) {
-  return withErrorHandling(
-    (req) => withAuthRequest(req, (r, ctx) => handleGet(r, ctx.userId)),
-    request
-  );
-}
+export const GET = createApiHandler(
+  emptySchema,
+  async (_req, { userId }, _data, services) => {
+    if (!userId) {
+      throw new Error('User ID is required');
+    }
+    return handleGet(userId, services.user);
+  },
+  { requireAuth: true }
+);
 
-export async function PATCH(request: NextRequest) {
-  return withErrorHandling(
-    (req) =>
-      withAuthRequest(req, (r, ctx) =>
-        withValidation(UpdateSchema, (r2, data) => handlePatch(r2, ctx.userId, data), r)
-      ),
-    request
-  );
-}
+export const PATCH = createApiHandler(
+  UpdateSchema,
+  async (_req, { userId }, data, services) => {
+    if (!userId) {
+      throw new Error('User ID is required');
+    }
+    return handlePatch(userId, data, services.user);
+  },
+  { requireAuth: true }
+);


### PR DESCRIPTION
## Summary
- switch `/profile/avatar` and `/settings` API routes to `createApiHandler`
- update corresponding tests to use service container

## Testing
- `npx vitest run --coverage` *(fails: Adapter 'permission' not registered, among other errors)*

------
https://chatgpt.com/codex/tasks/task_b_683f625899448331bfadf9300a30588a