### PR TITLE
Refactor team API routes

### DIFF
--- a/app/api/team/[teamId]/route.ts
+++ b/app/api/team/[teamId]/route.ts
@@ -1,75 +1,57 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { z } from 'zod';
-import { getApiTeamService } from '@/services/team/factory';
-import {
-  createMiddlewareChain,
-  errorHandlingMiddleware,
-  routeAuthMiddleware,
-  validationMiddleware
-} from '@/middleware/createMiddlewareChain';
-import type { RouteAuthContext } from '@/middleware/auth';
+import { createApiHandler, emptySchema } from '@/lib/api/route-helpers';
+import { createSuccessResponse, ApiError, ERROR_CODES } from '@/lib/api/common';
 
 const UpdateTeamSchema = z.object({
   name: z.string().optional(),
-  description: z.string().optional()
+  description: z.string().optional(),
 });
 
-async function handleGet(
-  _req: NextRequest,
-  _auth: RouteAuthContext,
-  _data: unknown,
-  { params }: { params: { teamId: string } }
-) {
-  const service = getApiTeamService();
-  const team = await service.getTeam(params.teamId);
-  if (!team) {
-    return NextResponse.json({ error: 'Team not found' }, { status: 404 });
-  }
-  return NextResponse.json({ team });
-}
-
-async function handlePatch(
-  _req: NextRequest,
-  _auth: RouteAuthContext,
-  data: z.infer<typeof UpdateTeamSchema>,
-  { params }: { params: { teamId: string } }
-) {
-  const result = await getApiTeamService().updateTeam(params.teamId, data);
-  if (!result.success || !result.team) {
-    return NextResponse.json({ error: result.error || 'Failed to update team' }, { status: 400 });
-  }
-  return NextResponse.json({ team: result.team });
-}
-
-async function handleDelete(
-  _req: NextRequest,
-  _auth: RouteAuthContext,
-  _data: unknown,
-  { params }: { params: { teamId: string } }
-) {
-  const result = await getApiTeamService().deleteTeam(params.teamId);
-  if (!result.success) {
-    return NextResponse.json({ error: result.error || 'Failed to delete team' }, { status: 400 });
-  }
-  return NextResponse.json({ success: true });
-}
-
-const baseMiddleware = createMiddlewareChain([
-  errorHandlingMiddleware(),
-  routeAuthMiddleware()
-]);
-
-const patchMiddleware = createMiddlewareChain([
-  errorHandlingMiddleware(),
-  routeAuthMiddleware(),
-  validationMiddleware(UpdateTeamSchema)
-]);
-
 export const GET = (req: NextRequest, ctx: { params: { teamId: string } }) =>
-  baseMiddleware((r, auth) => handleGet(r, auth, undefined, ctx))(req);
+  createApiHandler(
+    emptySchema,
+    async (_request, { userId }, _data, services) => {
+      if (!services.team) {
+        throw new ApiError(ERROR_CODES.NOT_IMPLEMENTED, 'Team service not available');
+      }
+      const team = await services.team.getTeam(ctx.params.teamId);
+      if (!team) {
+        throw new ApiError(ERROR_CODES.NOT_FOUND, 'Team not found', 404);
+      }
+      return createSuccessResponse({ team });
+    },
+    { requireAuth: true }
+  )(req as any);
 
 export const PATCH = (req: NextRequest, ctx: { params: { teamId: string } }) =>
-  patchMiddleware((r, auth, data) => handlePatch(r, auth, data, ctx))(req);
+  createApiHandler(
+    UpdateTeamSchema,
+    async (_request, { userId }, data, services) => {
+      if (!services.team) {
+        throw new ApiError(ERROR_CODES.NOT_IMPLEMENTED, 'Team service not available');
+      }
+      const result = await services.team.updateTeam(ctx.params.teamId, data);
+      if (!result.success || !result.team) {
+        throw new ApiError(ERROR_CODES.INVALID_REQUEST, result.error || 'Failed to update team', 400);
+      }
+      return createSuccessResponse({ team: result.team });
+    },
+    { requireAuth: true }
+  )(req as any);
 
 export const DELETE = (req: NextRequest, ctx: { params: { teamId: string } }) =>
