### PR TITLE
Add default file storage service

### DIFF
--- a/src/services/storage/DefaultFileStorageService.ts
+++ b/src/services/storage/DefaultFileStorageService.ts
@@ -1,0 +1,66 @@
+import type {
+  StorageAdapter,
+  FileUploadOptions,
+  FileUploadResult,
+  FileDeleteResult,
+} from '@/core/storage/interfaces';
+import type { FileStorageService } from '@/core/storage/services';
+
+/**
+ * Default implementation of the FileStorageService.
+ *
+ * This service acts as an orchestrator around a {@link StorageAdapter}
+ * instance. It forwards calls to the underlying adapter and can contain
+ * additional business logic such as path generation or bucket selection.
+ */
+export class DefaultFileStorageService implements FileStorageService {
+  constructor(private readonly storageAdapter: StorageAdapter) {}
+
+  /**
+   * Upload a file buffer to the configured storage provider.
+   */
+  async uploadFile(
+    _bucketName: string,
+    filePath: string,
+    fileBuffer: ArrayBuffer,
+    options?: FileUploadOptions,
+  ): Promise<FileUploadResult> {
+    try {
+      const blob = new Blob([fileBuffer]);
+      return await this.storageAdapter.upload(blob, filePath, options);
+    } catch (err: any) {
+      return { success: false, error: err.message || 'Upload failed' };
+    }
+  }
+
+  /**
+   * Delete a file from the configured storage provider.
+   */
+  async deleteFile(
+    _bucketName: string,
+    filePath: string,
+  ): Promise<FileDeleteResult> {
+    try {
+      return await this.storageAdapter.delete(filePath);
+    } catch (err: any) {
+      return { success: false, error: err.message || 'Delete failed' };
+    }
+  }
+
+  /**
+   * Get a public URL for a stored file if available.
+   */
+  async getFileUrl(
+    _bucketName: string,
+    filePath: string,
+  ): Promise<string | null> {
+    try {
+      const url = this.storageAdapter.getPublicUrl(filePath);
+      return url || null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+export default DefaultFileStorageService;

--- a/src/services/storage/__tests__/DefaultFileStorageService.test.ts
+++ b/src/services/storage/__tests__/DefaultFileStorageService.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DefaultFileStorageService } from '../DefaultFileStorageService';
+import type { StorageAdapter } from '@/core/storage/interfaces';
+
+function createAdapterMock(): StorageAdapter {
+  return {
+    upload: vi.fn(),
+    delete: vi.fn(),
+    getPublicUrl: vi.fn(),
+  };
+}
+
+describe('DefaultFileStorageService', () => {
+  it('delegates file upload to adapter', async () => {
+    const adapter = createAdapterMock();
+    (adapter.upload as any).mockResolvedValue({ success: true, path: 'p' });
+    const service = new DefaultFileStorageService(adapter);
+    const res = await service.uploadFile('bucket', 'p', new ArrayBuffer(4));
+    expect(adapter.upload).toHaveBeenCalled();
+    expect(res).toEqual({ success: true, path: 'p' });
+  });
+
+  it('returns error when adapter upload throws', async () => {
+    const adapter = createAdapterMock();
+    (adapter.upload as any).mockRejectedValue(new Error('fail'));
+    const service = new DefaultFileStorageService(adapter);
+    const res = await service.uploadFile('b', 'p', new ArrayBuffer(1));
+    expect(res.success).toBe(false);
+    expect(res.error).toBe('fail');
+  });
+
+  it('delegates delete to adapter', async () => {
+    const adapter = createAdapterMock();
+    (adapter.delete as any).mockResolvedValue({ success: true });
+    const service = new DefaultFileStorageService(adapter);
+    const res = await service.deleteFile('b', 'p');
+    expect(adapter.delete).toHaveBeenCalledWith('p');
+    expect(res.success).toBe(true);
+  });
+
+  it('returns error when delete throws', async () => {
+    const adapter = createAdapterMock();
+    (adapter.delete as any).mockRejectedValue(new Error('oops'));
+    const service = new DefaultFileStorageService(adapter);
+    const res = await service.deleteFile('b', 'p');
+    expect(res.success).toBe(false);
+    expect(res.error).toBe('oops');
+  });
+
+  it('delegates getFileUrl to adapter', async () => {
+    const adapter = createAdapterMock();
+    (adapter.getPublicUrl as any).mockReturnValue('url');
+    const service = new DefaultFileStorageService(adapter);
+    const res = await service.getFileUrl('b', 'p');
+    expect(adapter.getPublicUrl).toHaveBeenCalledWith('p');
+    expect(res).toBe('url');
+  });
+});


### PR DESCRIPTION
## Summary
- implement `DefaultFileStorageService`
- add accompanying unit tests

## Testing
- `npx vitest run --coverage src/services/storage/__tests__/DefaultFileStorageService.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_684076a3775083319264e50fc8d24e03