### PR TITLE
Integrate ServiceContainer with address service factory

### DIFF
--- a/src/services/address/__tests__/factory.test.ts
+++ b/src/services/address/__tests__/factory.test.ts
@@ -1,24 +1,48 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
+vi.mock('@/lib/config/service-container', () => {
+  let config: any = {};
+  let container: any = { address: undefined };
+  return {
+    getServiceContainer: vi.fn(() => container),
+    getServiceConfiguration: vi.fn(() => config),
+    configureServices: vi.fn((cfg: any) => {
+      config = { ...config, ...cfg };
+      if (cfg.addressService) {
+        container.address = cfg.addressService;
+      }
+    }),
+    resetServiceContainer: vi.fn(() => {
+      config = {};
+      container = { address: undefined };
+    })
+  };
+});
+
 let getApiAddressService: typeof import('../factory').getApiAddressService;
+let getApiPersonalAddressService: typeof import('../factory').getApiPersonalAddressService;
 let DefaultAddressService: typeof import('../default-address.service').DefaultAddressService;
 let AdapterRegistry: typeof import('@/adapters/registry').AdapterRegistry;
+let configureServices: typeof import('@/lib/config/service-container').configureServices;
+let resetServiceContainer: typeof import('@/lib/config/service-container').resetServiceContainer;
 let UserManagementConfiguration: typeof import('@/core/config').UserManagementConfiguration;
 
 describe('getApiAddressService', () => {
   beforeEach(async () => {
     vi.resetModules();
     ({ AdapterRegistry } = await import('@/adapters/registry'));
+    ({ configureServices, resetServiceContainer } = await import('@/lib/config/service-container'));
     ({ UserManagementConfiguration } = await import('@/core/config'));
     (AdapterRegistry as any).instance = null;
+    resetServiceContainer();
     UserManagementConfiguration.reset();
-    ({ getApiAddressService } = await import('../factory'));
+    ({ getApiAddressService, getApiPersonalAddressService } = await import('../factory'));
     ({ DefaultAddressService } = await import('../default-address.service'));
   });
 
   it('returns configured service if registered', () => {
     const svc = {} as any;
-    UserManagementConfiguration.configureServiceProviders({ addressService: svc });
+    configureServices({ addressService: svc });
     expect(getApiAddressService()).toBe(svc);
     expect(getApiAddressService()).toBe(svc);
   });
@@ -26,8 +50,57 @@ describe('getApiAddressService', () => {
   it('creates default service with adapter when not configured', () => {
     const adapter = {} as any;
     AdapterRegistry.getInstance().registerAdapter('address', adapter);
-    const service = getApiAddressService();
+    const service = getApiAddressService({ reset: true });
     expect(service).toBeInstanceOf(DefaultAddressService);
     expect(getApiAddressService()).toBe(service);
+  });
+
+  it('allows resetting the cached instance', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('address', adapter);
+    const first = getApiAddressService({ reset: true });
+    const second = getApiAddressService();
+    const third = getApiAddressService({ reset: true });
+    expect(first).toBe(second);
+    expect(third).not.toBe(first);
+  });
+});
+
+describe('getApiPersonalAddressService', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ AdapterRegistry } = await import('@/adapters/registry'));
+    ({ configureServices, resetServiceContainer } = await import('@/lib/config/service-container'));
+    ({ UserManagementConfiguration } = await import('@/core/config'));
+    (AdapterRegistry as any).instance = null;
+    resetServiceContainer();
+    UserManagementConfiguration.reset();
+    ({ getApiAddressService, getApiPersonalAddressService } = await import('../factory'));
+    ({ DefaultAddressService } = await import('../default-address.service'));
+  });
+
+  it('returns configured personal service if registered', () => {
+    const svc = {} as any;
+    UserManagementConfiguration.configureServiceProviders({ personalAddressService: svc });
+    expect(getApiPersonalAddressService()).toBe(svc);
+    expect(getApiPersonalAddressService()).toBe(svc);
+  });
+
+  it('creates default personal service with adapter when not configured', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('address', adapter);
+    const svc = getApiPersonalAddressService({ reset: true });
+    expect(svc).toBeInstanceOf(DefaultAddressService);
+    expect(getApiPersonalAddressService()).toBe(svc);
+  });
+
+  it('allows resetting the cached personal instance', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('address', adapter);
+    const first = getApiPersonalAddressService({ reset: true });
+    const second = getApiPersonalAddressService();
+    const third = getApiPersonalAddressService({ reset: true });
+    expect(first).toBe(second);
+    expect(third).not.toBe(first);
   });
 });

--- a/src/services/address/factory.ts
+++ b/src/services/address/factory.ts
@@ -10,26 +10,66 @@ import { UserManagementConfiguration } from '@/core/config';
 import type { IAddressDataProvider } from '@/core/address';
 import { AdapterRegistry } from '@/adapters/registry';
 import { DefaultAddressService } from './default-address.service';