-  baseMiddleware((r, auth) => handleDelete(r, auth, undefined, ctx))(req);
+  createApiHandler(
+    emptySchema,
+    async (_request, { userId }, _data, services) => {
+      if (!services.team) {
+        throw new ApiError(ERROR_CODES.NOT_IMPLEMENTED, 'Team service not available');
+      }
+      const result = await services.team.deleteTeam(ctx.params.teamId);
+      if (!result.success) {
+        throw new ApiError(ERROR_CODES.INVALID_REQUEST, result.error || 'Failed to delete team', 400);
+      }
+      return createSuccessResponse({ success: true });
+    },
+    { requireAuth: true }
+  )(req as any);

--- a/app/api/team/__tests__/route.test.ts
+++ b/app/api/team/__tests__/route.test.ts
@@ -1,39 +1,42 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import { GET, POST } from '../route';
-import { getApiTeamService } from '@/services/team/factory';
-import { withRouteAuth } from '@/middleware/auth';
+import { configureServices, resetServiceContainer } from '@/lib/config/service-container';
+import type { TeamService } from '@/core/team/interfaces';
+import type { AuthService } from '@/core/auth/interfaces';
 
-vi.mock('@/services/team/factory', () => ({
-  getApiTeamService: vi.fn()
-}));
-vi.mock('@/middleware/auth', () => ({
-  withRouteAuth: vi.fn((handler: any) => async (req: any) => handler(req, { userId: 'u1', role: 'user' }))
-}));
 
 describe('team API', () => {
-  const service = {
+  const mockTeamService: Partial<TeamService> = {
     getUserTeams: vi.fn(async () => []),
-    createTeam: vi.fn(async () => ({ success: true, team: { id: 't' } }))
-  } as any;
+    createTeam: vi.fn(async () => ({ success: true, team: { id: 't' } })),
+  };
+  const mockAuthService: Partial<AuthService> = {
+    getCurrentUser: vi.fn(),
+  };
 
   beforeEach(() => {
-    vi.mocked(getApiTeamService).mockReturnValue(service);
     vi.clearAllMocks();
+    resetServiceContainer();
+    (mockAuthService.getCurrentUser as any).mockResolvedValue({ id: 'u1' });
+    configureServices({
+      teamService: mockTeamService as TeamService,
+      authService: mockAuthService as AuthService,
+    });
   });
 
   it('GET returns teams', async () => {
-    const req = new NextRequest('http://test');
+    const req = new NextRequest('http://test', { headers: { authorization: 'Bearer token' } });
     const res = await GET(req as any);
     expect(res.status).toBe(200);
-    expect(service.getUserTeams).toHaveBeenCalledWith('u1');
+    expect(mockTeamService.getUserTeams).toHaveBeenCalledWith('u1');
   });
 
   it('POST creates team', async () => {
-    const req = new NextRequest('http://test', { method: 'POST', body: JSON.stringify({ name: 'My Team' }) });
+    const req = new NextRequest('http://test', { method: 'POST', body: JSON.stringify({ name: 'My Team' }), headers: { authorization: 'Bearer token' } });
     (req as any).json = async () => ({ name: 'My Team' });
     const res = await POST(req as any);
     expect(res.status).toBe(201);
-    expect(service.createTeam).toHaveBeenCalled();
+    expect(mockTeamService.createTeam).toHaveBeenCalled();
   });
 });

--- a/app/api/team/members/route.ts
+++ b/app/api/team/members/route.ts
@@ -1,15 +1,9 @@
-import { type NextRequest } from 'next/server';
+import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/database/prisma';
 import { z } from 'zod';
 import { createSuccessResponse, ApiError, ERROR_CODES } from '@/lib/api/common';
