### PR TITLE
Update feature service factories

### DIFF
--- a/src/services/session/factory.ts
+++ b/src/services/session/factory.ts
@@ -9,14 +9,62 @@ import { SessionService } from '@/core/session/interfaces';
 import type { ISessionDataProvider } from '@/core/session';
 import { AdapterRegistry } from '@/adapters/registry';
 import { DefaultSessionService } from './default-session.service';
+import { getServiceContainer, getServiceConfiguration } from '@/lib/config/service-container';
+
+export interface ApiSessionServiceOptions {
+  /** Reset the cached instance, used in tests */
+  reset?: boolean;
+}
+
+const GLOBAL_CACHE_KEY = '__UM_SESSION_SERVICE__';
+
+let cachedService: SessionService | null = null;
+let building = false;
 
 /**
  * Get the configured session service instance for API routes
  * 
  * @returns Configured SessionService instance
  */
-export function getApiSessionService(): SessionService {
-  const sessionDataProvider =
-    AdapterRegistry.getInstance().getAdapter<ISessionDataProvider>('session');
-  return new DefaultSessionService(sessionDataProvider);
+export function getApiSessionService(
+  options: ApiSessionServiceOptions = {}
+): SessionService | undefined {
+  if (options.reset) {
+    cachedService = null;
+    if (typeof globalThis !== 'undefined') {
+      delete (globalThis as any)[GLOBAL_CACHE_KEY];
+    }
+  }
+
+  if (!cachedService && typeof globalThis !== 'undefined') {
+    cachedService = (globalThis as any)[GLOBAL_CACHE_KEY] as SessionService | null;
+  }
+
+  if (!cachedService && !building) {
+    building = true;
+    const existing = getServiceContainer().session;
+    if (existing) {
+      cachedService = existing;
+    }
+    building = false;
+  }
+
+  if (!cachedService) {
+    const config = getServiceConfiguration();
+    if (config.featureFlags?.sessions === false) {
+      return undefined;
+    }
+
+    cachedService =
+      config.sessionService ??
+      new DefaultSessionService(
+        AdapterRegistry.getInstance().getAdapter<ISessionDataProvider>('session')
+      );
+  }
+
+  if (cachedService && typeof globalThis !== 'undefined') {
+    (globalThis as any)[GLOBAL_CACHE_KEY] = cachedService;
+  }
+
+  return cachedService;
 }

--- a/src/services/sso/factory.ts
+++ b/src/services/sso/factory.ts
@@ -9,14 +9,62 @@ import { SsoService } from '@/core/sso/interfaces';
 import type { ISsoDataProvider } from '@/core/sso';
 import { AdapterRegistry } from '@/adapters/registry';
 import { DefaultSsoService } from './default-sso.service';
+import { getServiceContainer, getServiceConfiguration } from '@/lib/config/service-container';
+
+export interface ApiSsoServiceOptions {
+  /** Reset the cached instance for testing */
+  reset?: boolean;
+}
+
+const GLOBAL_CACHE_KEY = '__UM_SSO_SERVICE__';
+
+let cachedService: SsoService | null = null;
+let building = false;
 
 /**
  * Get the configured SSO service instance for API routes
  * 
  * @returns Configured SsoService instance
  */
-export function getApiSsoService(): SsoService {
-  const ssoDataProvider =
-    AdapterRegistry.getInstance().getAdapter<ISsoDataProvider>('sso');
-  return new DefaultSsoService(ssoDataProvider);
+export function getApiSsoService(
+  options: ApiSsoServiceOptions = {}
+): SsoService | undefined {
+  if (options.reset) {
+    cachedService = null;
+    if (typeof globalThis !== 'undefined') {
+      delete (globalThis as any)[GLOBAL_CACHE_KEY];
+    }
+  }
+
+  if (!cachedService && typeof globalThis !== 'undefined') {
+    cachedService = (globalThis as any)[GLOBAL_CACHE_KEY] as SsoService | null;
+  }
+
+  if (!cachedService && !building) {
+    building = true;
+    const existing = getServiceContainer().sso;
+    if (existing) {
+      cachedService = existing;
+    }
+    building = false;
+  }
+
+  if (!cachedService) {
+    const config = getServiceConfiguration();
+    if (config.featureFlags?.sso === false) {
+      return undefined;
+    }
+
+    cachedService =
+      config.ssoService ??
+      new DefaultSsoService(
+        AdapterRegistry.getInstance().getAdapter<ISsoDataProvider>('sso')
+      );
+  }
+
+  if (cachedService && typeof globalThis !== 'undefined') {
+    (globalThis as any)[GLOBAL_CACHE_KEY] = cachedService;
+  }
+
+  return cachedService;
 }

--- a/src/services/team/__tests__/factory.test.ts
+++ b/src/services/team/__tests__/factory.test.ts
@@ -3,19 +3,25 @@ import { AdapterRegistry } from '@/adapters/registry';
 import { getApiTeamService } from '../factory';
 import { DefaultTeamService } from '../default-team.service';
 
+vi.mock('@/lib/config/service-container', () => ({
+  getServiceContainer: vi.fn(() => ({ team: undefined })),
+  getServiceConfiguration: vi.fn(() => ({ featureFlags: { teams: true } }))
+}));
+
 describe('getApiTeamService', () => {
   beforeEach(() => {
     vi.resetModules();
     (AdapterRegistry as any).instance = null;
+    delete (globalThis as any).__UM_TEAM_SERVICE__;
   });
 
-  it('returns new service instance using adapter from registry', () => {
+  it('caches instance using adapter from registry', () => {
     const adapter = {} as any;
     AdapterRegistry.getInstance().registerAdapter('team', adapter);
-    const service1 = getApiTeamService();
+    const service1 = getApiTeamService({ reset: true });
     const service2 = getApiTeamService();
     expect(service1).toBeInstanceOf(DefaultTeamService);
     expect(service2).toBeInstanceOf(DefaultTeamService);
-    expect(service1).not.toBe(service2);
+    expect(service1).toBe(service2);
   });
 });

--- a/src/services/team/factory.ts
+++ b/src/services/team/factory.ts
@@ -9,14 +9,62 @@ import { TeamService } from '@/core/team/interfaces';
 import type { ITeamDataProvider } from '@/core/team/ITeamDataProvider';
 import { DefaultTeamService } from './default-team.service';
 import { AdapterRegistry } from '@/adapters/registry';
+import { getServiceContainer, getServiceConfiguration } from '@/lib/config/service-container';
+
+export interface ApiTeamServiceOptions {
+  /** When true, resets the cached instance. Useful for tests */
+  reset?: boolean;
+}
+
+const GLOBAL_CACHE_KEY = '__UM_TEAM_SERVICE__';
+
+let cachedService: TeamService | null = null;
+let building = false;
 
 /**
  * Get the configured team service instance for API routes
  * 
  * @returns Configured TeamService instance
  */
-export function getApiTeamService(): TeamService {
-  const teamDataProvider =
-    AdapterRegistry.getInstance().getAdapter<ITeamDataProvider>('team');
-  return new DefaultTeamService(teamDataProvider);
+export function getApiTeamService(
+  options: ApiTeamServiceOptions = {}
+): TeamService | undefined {
+  if (options.reset) {
+    cachedService = null;
+    if (typeof globalThis !== 'undefined') {
+      delete (globalThis as any)[GLOBAL_CACHE_KEY];
+    }
+  }
+
+  if (!cachedService && typeof globalThis !== 'undefined') {
+    cachedService = (globalThis as any)[GLOBAL_CACHE_KEY] as TeamService | null;
+  }
+
+  if (!cachedService && !building) {
+    building = true;
+    const existing = getServiceContainer().team;
+    if (existing) {
+      cachedService = existing;
+    }
+    building = false;
+  }
+
+  if (!cachedService) {
+    const config = getServiceConfiguration();
+    if (config.featureFlags?.teams === false) {
+      return undefined;
+    }
+
+    cachedService =
+      config.teamService ??
+      new DefaultTeamService(
+        AdapterRegistry.getInstance().getAdapter<ITeamDataProvider>('team')
+      );
+  }
+
+  if (cachedService && typeof globalThis !== 'undefined') {
+    (globalThis as any)[GLOBAL_CACHE_KEY] = cachedService;
+  }
+
+  return cachedService;
 }


### PR DESCRIPTION
## Summary
- add caching, feature-flag checks, and service container support to Team, Session, and SSO service factories
- adjust TeamService factory unit test

## Testing
- `npx vitest run src/services/team/__tests__/factory.test.ts`
- `npx vitest run --coverage src/services/team/__tests__/factory.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_68407de9bddc8331a93f23740ac8ac31