### PR TITLE
Integrate ServiceContainer for admin factory

### DIFF
--- a/src/services/admin/__tests__/factory.test.ts
+++ b/src/services/admin/__tests__/factory.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let AdapterRegistry: typeof import('@/adapters/registry').AdapterRegistry;
+let getApiAdminService: typeof import('../factory').getApiAdminService;
+let DefaultAdminService: typeof import('../default-admin.service').DefaultAdminService;
+let configureServices: typeof import('@/lib/config/service-container').configureServices;
+let resetServiceContainer: typeof import('@/lib/config/service-container').resetServiceContainer;
+
+describe('getApiAdminService', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ AdapterRegistry } = await import('@/adapters/registry'));
+    (AdapterRegistry as any).instance = null;
+    ({ configureServices, resetServiceContainer } = await import('@/lib/config/service-container'));
+    resetServiceContainer();
+    ({ getApiAdminService } = await import('../factory'));
+    ({ DefaultAdminService } = await import('../default-admin.service'));
+  });
+
+  it('returns configured service if registered in ServiceContainer', () => {
+    const svc = { searchUsers: vi.fn() } as any;
+    configureServices({ adminService: svc });
+    expect(getApiAdminService()).toBe(svc);
+    expect(getApiAdminService()).toBe(svc);
+  });
+
+  it('creates default service with adapter when not configured', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('admin', adapter);
+    const service = getApiAdminService({ reset: true });
+    expect(service).toBeInstanceOf(DefaultAdminService);
+    expect(getApiAdminService()).toBe(service);
+  });
+
+  it('supports reset option to clear cache', () => {
+    const svc1 = { searchUsers: vi.fn() } as any;
+    const svc2 = { searchUsers: vi.fn() } as any;
+    configureServices({ adminService: svc1 });
+    expect(getApiAdminService()).toBe(svc1);
+    configureServices({ adminService: svc2 });
+    // Still cached
+    expect(getApiAdminService()).toBe(svc1);
+    expect(getApiAdminService({ reset: true })).toBe(svc2);
+  });
+});


### PR DESCRIPTION
## Summary
- add ServiceContainer usage in admin service factory
- support instance reset for tests
- test factory behavior with host overrides and reset capability

## Testing
- `npm run test:coverage` *(fails: Adapter 'user' not registered...)*

------
https://chatgpt.com/codex/tasks/task_b_68407f052f888331b4794f75eeff4f90