### PR TITLE
Migrate company API routes to service container

### DIFF
--- a/app/api/company/domains/[id]/verify-check/route.ts
+++ b/app/api/company/domains/[id]/verify-check/route.ts
@@ -1,27 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { getServiceSupabase } from "@/lib/database/supabase";
-import { getApiCompanyService } from "@/services/company/factory";
 import { type RouteAuthContext } from "@/middleware/auth";
-import {
-  createMiddlewareChain,
-  errorHandlingMiddleware,
-  routeAuthMiddleware,
-  rateLimitMiddleware,
-} from "@/middleware/createMiddlewareChain";
+import { createApiHandler } from "@/lib/api/route-helpers";
+import { createSuccessResponse } from "@/lib/api/common";
 import dns from "dns/promises";
 
 const supabaseService = getServiceSupabase();
 
-const middleware = createMiddlewareChain([
-  rateLimitMiddleware(),
-  errorHandlingMiddleware(),
-  routeAuthMiddleware(),
-]);
 
 async function handlePost(
   _request: NextRequest,
   params: { id: string },
   auth: RouteAuthContext,
+  services: any
 ) {
   try {
     const userId = auth.userId!;
@@ -37,8 +29,7 @@ async function handlePost(
       return NextResponse.json({ error: "Domain not found." }, { status: 404 });
     }
 
-    const companyService = getApiCompanyService();
-    const profile = await companyService.getProfileByUserId(userId);
+    const profile = await services.addressService.getProfileByUserId(userId);
     if (!profile || profile.id !== domainRecord.company_id) {
       return NextResponse.json(
         { error: "You do not have permission to verify this domain." },
@@ -130,4 +121,8 @@ async function handlePost(
 }
 
 export const POST = (req: NextRequest, ctx: { params: { id: string } }) =>
-  middleware((r, auth) => handlePost(r, ctx.params, auth))(req);
+  createApiHandler(
+    z.object({}),
+    (r, a, d, services) => handlePost(r, ctx.params, a, services),
+    { requireAuth: true }
+  )(req);

--- a/app/api/company/validate/registration/route.ts
+++ b/app/api/company/validate/registration/route.ts
@@ -1,10 +1,9 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getServiceSupabase } from '@/lib/database/supabase';
-import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
-import { withRouteAuth, type RouteAuthContext } from '@/middleware/auth';
-import { withErrorHandling } from '@/middleware/error-handling';
+import { createApiHandler } from '@/lib/api/route-helpers';
+import { createSuccessResponse } from '@/lib/api/common';
 
 const ValidationRequestSchema = z.object({
   registrationNumber: z.string().min(1),
@@ -51,8 +50,12 @@ const countryValidators: Record<string, (registrationNumber: string) => Promise<
   // Add more countries here as needed
 };
 
-async function handlePost(request: NextRequest, auth: RouteAuthContext) {
-  // 1. Rate Limiting
+async function handlePost(
+  request: NextRequest,
+  auth: { userId?: string },
+  data: ValidationRequest,
+  services: any
+) {
   const isRateLimited = await checkRateLimit(request);
   if (isRateLimited) {
     return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
@@ -61,26 +64,12 @@ async function handlePost(request: NextRequest, auth: RouteAuthContext) {
   try {
     const supabaseService = getServiceSupabase();
     const userId = auth.userId!;
-    const companyService = getApiCompanyService();
-    const companyProfile = await companyService.getProfileByUserId(userId);
+    const companyProfile = await services.addressService.getProfileByUserId(userId);
     if (!companyProfile) {
       return NextResponse.json({ error: 'Company profile not found' }, { status: 404 });
     }
 
-    // 3. Parse and Validate Body
-    let body: ValidationRequest;
-    try {
-      body = await request.json();
-    } catch (e) {
-      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
-    }
-
-    const parseResult = ValidationRequestSchema.safeParse(body);
-    if (!parseResult.success) {
-      return NextResponse.json({ error: 'Validation failed', details: parseResult.error.format() }, { status: 400 });
-    }
-    
-    const { registrationNumber, countryCode } = parseResult.data;
+    const { registrationNumber, countryCode } = data;
 
     const validator = countryValidators[countryCode.toUpperCase()];
     let validationResult: ValidationResult;
@@ -105,7 +94,7 @@ async function handlePost(request: NextRequest, auth: RouteAuthContext) {
       })
       .eq('user_id', userId);
 
-    return NextResponse.json({
+    return createSuccessResponse({
       status: validationResult.status,
       message: validationResult.message,
       details: validationResult.details,
@@ -117,5 +106,8 @@ async function handlePost(request: NextRequest, auth: RouteAuthContext) {
   }
 }
 
-export const POST = (req: NextRequest) =>
-  withErrorHandling((r) => withRouteAuth(handlePost, r), req);
+export const POST = createApiHandler(
+  ValidationRequestSchema,
+  (req, auth, data, services) => handlePost(req, auth, data, services),
+  { requireAuth: true }
+);


### PR DESCRIPTION
## Summary
- refactor company API endpoints to use `createApiHandler`
- inject services via service container and use `addressService`
- update success responses with `createSuccessResponse`
- remove old middleware chains

## Testing
- `npm run test:coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_684064a87b848331a4c28d47b2e9b5a2