### PR TITLE
Migrate address and 2fa routes to service injection

### DIFF
--- a/app/api/2fa/setup/route.ts
+++ b/app/api/2fa/setup/route.ts
@@ -1,11 +1,10 @@
-import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
+import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { authenticator } from 'otplib';
 import * as qrcode from 'qrcode';
 import { TwoFactorMethod } from '@/types/2fa';
-import { getApi2FAService } from '@/services/two-factor/factory';
-import { getApiAuthService } from '@/services/auth/factory';
+import { createApiHandler } from '@/lib/api/route-helpers';
+import { createSuccessResponse } from '@/lib/api/common';
 
 // Request schema
 const setupRequestSchema = z.object({
@@ -14,43 +13,22 @@ const setupRequestSchema = z.object({
   email: z.string().optional(),
 });
 
-export async function POST(request: Request): Promise<NextResponse> {
-  try {
-    // Parse and validate request body
-    const body = await request.json();
-    const { method } = setupRequestSchema.parse(body);
+export const POST = createApiHandler(
+  setupRequestSchema,
+  async (request: NextRequest, authContext, data, services) => {
+    try {
+      const user = authContext.user!;
+      const { method, phone, email } = data;
 
-    // Get service instances from factories
-    const authService = getApiAuthService();
-    const twoFactorService = getApi2FAService();
-    
-    // Verify user authentication
-    const cookieStore = cookies();
-    const user = await authService.getCurrentUser(cookieStore);
-
-    if (!user) {
-      return NextResponse.json(
-        { error: 'Authentication required' },
-        { status: 401 }
-      );
-    }
-
-    switch (method) {
+      switch (method) {
       case TwoFactorMethod.TOTP: {
         try {
-          // Use the two-factor service to set up TOTP
-          const setupResult = await twoFactorService.setupTOTP(user.id);
-          
-          // Generate a QR code for easy setup
+          const setupResult = await services.twoFactor!.setupTOTP(user.id);
           const appName = 'User Management';
           const accountName = user.email || user.id;
           const otpAuthUrl = authenticator.keyuri(accountName, appName, setupResult.secret);
           const qrCodeDataUrl = await qrcode.toDataURL(otpAuthUrl);
-          
-          return NextResponse.json({
-            secret: setupResult.secret,
-            qrCode: qrCodeDataUrl
-          });
+          return createSuccessResponse({ secret: setupResult.secret, qrCode: qrCodeDataUrl });
         } catch (error) {
           console.error('Failed to set up TOTP:', error);
           return NextResponse.json(
@@ -59,24 +37,18 @@ export async function POST(request: Request): Promise<NextResponse> {
           );
         }
       }
-      
+
       case TwoFactorMethod.SMS: {
-        // Accept phone number from request (if not present in user metadata)
-        let phone = user.user_metadata?.mfaPhone;
-        if (!phone) {
-          phone = body.phone;
-        }
-        if (!phone) {
+        const resolvedPhone = user.user_metadata?.mfaPhone || phone;
+        if (!resolvedPhone) {
           return NextResponse.json(
             { error: 'Phone number is required for SMS MFA setup.' },
             { status: 400 }
           );
         }
-
         try {
-          // Use the two-factor service to set up SMS
-          await twoFactorService.setupSMS(user.id, phone);
-          return NextResponse.json({ success: true });
+          await services.twoFactor!.setupSMS(user.id, resolvedPhone);
+          return createSuccessResponse({ success: true });
         } catch (error) {
           console.error('Failed to set up SMS MFA:', error);
           return NextResponse.json(
@@ -85,24 +57,18 @@ export async function POST(request: Request): Promise<NextResponse> {
           );
         }
       }
-      
+
       case TwoFactorMethod.EMAIL: {
-        // Accept email from request or use user's email
-        let email = user.user_metadata?.mfaEmail;
-        if (!email) {
-          email = body.email || user.email;
-        }
-        if (!email) {
+        const resolvedEmail = user.user_metadata?.mfaEmail || email || user.email;
+        if (!resolvedEmail) {
           return NextResponse.json(
             { error: 'Email address is required for Email MFA setup.' },
             { status: 400 }
           );
         }
-
         try {
-          // Use the two-factor service to set up Email MFA
-          await twoFactorService.setupEmail(user.id, email);
-          return NextResponse.json({ success: true, testid: 'email-mfa-setup-success' });
+          await services.twoFactor!.setupEmail(user.id, resolvedEmail);
+          return createSuccessResponse({ success: true, testid: 'email-mfa-setup-success' });
         } catch (error) {
           console.error('Failed to set up Email MFA:', error);
           return NextResponse.json(
@@ -111,18 +77,20 @@ export async function POST(request: Request): Promise<NextResponse> {
           );
         }
       }
-      
-      default:
-        return NextResponse.json(
-          { error: `Unsupported MFA method: ${method}` },
-          { status: 400 }
-        );
+
+        default:
+          return NextResponse.json(
+            { error: `Unsupported MFA method: ${method}` },
+            { status: 400 }
+          );
+      }
+    } catch (error) {
+      console.error('Error in 2FA setup:', error);
+      return NextResponse.json(
+        { error: error instanceof Error ? error.message : 'An unexpected error occurred' },
+        { status: 500 }
+      );
     }
-  } catch (error) {
-    console.error('Error in 2FA setup:', error);
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'An unexpected error occurred' },
-      { status: 500 }
-    );
-  }
-} 
+  },
+  { requireAuth: true, includeUser: true }
+);

--- a/app/api/addresses/[id]/__tests__/route.test.ts
+++ b/app/api/addresses/[id]/__tests__/route.test.ts
@@ -1,109 +1,60 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { NextRequest, NextResponse } from 'next/server';
 import { GET, PUT, DELETE } from '../route';
-import { getApiAddressService } from '@/services/address/factory';
+import { configureServices, resetServiceContainer } from '@/lib/config/service-container';
+import type { AddressService } from '@/core/address/interfaces';
+import type { AuthService } from '@/core/auth/interfaces';
+import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
 
-vi.mock('@/services/address/factory', () => ({
-  getApiAddressService: vi.fn(),
-}));
+const service: AddressService = {
+  getAddress: vi.fn(async () => ({ id: '1', fullName: 'John Doe' })),
+  updateAddress: vi.fn(async (id, data) => ({ id, ...data })),
+  deleteAddress: vi.fn(async () => {}),
+  getAddresses: vi.fn(async () => []),
+  createAddress: vi.fn(async (a: any) => a),
+  setDefaultAddress: vi.fn(async () => {}),
+} as any;
 
-vi.mock('@/middleware/with-security', () => ({
-  withSecurity: vi.fn((handler: any) => handler),
-}));
+const authService: Partial<AuthService> = {
+  getCurrentUser: vi.fn().mockResolvedValue({ id: 'u1' }),
+};
 
-vi.mock('@/middleware/rate-limit', () => ({
-  withRateLimit: vi.fn((req: any, handler: any) => handler(req)),
-}));
-
-vi.mock('@/middleware/auth', () => ({
-  withRouteAuth: vi.fn((handler: any, req: any) => {
-    // Mock successful authentication
-    return handler(req, { userId: 'u1', role: 'user', permissions: [] });
-  }),
-}));
-
-vi.mock('@/lib/api/common', () => ({
-  createSuccessResponse: vi.fn((data) => NextResponse.json(data, { status: 200 })),
-  createNoContentResponse: vi.fn(() => new NextResponse(null, { status: 204 })),
-  createValidationError: vi.fn((message, details) => {
-    const error = new Error(message);
-    (error as any).details = details;
-    (error as any).status = 400;
-    return error;
-  }),
-  createUnauthorizedError: vi.fn(() => {
-    const error = new Error('Unauthorized');
-    (error as any).status = 401;
-    return error;
-  }),
-}));
-
-vi.mock('@/core/address/validation', () => ({
-  addressSchema: {
-    partial: vi.fn(() => ({
-      safeParse: vi.fn((data) => {
-        // Valid if data is present and postalCode is not a number
-        if (data && typeof data.postalCode !== 'number') {
-          return { success: true, data };
-        }
-        return { 
-          success: false, 
-          error: { 
-            flatten: () => ({ fieldErrors: { postalCode: ['Invalid type'] } }) 
-          }
-        };
-      }),
-    })),
-  },
-}));
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetServiceContainer();
+  configureServices({
+    addressService: service as AddressService,
+    authService: authService as AuthService,
+  });
+});
 
 describe('[id] address API', () => {
-  interface AddressService {
-    getAddress: (id: string, userId: string) => Promise<Record<string, unknown>>;
-    updateAddress: (id: string, data: Record<string, unknown>, userId: string) => Promise<Record<string, unknown>>;
-    deleteAddress: (id: string, userId: string) => Promise<void>;
-  }
-
-  const service: AddressService = {
-    getAddress: vi.fn(async () => ({ id: '1', fullName: 'John Doe' })),
-    updateAddress: vi.fn(async (id, data) => ({ id, ...data })),
-    deleteAddress: vi.fn(async () => {}),
-  };
-
-  beforeEach(() => {
-    vi.mocked(getApiAddressService).mockReturnValue(service);
-    vi.clearAllMocks();
-  });
-
   it('GET returns address', async () => {
-    const req = new NextRequest('http://test');
-    const res = await GET(req, { params: { id: '1' } });
+    const req = createAuthenticatedRequest('GET', 'http://test/api/addresses/1');
+    const res = await GET(req);
     expect(res.status).toBe(200);
     expect(service.getAddress).toHaveBeenCalledWith('1', 'u1');
   });
 
   it('PUT updates address with valid data', async () => {
     const updateData = { fullName: 'John Updated' };
-    const req = new NextRequest('http://test', { method: 'PUT', body: JSON.stringify(updateData) });
-    req.json = vi.fn().mockResolvedValue(updateData);
-    
-    const res = await PUT(req, { params: { id: '1' } });
+    const req = createAuthenticatedRequest('PUT', 'http://test/api/addresses/1', updateData);
+    (req as any).json = vi.fn().mockResolvedValue(updateData);
+    const res = await PUT(req);
     expect(res.status).toBe(200);
     expect(service.updateAddress).toHaveBeenCalledWith('1', updateData, 'u1');
   });
 
   it('PUT validates input and rejects invalid data', async () => {
-    const invalidData = { postalCode: 123 }; // Should be string, not number
-    const req = new NextRequest('http://test', { method: 'PUT', body: JSON.stringify(invalidData) });
-    req.json = vi.fn().mockResolvedValue(invalidData);
-    
-    // The validation error should be thrown and handled
-    await expect(PUT(req, { params: { id: '1' } })).rejects.toThrow();
+    const invalidData = { postalCode: 123 };
+    const req = createAuthenticatedRequest('PUT', 'http://test/api/addresses/1', invalidData);
+    (req as any).json = vi.fn().mockResolvedValue(invalidData);
+    const res = await PUT(req);
+    expect(res.status).toBe(400);
   });
 
   it('DELETE deletes address', async () => {
-    const req = new NextRequest('http://test', { method: 'DELETE' });
-    const res = await DELETE(req, { params: { id: '1' } });
+    const req = createAuthenticatedRequest('DELETE', 'http://test/api/addresses/1');
+    const res = await DELETE(req);
     expect(res.status).toBe(204);
     expect(service.deleteAddress).toHaveBeenCalledWith('1', 'u1');
   });

--- a/app/api/addresses/default/[id]/__tests__/route.test.ts
+++ b/app/api/addresses/default/[id]/__tests__/route.test.ts
@@ -1,52 +1,36 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { NextRequest, NextResponse } from 'next/server';
 import { POST } from '../route';
-import { getApiPersonalAddressService } from '@/services/address/factory';
+import { configureServices, resetServiceContainer } from '@/lib/config/service-container';
+import type { AddressService } from '@/core/address/interfaces';
+import type { AuthService } from '@/core/auth/interfaces';
+import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
 
-vi.mock('@/services/address/factory', () => ({
-  getApiAddressService: vi.fn(),
-  getApiPersonalAddressService: vi.fn(),
-}));
+const service: AddressService = {
+  setDefaultAddress: vi.fn(async () => {}),
+  getAddresses: vi.fn(async () => []),
+  createAddress: vi.fn(async (a: any) => a),
+  getAddress: vi.fn(async () => ({})),
+  updateAddress: vi.fn(async () => ({})),
+  deleteAddress: vi.fn(async () => {}),
+} as any;
 
-vi.mock('@/middleware/with-security', () => ({
-  withSecurity: vi.fn((handler: any) => {
-    return (req: NextRequest) => {
-      // Call the handler with the request
-      return handler(req);
-    };
-  }),
-}));
+const authService: Partial<AuthService> = {
+  getCurrentUser: vi.fn().mockResolvedValue({ id: 'u1' }),
+};
 
-vi.mock('@/middleware/auth', () => ({
-  withRouteAuth: vi.fn((handler: any, req: any) => {
-    // Mock successful authentication
-    return handler(req, { userId: 'u1', role: 'user', permissions: [] });
-  }),
-}));
-
-vi.mock('@/lib/api/common', () => ({
-  createNoContentResponse: vi.fn(() => new NextResponse(null, { status: 204 })),
-}));
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetServiceContainer();
+  configureServices({
+    addressService: service as AddressService,
+    authService: authService as AuthService,
+  });
+});
 
 describe('default address API', () => {
-  const service = { 
-    setDefaultAddress: vi.fn(async () => {}),
-    // Add other required methods to avoid type errors
-    getAddresses: vi.fn(async () => []),
-    createAddress: vi.fn(async (a: any) => a),
-    getAddress: vi.fn(async () => ({})),
-    updateAddress: vi.fn(async () => ({})),
-    deleteAddress: vi.fn(async () => {}),
-  } as any;
-
-  beforeEach(() => {
-    vi.mocked(getApiPersonalAddressService).mockReturnValue(service);
-    vi.clearAllMocks();
-  });
-
   it('sets default address', async () => {
-    const req = new NextRequest('http://test', { method: 'POST' });
-    const res = await POST(req, { params: { id: '1' } });
+    const req = createAuthenticatedRequest('POST', 'http://test/api/addresses/default/1');
+    const res = await POST(req);
     expect(res.status).toBe(204);
     expect(service.setDefaultAddress).toHaveBeenCalledWith('1', 'u1');
   });

--- a/app/api/addresses/default/[id]/route.ts
+++ b/app/api/addresses/default/[id]/route.ts
@@ -1,16 +1,18 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getApiPersonalAddressService } from '@/services/address/factory';
-import { withRouteAuth } from '@/middleware/auth';
-import { withSecurity } from '@/middleware/with-security';
+import { type NextRequest } from 'next/server';
+import { createApiHandler, emptySchema } from '@/lib/api/route-helpers';
 import { createNoContentResponse } from '@/lib/api/common';
 
-async function handlePost(_req: NextRequest, id: string, userId: string): Promise<NextResponse> {
-  const service = getApiPersonalAddressService();
-  await service.setDefaultAddress(id, userId);
-  return createNoContentResponse();
+function extractAddressId(url: string): string {
+  const parts = new URL(url).pathname.split('/');
+  return parts[parts.length - 1] || '';
 }
 
-export const POST = (req: NextRequest, { params }: { params: { id: string } }) =>
-  withSecurity(r =>
-    withRouteAuth((s, ctx) => handlePost(s, params.id, ctx.userId!), r)
-  )(req);
+export const POST = createApiHandler(
+  emptySchema,
+  async (req: NextRequest, auth, _data, services) => {
+    const id = extractAddressId(req.url);
+    await services.addressService.setDefaultAddress(id, auth.userId!);
+    return createNoContentResponse();
+  },
+  { requireAuth: true }
+);


### PR DESCRIPTION
## Summary
- switch address detail and default routes to `createApiHandler`
- inject services instead of using factories
- migrate 2FA setup route to service injection
- update related tests

## Testing
- `npm run test:coverage` *(fails: Adapter errors)*

------
https://chatgpt.com/codex/tasks/task_b_684075f9c1608331bf31b1fb595774d7