### PR TITLE
Migrate role permission routes to service container

### DIFF
--- a/app/api/roles/[roleId]/permissions/__tests__/route.test.ts
+++ b/app/api/roles/[roleId]/permissions/__tests__/route.test.ts
@@ -1,41 +1,48 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GET, POST, DELETE } from '../route';
+import { configureServices, resetServiceContainer } from '@/lib/config/service-container';
+import type { PermissionService } from '@/core/permission/interfaces';
+import type { AuthService } from '@/core/auth/interfaces';
+import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
 
-const mockService = {
+const mockService: Partial<PermissionService> = {
   getRolePermissions: vi.fn(),
   addPermissionToRole: vi.fn(),
   removePermissionFromRole: vi.fn(),
 };
-vi.mock('@/services/permission/factory', () => ({
-  getApiPermissionService: () => mockService,
-}));
+const mockAuth: Partial<AuthService> = {
+  getCurrentUser: vi.fn().mockResolvedValue({ id: 'u1' }),
+};
 
 beforeEach(() => {
-  vi.resetAllMocks();
+  vi.clearAllMocks();
+  resetServiceContainer();
+  configureServices({
+    permissionService: mockService as PermissionService,
+    authService: mockAuth as AuthService,
+  });
 });
 
 describe('role permissions API', () => {
   it('GET returns permissions', async () => {
     mockService.getRolePermissions.mockResolvedValue(['p1']);
-    const res = await GET(new Request('http://test') as any, { params: { roleId: '1' } } as any);
+    const res = await GET(createAuthenticatedRequest('GET', 'http://test/api/roles/1/permissions'));
     expect(res.status).toBe(200);
     expect(mockService.getRolePermissions).toHaveBeenCalledWith('1');
   });
 
   it('POST assigns permission', async () => {
-    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({ permission: 'p1' }) });
-    (req as any).json = async () => ({ permission: 'p1' });
+    const req = createAuthenticatedRequest('POST', 'http://test/api/roles/1/permissions', { permission: 'p1' });
     mockService.addPermissionToRole.mockResolvedValue({ id: '123' });
-    const res = await POST(req as any, { params: { roleId: '1' } } as any);
+    const res = await POST(req as any);
     expect(res.status).toBe(200);
     expect(mockService.addPermissionToRole).toHaveBeenCalled();
   });
 
   it('DELETE removes permission', async () => {
-    const req = new Request('http://test', { method: 'DELETE', body: JSON.stringify({ permission: 'p1' }) });
-    (req as any).json = async () => ({ permission: 'p1' });
+    const req = createAuthenticatedRequest('DELETE', 'http://test/api/roles/1/permissions', { permission: 'p1' });
     mockService.removePermissionFromRole.mockResolvedValue(true);
-    const res = await DELETE(req as any, { params: { roleId: '1' } } as any);
+    const res = await DELETE(req as any);
     expect(res.status).toBe(204);
     expect(mockService.removePermissionFromRole).toHaveBeenCalledWith('1', 'p1');
   });

--- a/app/api/users/[id]/permissions/route.ts
+++ b/app/api/users/[id]/permissions/route.ts
@@ -1,24 +1,33 @@
 import { type NextRequest } from 'next/server';
+import { z } from 'zod';
 import { createSuccessResponse } from '@/lib/api/common';
-import { withErrorHandling } from '@/middleware/error-handling';
-import { createProtectedHandler } from '@/middleware/permissions';
-import { getApiPermissionService } from '@/services/permission/factory';
+import { createApiHandler } from '@/lib/api/route-helpers';
 import { PermissionValues, type Permission } from '@/core/permission/models';
 
 // GET /api/users/[id]/permissions - Get effective permissions for a user
 
-async function handleGet(userId: string) {
-  const service = getApiPermissionService();
-  const roles = await service.getUserRoles(userId);
+function getUserId(req: NextRequest): string {
+  const url = new URL(req.url);
+  return url.pathname.split('/')[3];
+}
+
+async function handleGet(
+  req: NextRequest,
+  _auth: any,
+  _data: unknown,
+  services: any,
+) {
+  const userId = getUserId(req);
+  const roles = await services.permission.getUserRoles(userId);
   const permissions = new Set<Permission>();
   for (const role of roles) {
-    const roleData = await service.getRoleById(role.roleId);
+    const roleData = await services.permission.getRoleById(role.roleId);
     roleData?.permissions.forEach((p) => permissions.add(p));
   }
   return createSuccessResponse({ permissions: Array.from(permissions) });
 }
 
-export const GET = createProtectedHandler(
-  (req, ctx) => withErrorHandling(() => handleGet(ctx.params.id), req),
-  PermissionValues.MANAGE_ROLES,
-);
+export const GET = createApiHandler(z.object({}), handleGet, {
+  requireAuth: true,
+  requiredPermissions: [PermissionValues.MANAGE_ROLES],
+});


### PR DESCRIPTION
## Summary
- migrate role and permission routes to createApiHandler service pattern
- update route tests to configure service container and authenticated requests

## Testing
- `npm run test:coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_6840695260888331abdb845c78246c3d