### PR TITLE
Upgrade minimal factories to service container

### DIFF
--- a/src/services/company/__tests__/factory.test.ts
+++ b/src/services/company/__tests__/factory.test.ts
@@ -16,13 +16,21 @@ describe('getApiCompanyService', () => {
   it('returns configured service if registered', () => {
     const svc = {} as any;
     UserManagementConfiguration.configureServiceProviders({ companyService: svc });
-    expect(getApiCompanyService()).toBe(svc);
+    expect(getApiCompanyService({ reset: true })).toBe(svc);
     expect(getApiCompanyService()).toBe(svc);
   });
 
   it('creates default service when not configured', () => {
-    const service = getApiCompanyService();
+    const service = getApiCompanyService({ reset: true });
     expect(service).toBeInstanceOf(DefaultCompanyService);
     expect(getApiCompanyService()).toBe(service);
+  });
+
+  it('allows resetting the cached instance', () => {
+    const first = getApiCompanyService({ reset: true });
+    const second = getApiCompanyService();
+    const third = getApiCompanyService({ reset: true });
+    expect(first).toBe(second);
+    expect(third).not.toBe(first);
   });
 });

--- a/src/services/company/factory.ts
+++ b/src/services/company/factory.ts
@@ -1,13 +1,46 @@
+/**
+ * Company Service Factory for API routes.
+ *
+ * Provides a configured {@link CompanyService} instance with optional caching
+ * and reset functionality for tests.
+ */
 import { UserManagementConfiguration } from '@/core/config';
 import { DefaultCompanyService, type CompanyService } from './companyService';
+import { getServiceContainer } from '@/lib/config/service-container';
+
+/** Options for {@link getApiCompanyService}. */
+export interface ApiCompanyServiceOptions {
+  /** When true, clears the cached instance. */
+  reset?: boolean;
+}
 
 let companyServiceInstance: CompanyService | null = null;
+let constructing = false;
 
-export function getApiCompanyService(): CompanyService {
+export function getApiCompanyService(
+  options: ApiCompanyServiceOptions = {}
+): CompanyService {
+  if (options.reset) {
+    companyServiceInstance = null;
+  }
+
+  if (!companyServiceInstance && !constructing) {
+    constructing = true;
+    try {
+      const containerService = (getServiceContainer() as any).company as CompanyService | undefined;
+      if (containerService) {
+        companyServiceInstance = containerService;
+      }
+    } finally {
+      constructing = false;
+    }
+  }
+
   if (!companyServiceInstance) {
     companyServiceInstance =
       (UserManagementConfiguration.getServiceProvider('companyService') as CompanyService) ||
       new DefaultCompanyService();
   }
+
   return companyServiceInstance;
 }

--- a/src/services/consent/__tests__/factory.test.ts
+++ b/src/services/consent/__tests__/factory.test.ts
@@ -17,15 +17,25 @@ describe('getApiConsentService', () => {
   it('returns configured service if registered', () => {
     const svc = {} as any;
     UserManagementConfiguration.configureServiceProviders({ consentService: svc });
-    expect(getApiConsentService()).toBe(svc);
+    expect(getApiConsentService({ reset: true })).toBe(svc);
     expect(getApiConsentService()).toBe(svc);
   });
 
   it('creates default service with adapter when not configured', () => {
     const adapter = {} as any;
     AdapterRegistry.getInstance().registerAdapter('consent', adapter);
-    const service = getApiConsentService();
+    const service = getApiConsentService({ reset: true });
     expect(service).toBeInstanceOf(DefaultConsentService);
     expect(getApiConsentService()).toBe(service);
+  });
+
+  it('allows resetting the cached instance', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('consent', adapter);
+    const first = getApiConsentService({ reset: true });
+    const second = getApiConsentService();
+    const third = getApiConsentService({ reset: true });
+    expect(first).toBe(second);
+    expect(third).not.toBe(first);
   });
 });

--- a/src/services/consent/factory.ts
+++ b/src/services/consent/factory.ts
@@ -1,12 +1,44 @@
+/**
+ * Consent Service Factory for API routes.
+ *
+ * Returns a configured {@link ConsentService} instance. The instance is cached
+ * and can be reset, allowing tests to run in isolation.
+ */
 import { ConsentService } from '@/core/consent/interfaces';
 import { UserManagementConfiguration } from '@/core/config';
 import type { IConsentDataProvider } from '@/core/consent';
 import { AdapterRegistry } from '@/adapters/registry';
+import { getServiceContainer } from '@/lib/config/service-container';
 import { DefaultConsentService } from './default-consent.service';
 
