### PR TITLE
Refactor API key & GDPR factories to use service container

### DIFF
--- a/src/services/api-keys/factory.ts
+++ b/src/services/api-keys/factory.ts
@@ -6,10 +6,14 @@
  */
 
 import { ApiKeyService } from '@/core/api-key/interfaces';
-import { UserManagementConfiguration } from '@/core/config';
 import type { IApiKeyDataProvider } from '@/core/api-keys';
 import { AdapterRegistry } from '@/adapters/registry';
+import { getServiceContainer } from '@/lib/config/service-container';
 import { DefaultApiKeysService } from './default-api-keys.service';
+
+export interface ApiKeysServiceOptions {
+  reset?: boolean;
+}
 
 // Singleton instance for API routes
 let apiKeyServiceInstance: ApiKeyService | null = null;
@@ -19,15 +23,18 @@ let apiKeyServiceInstance: ApiKeyService | null = null;
  * 
  * @returns Configured ApiKeyService instance
  */
-export function getApiKeyService(): ApiKeyService {
-  if (!apiKeyServiceInstance) {
-    apiKeyServiceInstance =
-      UserManagementConfiguration.getServiceProvider('apiKeyService') as ApiKeyService | undefined;
+export function getApiKeyService(options: ApiKeysServiceOptions = {}): ApiKeyService {
+  if (options.reset) {
+    apiKeyServiceInstance = null;
+  }
 
-    if (!apiKeyServiceInstance) {
-      const provider = AdapterRegistry.getInstance().getAdapter<IApiKeyDataProvider>('apiKey');
-      apiKeyServiceInstance = new DefaultApiKeysService(provider);
-    }
+  if (!apiKeyServiceInstance) {
+    apiKeyServiceInstance = getServiceContainer().apiKey || null;
+  }
+
+  if (!apiKeyServiceInstance) {
+    const provider = AdapterRegistry.getInstance().getAdapter<IApiKeyDataProvider>('apiKey');
+    apiKeyServiceInstance = new DefaultApiKeysService(provider);
   }
 
   return apiKeyServiceInstance;
@@ -36,6 +43,6 @@ export function getApiKeyService(): ApiKeyService {
 /**
  * Temporary alias for backwards compatibility with older route imports.
  */
-export function getApiKeysService(): ApiKeyService {
-  return getApiKeyService();
+export function getApiKeysService(options: ApiKeysServiceOptions = {}): ApiKeyService {
+  return getApiKeyService(options);
 }

--- a/src/services/gdpr/__tests__/factory.test.ts
+++ b/src/services/gdpr/__tests__/factory.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 let AdapterRegistry: typeof import('@/adapters/registry').AdapterRegistry;
-let UserManagementConfiguration: typeof import('@/core/config').UserManagementConfiguration;
+let configureServices: typeof import('@/lib/config/service-container').configureServices;
+let resetServiceContainer: typeof import('@/lib/config/service-container').resetServiceContainer;
 
 let getApiGdprService: typeof import('../factory').getApiGdprService;
 let DefaultGdprService: typeof import('../default-gdpr.service').DefaultGdprService;
@@ -9,16 +10,16 @@ describe('getApiGdprService', () => {
   beforeEach(async () => {
     vi.resetModules();
     ({ AdapterRegistry } = await import('@/adapters/registry'));
-    ({ UserManagementConfiguration } = await import('@/core/config'));
+    ({ configureServices, resetServiceContainer } = await import('@/lib/config/service-container'));
     (AdapterRegistry as any).instance = null;
-    UserManagementConfiguration.reset();
+    resetServiceContainer();
     ({ getApiGdprService } = await import('../factory'));
     ({ DefaultGdprService } = await import('../default-gdpr.service'));
   });
 
   it('returns configured service if registered', () => {
     const service = {} as any;
-    UserManagementConfiguration.configureServiceProviders({ gdprService: service });
+    configureServices({ gdprService: service });
     expect(getApiGdprService()).toBe(service);
     expect(getApiGdprService()).toBe(service);
   });
@@ -26,8 +27,18 @@ describe('getApiGdprService', () => {
   it('creates default service with adapter when not configured', () => {
     const adapter = {} as any;
     AdapterRegistry.getInstance().registerAdapter('gdpr', adapter);
-    const service = getApiGdprService();
+    const service = getApiGdprService({ reset: true });
     expect(service).toBeInstanceOf(DefaultGdprService);
     expect(getApiGdprService()).toBe(service);
+  });
+
+  it('allows resetting the cached instance', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('gdpr', adapter);
+    const first = getApiGdprService({ reset: true });
+    const second = getApiGdprService();
+    const third = getApiGdprService({ reset: true });
+    expect(first).toBe(second);
+    expect(third).not.toBe(first);
   });
 });

--- a/src/services/gdpr/factory.ts
+++ b/src/services/gdpr/factory.ts
@@ -6,10 +6,14 @@
  */
 
 import { GdprService } from '@/core/gdpr/interfaces';
-import { UserManagementConfiguration } from '@/core/config';
 import type { IGdprDataProvider } from '@/core/gdpr';
 import { AdapterRegistry } from '@/adapters/registry';
+import { getServiceContainer } from '@/lib/config/service-container';
 import { DefaultGdprService } from './default-gdpr.service';
+
+export interface GdprServiceOptions {
+  reset?: boolean;
+}
 
 // Singleton instance for API routes
 let gdprServiceInstance: GdprService | null = null;
@@ -19,13 +23,18 @@ let gdprServiceInstance: GdprService | null = null;
  * 
  * @returns Configured GdprService instance
  */
-export function getApiGdprService(): GdprService {
+export function getApiGdprService(options: GdprServiceOptions = {}): GdprService {
+  if (options.reset) {
+    gdprServiceInstance = null;
+  }
+
   if (!gdprServiceInstance) {
-    gdprServiceInstance = UserManagementConfiguration.getServiceProvider('gdprService') as GdprService | undefined;
-    if (!gdprServiceInstance) {
-      const gdprDataProvider = AdapterRegistry.getInstance().getAdapter<IGdprDataProvider>('gdpr');
-      gdprServiceInstance = new DefaultGdprService(gdprDataProvider);
-    }
+    gdprServiceInstance = getServiceContainer().gdpr || null;
+  }
+
+  if (!gdprServiceInstance) {
+    const gdprDataProvider = AdapterRegistry.getInstance().getAdapter<IGdprDataProvider>('gdpr');
+    gdprServiceInstance = new DefaultGdprService(gdprDataProvider);
   }
 
   return gdprServiceInstance;
@@ -34,6 +43,6 @@ export function getApiGdprService(): GdprService {
 /**
  * Temporary alias for backwards compatibility with older route imports.
  */
-export function getApiGDPRService(): GdprService {
-  return getApiGdprService();
+export function getApiGDPRService(options: GdprServiceOptions = {}): GdprService {
+  return getApiGdprService(options);
 }


### PR DESCRIPTION
## Summary
- refactor api-keys and GDPR service factories to use `getServiceContainer`
- add resettable options to both factories
- create default services directly in the service container to avoid circular deps
- update related tests

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_68407cacbe88833183a14c7e96e66433