### PR TITLE
Refactor CSRF & 2FA service factories

### DIFF
--- a/src/services/csrf/__tests__/factory.test.ts
+++ b/src/services/csrf/__tests__/factory.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { AdapterRegistry } from '@/adapters/registry';
 import { UserManagementConfiguration } from '@/core/config';
+import {
+  configureServices,
+  resetServiceContainer
+} from '@/lib/config/service-container';
 
 let getApiCsrfService: typeof import('../factory').getApiCsrfService;
 let DefaultCsrfService: typeof import('../default-csrf.service').DefaultCsrfService;
@@ -10,6 +14,7 @@ describe('getApiCsrfService', () => {
     vi.resetModules();
     (AdapterRegistry as any).instance = null;
     UserManagementConfiguration.reset();
+    resetServiceContainer();
     ({ getApiCsrfService } = await import('../factory'));
     ({ DefaultCsrfService } = await import('../default-csrf.service'));
   });
@@ -27,5 +32,24 @@ describe('getApiCsrfService', () => {
     const service = getApiCsrfService();
     expect(service).toBeInstanceOf(DefaultCsrfService);
     expect(getApiCsrfService()).toBe(service);
+  });
+
+  it('uses ServiceContainer override when configured', () => {
+    const svc = {} as any;
+    configureServices({ csrfService: svc });
+    const result = getApiCsrfService();
+    expect(result).toBe(svc);
+    expect(getApiCsrfService()).toBe(svc);
+  });
+
+  it('can reset cached instance', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('csrf', adapter);
+    const first = getApiCsrfService();
+    const second = getApiCsrfService();
+    expect(first).toBe(second);
+
+    const reset = getApiCsrfService({ reset: true });
+    expect(reset).not.toBe(first);
   });
 });

--- a/src/services/csrf/factory.ts
+++ b/src/services/csrf/factory.ts
@@ -10,8 +10,19 @@ import type { ICsrfDataProvider } from '@/core/csrf';
 import { DefaultCsrfService } from './default-csrf.service';
 import { AdapterRegistry } from '@/adapters/registry';
 import { UserManagementConfiguration } from '@/core/config';
+import {
+  getServiceContainer,
+  getServiceConfiguration
+} from '@/lib/config/service-container';
 
 // Singleton instance for API routes
+export interface ApiCsrfServiceOptions {
+  /** When true, forces creation of a new service instance */
+  reset?: boolean;
+}
+
+const GLOBAL_CACHE_KEY = '__UM_CSRF_SERVICE__';
+
 let csrfServiceInstance: CsrfService | null = null;
 
 /**
@@ -19,22 +30,61 @@ let csrfServiceInstance: CsrfService | null = null;
  * 
  * @returns Configured CsrfService instance
  */
-export function getApiCsrfService(): CsrfService {
-  if (!csrfServiceInstance) {
-    csrfServiceInstance =
-      UserManagementConfiguration.getServiceProvider('csrfService') as CsrfService | undefined;
-
-    if (!csrfServiceInstance) {
-      const csrfDataProvider = AdapterRegistry.getInstance().getAdapter<ICsrfDataProvider>('csrf');
-      csrfServiceInstance = new DefaultCsrfService(csrfDataProvider);
+export function getApiCsrfService(
+  options: ApiCsrfServiceOptions = {}
+): CsrfService {
+  if (options.reset) {
+    csrfServiceInstance = null;
+    if (typeof globalThis !== 'undefined') {
+      delete (globalThis as any)[GLOBAL_CACHE_KEY];
     }
   }
+
+  if (!csrfServiceInstance && typeof globalThis !== 'undefined') {
+    csrfServiceInstance = (globalThis as any)[GLOBAL_CACHE_KEY] as
+      | CsrfService
+      | null;
+  }
+
+  if (!csrfServiceInstance) {
+    const config = getServiceConfiguration();
+
+    if (config.csrfService) {
+      csrfServiceInstance = config.csrfService;
+    } else {
+      try {
+        csrfServiceInstance = getServiceContainer().csrf ?? null;
+      } catch {
+        // Service container not fully configured
+      }
+
+      if (!csrfServiceInstance) {
+        csrfServiceInstance =
+          UserManagementConfiguration.getServiceProvider(
+            'csrfService'
+          ) as CsrfService | null;
+
+        if (!csrfServiceInstance) {
+          const csrfDataProvider =
+            AdapterRegistry.getInstance().getAdapter<ICsrfDataProvider>('csrf');
+          csrfServiceInstance = new DefaultCsrfService(csrfDataProvider);
+        }
+      }
+    }
+
+    if (typeof globalThis !== 'undefined') {
+      (globalThis as any)[GLOBAL_CACHE_KEY] = csrfServiceInstance;
+    }
+  }
+
   return csrfServiceInstance;
 }
 
 /**
  * Temporary alias for backwards compatibility with older route imports.
  */
-export function getApiCSRFService(): CsrfService {
-  return getApiCsrfService();
+export function getApiCSRFService(
+  options: ApiCsrfServiceOptions = {}
+): CsrfService {
+  return getApiCsrfService(options);
 }


### PR DESCRIPTION
## Summary
- integrate two-factor and csrf factories with `ServiceContainer`
- add singleton caching and reset option
- update csrf factory tests

## Testing
- `npx vitest run --coverage` *(fails: ServerStorage is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_b_68407fb4da108331a8aaf088b59b554f