### PR TITLE
Migrate permission auth routes to service container

### DIFF
--- a/app/api/auth/check-permissions/__tests__/route.test.ts
+++ b/app/api/auth/check-permissions/__tests__/route.test.ts
@@ -1,31 +1,34 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../route';
-import { getApiPermissionService } from '@/services/permission/factory';
+import { configureServices, resetServiceContainer } from '@/lib/config/service-container';
+import type { PermissionService } from '@/core/permission/interfaces';
+import type { AuthService } from '@/core/auth/interfaces';
+import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
 
-vi.mock('@/middleware/with-security', () => ({ withSecurity: (h: any) => h }));
-vi.mock('@/services/permission/factory', () => ({ getApiPermissionService: vi.fn() }));
-vi.mock('@/middleware/createMiddlewareChain', async () => {
-  const actual = await vi.importActual<any>('@/middleware/createMiddlewareChain');
-  return {
-    ...actual,
-    routeAuthMiddleware: vi.fn(() => (handler: any) => (req: any, _ctx?: any, data?: any) => handler(req, { userId: 'u1' }, data)),
-  };
-});
+vi.mock('@/services/permission/factory', () => ({}));
+vi.mock('@/services/auth/factory', () => ({}));
 
-const mockService = { hasPermission: vi.fn() };
+const mockService: Partial<PermissionService> = { hasPermission: vi.fn() };
+const mockAuth: Partial<AuthService> = {
+  getCurrentUser: vi.fn().mockResolvedValue({ id: 'u1' }),
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
-  (getApiPermissionService as unknown as vi.Mock).mockReturnValue(mockService);
-  mockService.hasPermission.mockResolvedValue(true);
+  resetServiceContainer();
+  configureServices({
+    permissionService: mockService as PermissionService,
+    authService: mockAuth as AuthService,
+  });
+  vi.mocked(mockService.hasPermission).mockResolvedValue(true);
 });
 
 function createReq(body: any) {
-  return new Request('http://test/api/auth/check-permissions', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body)
-  });
+  return createAuthenticatedRequest(
+    'POST',
+    'http://test/api/auth/check-permissions',
+    body,
+  );
 }
 
 describe('POST /api/auth/check-permissions', () => {

--- a/app/api/auth/check-permissions/route.ts
+++ b/app/api/auth/check-permissions/route.ts
@@ -1,16 +1,9 @@
 import { type NextRequest } from 'next/server';
 import { z } from 'zod';
-import { withSecurity } from '@/middleware/with-security';
-import {
-  createMiddlewareChain,
-  errorHandlingMiddleware,
-  routeAuthMiddleware,
-  validationMiddleware
-} from '@/middleware/createMiddlewareChain';
+import { createApiHandler } from '@/lib/api/route-helpers';
 import { createSuccessResponse } from '@/lib/api/common';
-import { getApiPermissionService } from '@/services/permission/factory';
 import { permissionCheckCache } from '@/lib/auth/permission-cache';
-import type { RouteAuthContext } from '@/middleware/auth';
+import type { AuthContext, ServiceContainer } from '@/core/config/interfaces';
 
 const CheckSchema = z.object({
   permission: z.string().min(1),
@@ -24,21 +17,21 @@ const BatchSchema = z.object({
 
 async function handleCheckPermissions(
   _req: NextRequest,
-  auth: RouteAuthContext,
-  data: z.infer<typeof BatchSchema>
+  auth: AuthContext,
+  data: z.infer<typeof BatchSchema>,
+  services: ServiceContainer,
 ) {
   if (!auth.userId) {
     return createSuccessResponse({
-      results: data.checks.map(c => ({ permission: c.permission, hasPermission: false }))
+      results: data.checks.map((c) => ({ permission: c.permission, hasPermission: false })),
     });
   }
 
-  const service = getApiPermissionService();
   const results = await Promise.all(
     data.checks.map(async (c) => {
       const key = `${auth.userId}:${c.permission}:${c.resourceType ?? ''}:${c.resourceId ?? ''}`;
       const allowed = await permissionCheckCache.getOrCreate(key, () =>
-        service.hasPermission(auth.userId!, c.permission as any)
+        services.permission!.hasPermission(auth.userId!, c.permission as any)
       );
       return { permission: c.permission, hasPermission: allowed };
     })
@@ -47,12 +40,8 @@ async function handleCheckPermissions(
   return createSuccessResponse({ results });
 }
 
-const middleware = createMiddlewareChain([
-  errorHandlingMiddleware(),
-  routeAuthMiddleware(),
-  validationMiddleware(BatchSchema)
-]);
-
-export const POST = withSecurity((req: NextRequest) =>
-  middleware((r, auth, data) => handleCheckPermissions(r, auth, data))(req)
+export const POST = createApiHandler(
+  BatchSchema,
+  handleCheckPermissions,
+  { requireAuth: true },
 );


### PR DESCRIPTION
## Summary
- migrate auth permission check routes to `createApiHandler`
- switch to injected `services.permission` service
- update permission resource routes to new pattern
- adjust tests for new service container pattern

## Testing
- `npx vitest run --coverage` *(fails: Adapter 'user' not registered)*

------
https://chatgpt.com/codex/tasks/task_b_68406cea6d208331900db9d35bcf2415