+import { getServiceContainer, getServiceConfiguration } from '@/lib/config/service-container';
+
+export interface ApiAddressServiceOptions {
+  /** Reset cached instances, mainly for testing */
+  reset?: boolean;
+}
 
 // Singleton instances for API routes
+const COMPANY_CACHE_KEY = '__UM_COMPANY_ADDRESS_SERVICE__';
+const PERSONAL_CACHE_KEY = '__UM_PERSONAL_ADDRESS_SERVICE__';
+
 let addressServiceInstance: CompanyAddressService | null = null;
 let personalAddressServiceInstance: AddressService | null = null;
+let constructingCompany = false;
+let constructingPersonal = false;
 
 /**
  * Get the configured address service instance for API routes (Company addresses)
  * 
  * @returns Configured CompanyAddressService instance
  */
-export function getApiAddressService(): CompanyAddressService {
+export function getApiAddressService(
+  options: ApiAddressServiceOptions = {}
+): CompanyAddressService {
+  if (options.reset) {
+    addressServiceInstance = null;
+    if (typeof globalThis !== 'undefined') {
+      delete (globalThis as any)[COMPANY_CACHE_KEY];
+    }
+  }
+
+  if (!addressServiceInstance && typeof globalThis !== 'undefined') {
+    addressServiceInstance = (globalThis as any)[COMPANY_CACHE_KEY] as CompanyAddressService | null;
+  }
+
+  if (!addressServiceInstance && !constructingCompany) {
+    constructingCompany = true;
+    const existing = getServiceContainer().address;
+    if (existing) {
+      addressServiceInstance = existing;
+    }
+    constructingCompany = false;
+  }
+
   if (!addressServiceInstance) {
-    const configuredService = UserManagementConfiguration.getServiceProvider('addressService') as CompanyAddressService;
-    
-    if (configuredService) {
-      addressServiceInstance = configuredService;
+    const config = getServiceConfiguration();
+    const override =
+      (config as any).addressService ??
+      UserManagementConfiguration.getServiceProvider('addressService');
+
+    if (override) {
+      addressServiceInstance = override as CompanyAddressService;
     } else {
       const provider = AdapterRegistry.getInstance().getAdapter<IAddressDataProvider>('address');
       addressServiceInstance = new DefaultAddressService(provider) as unknown as CompanyAddressService;
     }
+  }
+
+  if (addressServiceInstance && typeof globalThis !== 'undefined') {
+    (globalThis as any)[COMPANY_CACHE_KEY] = addressServiceInstance;
   }
 
   return addressServiceInstance;
@@ -40,16 +80,36 @@ export function getApiAddressService(): CompanyAddressService {
  * 
  * @returns Configured AddressService instance
  */
-export function getApiPersonalAddressService(): AddressService {
-  if (!personalAddressServiceInstance) {
-    const configuredService = UserManagementConfiguration.getServiceProvider('personalAddressService') as AddressService;
-    
-    if (configuredService) {
-      personalAddressServiceInstance = configuredService;
-    } else {
-      const provider = AdapterRegistry.getInstance().getAdapter<IAddressDataProvider>('address');
-      personalAddressServiceInstance = new DefaultAddressService(provider);
+export function getApiPersonalAddressService(
+  options: ApiAddressServiceOptions = {}
+): AddressService {
+  if (options.reset) {
+    personalAddressServiceInstance = null;
+    if (typeof globalThis !== 'undefined') {
+      delete (globalThis as any)[PERSONAL_CACHE_KEY];
     }
+  }
+
+  if (!personalAddressServiceInstance && typeof globalThis !== 'undefined') {
+    personalAddressServiceInstance = (globalThis as any)[PERSONAL_CACHE_KEY] as AddressService | null;
+  }
+
+  if (!personalAddressServiceInstance && !constructingPersonal) {
+    constructingPersonal = true;
+    const configService = UserManagementConfiguration.getServiceProvider('personalAddressService') as AddressService | undefined;
+    if (configService) {
+      personalAddressServiceInstance = configService;
+    }
+    constructingPersonal = false;
+  }
+
+  if (!personalAddressServiceInstance) {
+    const provider = AdapterRegistry.getInstance().getAdapter<IAddressDataProvider>('address');
+    personalAddressServiceInstance = new DefaultAddressService(provider);
+  }
+
+  if (personalAddressServiceInstance && typeof globalThis !== 'undefined') {
+    (globalThis as any)[PERSONAL_CACHE_KEY] = personalAddressServiceInstance;
   }
 
   return personalAddressServiceInstance;


### PR DESCRIPTION
## Summary
- refactor address service factory to use `ServiceContainer`
- add separate caching for company vs personal address services
- add resettable options for both factories
- expand address factory tests to cover personal service and container overrides

## Testing
- `npx vitest run src/services/address/__tests__/factory.test.ts`
- `npx vitest run --coverage src/services/address/__tests__/factory.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_684080be1cd88331acb2985cfb1ccdc2