-let consentServiceInstance: ConsentService | null = null;
+/** Options for {@link getApiConsentService}. */
+export interface ApiConsentServiceOptions {
+  /** When true, clears the cached instance. */
+  reset?: boolean;
+}
 
-export function getApiConsentService(): ConsentService {
+let consentServiceInstance: ConsentService | null = null;
+let constructing = false;
+
+export function getApiConsentService(
+  options: ApiConsentServiceOptions = {}
+): ConsentService {
+  if (options.reset) {
+    consentServiceInstance = null;
+  }
+
+  if (!consentServiceInstance && !constructing) {
+    constructing = true;
+    try {
+      const containerService = getServiceContainer().consent;
+      if (containerService) {
+        consentServiceInstance = containerService;
+      }
+    } finally {
+      constructing = false;
+    }
+  }
+
   if (!consentServiceInstance) {
     consentServiceInstance = UserManagementConfiguration.getServiceProvider('consentService') as ConsentService | undefined;
     if (!consentServiceInstance) {

--- a/src/services/organization/__tests__/factory.test.ts
+++ b/src/services/organization/__tests__/factory.test.ts
@@ -9,13 +9,22 @@ describe('getApiOrganizationService', () => {
     (AdapterRegistry as any).instance = null;
   });
 
-  it('returns new service instance using adapter from registry', () => {
+  it('creates service with adapter and caches instance', () => {
     const adapter = {} as any;
     AdapterRegistry.getInstance().registerAdapter('organization', adapter);
-    const svc1 = getApiOrganizationService();
+    const svc1 = getApiOrganizationService({ reset: true });
     const svc2 = getApiOrganizationService();
     expect(svc1).toBeInstanceOf(DefaultOrganizationService);
-    expect(svc2).toBeInstanceOf(DefaultOrganizationService);
-    expect(svc1).not.toBe(svc2);
+    expect(svc1).toBe(svc2);
+  });
+
+  it('allows resetting the cached instance', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('organization', adapter);
+    const first = getApiOrganizationService({ reset: true });
+    const second = getApiOrganizationService();
+    const third = getApiOrganizationService({ reset: true });
+    expect(first).toBe(second);
+    expect(third).not.toBe(first);
   });
 });

--- a/src/services/organization/factory.ts
+++ b/src/services/organization/factory.ts
@@ -1,9 +1,50 @@
+/**
+ * Organization Service Factory for API routes.
+ *
+ * Provides a configured {@link OrganizationService} instance used across API
+ * routes. The service instance is cached and can be reset between tests.
+ */
 import type { OrganizationService } from '@/core/organization/interfaces';
 import type { IOrganizationDataProvider } from '@/core/organization/IOrganizationDataProvider';
 import { AdapterRegistry } from '@/adapters/registry';
+import { getServiceContainer } from '@/lib/config/service-container';
 import { DefaultOrganizationService } from './default-organization.service';
 
-export function getApiOrganizationService(): OrganizationService {
-  const provider = AdapterRegistry.getInstance().getAdapter<IOrganizationDataProvider>('organization');
-  return new DefaultOrganizationService(provider);
+/** Options for {@link getApiOrganizationService}. */
+export interface ApiOrganizationServiceOptions {
+  /** When true, clears any cached instance (useful for testing). */
+  reset?: boolean;
+}
+
+let organizationServiceInstance: OrganizationService | null = null;
+let constructing = false;
+
+/**
+ * Get a configured organization service instance for API routes.
+ */
+export function getApiOrganizationService(
+  options: ApiOrganizationServiceOptions = {}
+): OrganizationService {
+  if (options.reset) {
+    organizationServiceInstance = null;
+  }
+
+  if (!organizationServiceInstance && !constructing) {
+    constructing = true;
+    try {
+      const containerService = getServiceContainer().organization;
+      if (containerService) {
+        organizationServiceInstance = containerService;
+      }
+    } finally {
+      constructing = false;
+    }
+  }
+
+  if (!organizationServiceInstance) {
+    const provider = AdapterRegistry.getInstance().getAdapter<IOrganizationDataProvider>('organization');
+    organizationServiceInstance = new DefaultOrganizationService(provider);
+  }
+
+  return organizationServiceInstance;
 }


### PR DESCRIPTION
## Summary
- integrate organization service factory with ServiceContainer and caching
- integrate company service factory with ServiceContainer and caching
- integrate consent service factory with ServiceContainer and caching
- update corresponding factory tests for singleton behaviour

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_68407e0b9e1c8331a3fa8f7f576bfe41