-import { getApiTeamService } from '@/services/team/factory';
-import {
-  createMiddlewareChain,
-  errorHandlingMiddleware,
-  routeAuthMiddleware,
-  validationMiddleware
-} from '@/middleware/createMiddlewareChain';
-import type { RouteAuthContext } from '@/middleware/auth';
+import { createApiHandler } from '@/lib/api/route-helpers';
+import type { AuthContext } from '@/core/config/interfaces';
 import { Permission } from '@/lib/rbac/roles';
 
 const querySchema = z.object({
@@ -28,20 +22,10 @@ const addMemberSchema = z.object({
 });
 
 async function handleTeamMembers(
-  req: NextRequest,
-  auth: RouteAuthContext,
-  data?: z.infer<typeof querySchema>
+  _req: NextRequest,
+  auth: AuthContext,
+  params: z.infer<typeof querySchema>
 ) {
-  let params;
-  
-  if (data) {
-    // New approach: validated data is passed from middleware
-    params = data;
-  } else {
-    // Legacy approach: parse and validate query params manually
-    const query = Object.fromEntries(new URL(req.url).searchParams.entries());
-    params = querySchema.parse(query);
-  }
   
   const { page, limit, search, status, sortBy, sortOrder } = params;
   const skip = (page - 1) * limit;
@@ -155,8 +139,9 @@ async function handleTeamMembers(
 
 async function handleAddMember(
   _req: NextRequest,
-  auth: RouteAuthContext,
-  data: z.infer<typeof addMemberSchema>
+  _auth: AuthContext,
+  data: z.infer<typeof addMemberSchema>,
+  services: any
 ) {
   const license = await prisma.teamLicense.findUnique({
     where: { id: data.teamId },
@@ -170,24 +155,30 @@ async function handleAddMember(
       400,
     );
   }
-  const service = getApiTeamService();
-  const result = await service.addTeamMember(data.teamId, data.userId, data.role);
+  if (!services.team) {
+    throw new ApiError(ERROR_CODES.NOT_IMPLEMENTED, 'Team service not available');
+  }
+  const result = await services.team.addTeamMember(data.teamId, data.userId, data.role);
   if (!result.success || !result.member) {
     throw new ApiError(ERROR_CODES.INVALID_REQUEST, result.error || 'Failed');
   }
   return createSuccessResponse(result.member, 201);
 }
 
-const getMiddleware = createMiddlewareChain([
-  errorHandlingMiddleware(),
-  routeAuthMiddleware({ requiredPermissions: [Permission.VIEW_TEAM_MEMBERS] })
-]);
+export const GET = createApiHandler(
+  querySchema,
+  handleTeamMembers,
+  {
+    requireAuth: true,
+    requiredPermissions: [Permission.VIEW_TEAM_MEMBERS],
+  }
+);
 
-const postMiddleware = createMiddlewareChain([
-  errorHandlingMiddleware(),
-  routeAuthMiddleware({ requiredPermissions: [Permission.INVITE_TEAM_MEMBER] }),
-  validationMiddleware(addMemberSchema)
-]);
-
-export const GET = getMiddleware(handleTeamMembers);
-export const POST = postMiddleware(handleAddMember);
+export const POST = createApiHandler(
+  addMemberSchema,
+  handleAddMember,
+  {
+    requireAuth: true,
+    requiredPermissions: [Permission.INVITE_TEAM_MEMBER],
+  }
+);


### PR DESCRIPTION
## Summary
- refactor team routes to use `createApiHandler`
- inject `teamService` via service container
- update team API tests for new handler

## Testing
- `npx vitest run --coverage` *(fails: Adapter 'user' not registered)*

------
https://chatgpt.com/codex/tasks/task_b_683f627f7db48331b7b0fd3c672b2b47