### PR TITLE
Standardize complex service factories

### DIFF
--- a/src/services/audit/__tests__/factory.test.ts
+++ b/src/services/audit/__tests__/factory.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { AdapterRegistry } from '@/adapters/registry';
 import { UserManagementConfiguration } from '@/core/config';
+import { configureServices, resetServiceContainer } from '@/lib/config/service-container';
 
 let getApiAuditService: typeof import('../factory').getApiAuditService;
 let DefaultAuditService: typeof import('../default-audit.service').DefaultAuditService;
@@ -10,6 +11,7 @@ describe('getApiAuditService', () => {
     vi.resetModules();
     (AdapterRegistry as any).instance = null;
     UserManagementConfiguration.reset();
+    resetServiceContainer();
     ({ getApiAuditService } = await import('../factory'));
     ({ DefaultAuditService } = await import('../default-audit.service'));
   });
@@ -17,15 +19,32 @@ describe('getApiAuditService', () => {
   it('returns configured service if registered', () => {
     const svc = {} as any;
     UserManagementConfiguration.configureServiceProviders({ auditService: svc });
-    expect(getApiAuditService()).toBe(svc);
+    expect(getApiAuditService({ reset: true })).toBe(svc);
     expect(getApiAuditService()).toBe(svc);
   });
 
   it('creates default service with adapter when not configured', () => {
     const adapter = {} as any;
     AdapterRegistry.getInstance().registerAdapter('audit', adapter);
-    const service = getApiAuditService();
+    const service = getApiAuditService({ reset: true });
     expect(service).toBeInstanceOf(DefaultAuditService);
     expect(getApiAuditService()).toBe(service);
+  });
+
+  it('uses ServiceContainer override when configured', () => {
+    const svc = {} as any;
+    configureServices({ auditService: svc });
+    expect(getApiAuditService({ reset: true })).toBe(svc);
+    expect(getApiAuditService()).toBe(svc);
+  });
+
+  it('allows resetting the cached instance', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('audit', adapter);
+    const first = getApiAuditService({ reset: true });
+    const second = getApiAuditService();
+    const third = getApiAuditService({ reset: true });
+    expect(first).toBe(second);
+    expect(third).not.toBe(first);
   });
 });

--- a/src/services/audit/factory.ts
+++ b/src/services/audit/factory.ts
@@ -10,19 +10,53 @@ import { UserManagementConfiguration } from '@/core/config';
 import type { IAuditDataProvider } from '@/core/audit';
 import { AdapterRegistry } from '@/adapters/registry';
 import { DefaultAuditService } from './default-audit.service';
+import {
+  getServiceContainer,
+  getServiceConfiguration,
+} from '@/lib/config/service-container';
 
 // Singleton instance for API routes
+export interface ApiAuditServiceOptions {
+  /** When true, clears the cached instance. Useful for tests */
+  reset?: boolean;
+}
+
 let auditServiceInstance: AuditService | null = null;
+let constructing = false;
 
 /**
  * Get the configured audit service instance for API routes
  * 
  * @returns Configured AuditService instance
  */
-export function getApiAuditService(): AuditService {
+export function getApiAuditService(
+  options: ApiAuditServiceOptions = {},
+): AuditService | undefined {
+  if (options.reset) {
+    auditServiceInstance = null;
+  }
+
+  if (!auditServiceInstance && !constructing) {
+    constructing = true;
+    try {
+      const containerService = getServiceContainer().audit;
+      if (containerService) {
+        auditServiceInstance = containerService;
+      }
+    } finally {
+      constructing = false;
+    }
+  }
+
   if (!auditServiceInstance) {
+    const config = getServiceConfiguration();
+    if (config.featureFlags?.audit === false) {
+      return undefined;
+    }
+
     auditServiceInstance =
-      UserManagementConfiguration.getServiceProvider('auditService') as AuditService | undefined;
+      config.auditService ||
+      (UserManagementConfiguration.getServiceProvider('auditService') as AuditService | undefined);
 
     if (!auditServiceInstance) {
       const provider = AdapterRegistry.getInstance().getAdapter<IAuditDataProvider>('audit');

--- a/src/services/notification/__tests__/factory.test.ts
+++ b/src/services/notification/__tests__/factory.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 let AdapterRegistry: typeof import('@/adapters/registry').AdapterRegistry;
 let UserManagementConfiguration: typeof import('@/core/config').UserManagementConfiguration;
+let configureServices: typeof import('@/lib/config/service-container').configureServices;
+let resetServiceContainer: typeof import('@/lib/config/service-container').resetServiceContainer;
 
 let getApiNotificationService: typeof import('../factory').getApiNotificationService;
 let DefaultNotificationService: typeof import('../default-notification.service').DefaultNotificationService;
@@ -10,8 +12,10 @@ describe('getApiNotificationService', () => {
     vi.resetModules();
     ({ AdapterRegistry } = await import('@/adapters/registry'));
     ({ UserManagementConfiguration } = await import('@/core/config'));
+    ({ configureServices, resetServiceContainer } = await import('@/lib/config/service-container'));
     (AdapterRegistry as any).instance = null;
     UserManagementConfiguration.reset();
+    resetServiceContainer();
     ({ getApiNotificationService } = await import('../factory'));
     ({ DefaultNotificationService } = await import('../default-notification.service'));
   });
@@ -19,15 +23,32 @@ describe('getApiNotificationService', () => {
   it('returns configured service if registered', () => {
     const service = {} as any;
     UserManagementConfiguration.configureServiceProviders({ notificationService: service });
-    expect(getApiNotificationService()).toBe(service);
+    expect(getApiNotificationService({ reset: true })).toBe(service);
     expect(getApiNotificationService()).toBe(service);
   });
 
   it('creates default service with adapter when not configured', () => {
     const adapter = {} as any;
     AdapterRegistry.getInstance().registerAdapter('notification', adapter);
-    const service = getApiNotificationService();
+    const service = getApiNotificationService({ reset: true });
     expect(service).toBeInstanceOf(DefaultNotificationService);
     expect(getApiNotificationService()).toBe(service);
+  });
+
+  it('uses ServiceContainer override when configured', () => {
+    const svc = {} as any;
+    configureServices({ notificationService: svc });
+    expect(getApiNotificationService({ reset: true })).toBe(svc);
+    expect(getApiNotificationService()).toBe(svc);
+  });
+
+  it('allows resetting the cached instance', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('notification', adapter);
+    const first = getApiNotificationService({ reset: true });
+    const second = getApiNotificationService();
+    const third = getApiNotificationService({ reset: true });
+    expect(first).toBe(second);
+    expect(third).not.toBe(first);
   });
 });

--- a/src/services/notification/factory.ts
+++ b/src/services/notification/factory.ts
@@ -11,25 +11,64 @@ import { DefaultNotificationService } from './default-notification.service';
 import { DefaultNotificationHandler } from './default-notification.handler';
 import { AdapterRegistry } from '@/adapters/registry';
 import { UserManagementConfiguration } from '@/core/config';
+import {
+  getServiceContainer,
+  getServiceConfiguration,
+} from '@/lib/config/service-container';
 
 // Singleton instance for API routes
+export interface ApiNotificationServiceOptions {
+  /** When true, clears the cached instance. Useful for tests */
+  reset?: boolean;
+}
+
 let notificationServiceInstance: NotificationService | null = null;
+let constructing = false;
 
 /**
  * Get the configured notification service instance for API routes
  * 
  * @returns Configured NotificationService instance
  */
-export function getApiNotificationService(): NotificationService {
+export function getApiNotificationService(
+  options: ApiNotificationServiceOptions = {},
+): NotificationService | undefined {
+  if (options.reset) {
+    notificationServiceInstance = null;
+  }
+
+  if (!notificationServiceInstance && !constructing) {
+    constructing = true;
+    try {
+      const containerService = getServiceContainer().notification;
+      if (containerService) {
+        notificationServiceInstance = containerService;
+      }
+    } finally {
+      constructing = false;
+    }
+  }
+
   if (!notificationServiceInstance) {
+    const config = getServiceConfiguration();
+    if (config.featureFlags?.notifications === false) {
+      return undefined;
+    }
+
     notificationServiceInstance =
-      UserManagementConfiguration.getServiceProvider('notificationService') as NotificationService | undefined;
+      config.notificationService ||
+      (UserManagementConfiguration.getServiceProvider(
+        'notificationService',
+      ) as NotificationService | undefined);
 
     if (!notificationServiceInstance) {
       const notificationDataProvider =
         AdapterRegistry.getInstance().getAdapter<INotificationDataProvider>('notification');
       const handler = new DefaultNotificationHandler();
-      notificationServiceInstance = new DefaultNotificationService(notificationDataProvider, handler);
+      notificationServiceInstance = new DefaultNotificationService(
+        notificationDataProvider,
+        handler,
+      );
     }
   }
 

--- a/src/services/subscription/__tests__/factory.test.ts
+++ b/src/services/subscription/__tests__/factory.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 let AdapterRegistry: typeof import('@/adapters/registry').AdapterRegistry;
 let UserManagementConfiguration: typeof import('@/core/config').UserManagementConfiguration;
+let configureServices: typeof import('@/lib/config/service-container').configureServices;
+let resetServiceContainer: typeof import('@/lib/config/service-container').resetServiceContainer;
 
 let getApiSubscriptionService: typeof import('../factory').getApiSubscriptionService;
 let DefaultSubscriptionService: typeof import('../default-subscription.service').DefaultSubscriptionService;
@@ -11,8 +13,10 @@ describe('getApiSubscriptionService', () => {
     vi.resetModules();
     ({ AdapterRegistry } = await import('@/adapters/registry'));
     ({ UserManagementConfiguration } = await import('@/core/config'));
+    ({ configureServices, resetServiceContainer } = await import('@/lib/config/service-container'));
     (AdapterRegistry as any).instance = null;
     UserManagementConfiguration.reset();
+    resetServiceContainer();
     ({ getApiSubscriptionService } = await import('../factory'));
     ({ DefaultSubscriptionService } = await import('../default-subscription.service'));
   });
@@ -20,15 +24,32 @@ describe('getApiSubscriptionService', () => {
   it('returns configured service if registered', () => {
     const svc = {} as any;
     UserManagementConfiguration.configureServiceProviders({ subscriptionService: svc });
-    expect(getApiSubscriptionService()).toBe(svc);
+    expect(getApiSubscriptionService({ reset: true })).toBe(svc);
     expect(getApiSubscriptionService()).toBe(svc);
   });
 
   it('creates default service with adapter when not configured', () => {
     const adapter = {} as any;
     AdapterRegistry.getInstance().registerAdapter('subscription', adapter);
-    const service = getApiSubscriptionService();
+    const service = getApiSubscriptionService({ reset: true });
     expect(service).toBeInstanceOf(DefaultSubscriptionService);
     expect(getApiSubscriptionService()).toBe(service);
+  });
+
+  it('uses ServiceContainer override when configured', () => {
+    const svc = {} as any;
+    configureServices({ subscriptionService: svc });
+    expect(getApiSubscriptionService({ reset: true })).toBe(svc);
+    expect(getApiSubscriptionService()).toBe(svc);
+  });
+
+  it('allows resetting the cached instance', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('subscription', adapter);
+    const first = getApiSubscriptionService({ reset: true });
+    const second = getApiSubscriptionService();
+    const third = getApiSubscriptionService({ reset: true });
+    expect(first).toBe(second);
+    expect(third).not.toBe(first);
   });
 });

--- a/src/services/subscription/factory.ts
+++ b/src/services/subscription/factory.ts
@@ -10,22 +10,59 @@ import { UserManagementConfiguration } from '@/core/config';
 import type { ISubscriptionDataProvider } from '@/core/subscription';
 import { AdapterRegistry } from '@/adapters/registry';
 import { DefaultSubscriptionService } from './default-subscription.service';
+import {
+  getServiceContainer,
+  getServiceConfiguration,
+} from '@/lib/config/service-container';
 
 // Singleton instance for API routes
+export interface ApiSubscriptionServiceOptions {
+  /** When true, clears the cached instance. Useful for tests */
+  reset?: boolean;
+}
+
 let subscriptionServiceInstance: SubscriptionService | null = null;
+let constructing = false;
 
 /**
  * Get the configured subscription service instance for API routes
  * 
  * @returns Configured SubscriptionService instance
  */
-export function getApiSubscriptionService(): SubscriptionService {
+export function getApiSubscriptionService(
+  options: ApiSubscriptionServiceOptions = {},
+): SubscriptionService | undefined {
+  if (options.reset) {
+    subscriptionServiceInstance = null;
+  }
+
+  if (!subscriptionServiceInstance && !constructing) {
+    constructing = true;
+    try {
+      const containerService = getServiceContainer().subscription;
+      if (containerService) {
+        subscriptionServiceInstance = containerService;
+      }
+    } finally {
+      constructing = false;
+    }
+  }
+
   if (!subscriptionServiceInstance) {
+    const config = getServiceConfiguration();
+    if (config.featureFlags?.subscription === false) {
+      return undefined;
+    }
+
     subscriptionServiceInstance =
-      UserManagementConfiguration.getServiceProvider('subscriptionService') as SubscriptionService | undefined;
+      config.subscriptionService ||
+      (UserManagementConfiguration.getServiceProvider(
+        'subscriptionService',
+      ) as SubscriptionService | undefined);
 
     if (!subscriptionServiceInstance) {
-      const provider = AdapterRegistry.getInstance().getAdapter<ISubscriptionDataProvider>('subscription');
+      const provider =
+        AdapterRegistry.getInstance().getAdapter<ISubscriptionDataProvider>('subscription');
       subscriptionServiceInstance = new DefaultSubscriptionService(provider);
     }
   }

--- a/src/services/webhooks/__tests__/factory.test.ts
+++ b/src/services/webhooks/__tests__/factory.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 let AdapterRegistry: typeof import('@/adapters/registry').AdapterRegistry;
 let UserManagementConfiguration: typeof import('@/core/config').UserManagementConfiguration;
+let configureServices: typeof import('@/lib/config/service-container').configureServices;
+let resetServiceContainer: typeof import('@/lib/config/service-container').resetServiceContainer;
 
 let getApiWebhookService: typeof import('../factory').getApiWebhookService;
 let WebhookServiceClass: typeof import('../WebhookService').WebhookService;
@@ -9,9 +11,11 @@ describe('getApiWebhookService', () => {
   beforeEach(async () => {
     vi.resetModules();
     ({ AdapterRegistry } = await import('@/adapters/registry'));
-    (AdapterRegistry as any).instance = null;
     ({ UserManagementConfiguration } = await import('@/core/config'));
+    ({ configureServices, resetServiceContainer } = await import('@/lib/config/service-container'));
+    (AdapterRegistry as any).instance = null;
     UserManagementConfiguration.reset();
+    resetServiceContainer();
     ({ getApiWebhookService } = await import('../factory'));
     ({ WebhookService: WebhookServiceClass } = await import('../WebhookService'));
   });
@@ -19,15 +23,32 @@ describe('getApiWebhookService', () => {
   it('returns configured service if registered', () => {
     const svc = {} as any;
     UserManagementConfiguration.configureServiceProviders({ webhookService: svc });
-    expect(getApiWebhookService()).toBe(svc);
+    expect(getApiWebhookService({ reset: true })).toBe(svc);
     expect(getApiWebhookService()).toBe(svc);
   });
 
   it('creates default service with adapter when not configured', () => {
     const adapter = {} as any;
     AdapterRegistry.getInstance().registerAdapter('webhook', adapter);
-    const service = getApiWebhookService();
+    const service = getApiWebhookService({ reset: true });
     expect(service).toBeInstanceOf(WebhookServiceClass);
     expect(getApiWebhookService()).toBe(service);
+  });
+
+  it('uses ServiceContainer override when configured', () => {
+    const svc = {} as any;
+    configureServices({ webhookService: svc });
+    expect(getApiWebhookService({ reset: true })).toBe(svc);
+    expect(getApiWebhookService()).toBe(svc);
+  });
+
+  it('allows resetting the cached instance', () => {
+    const adapter = {} as any;
+    AdapterRegistry.getInstance().registerAdapter('webhook', adapter);
+    const first = getApiWebhookService({ reset: true });
+    const second = getApiWebhookService();
+    const third = getApiWebhookService({ reset: true });
+    expect(first).toBe(second);
+    expect(third).not.toBe(first);
   });
 });

--- a/src/services/webhooks/factory.ts
+++ b/src/services/webhooks/factory.ts
@@ -10,22 +10,57 @@ import type { IWebhookDataProvider } from '@/core/webhooks';
 import { AdapterRegistry } from '@/adapters/registry';
 import { WebhookService } from './WebhookService';
 import { UserManagementConfiguration } from '@/core/config';
+import {
+  getServiceContainer,
+  getServiceConfiguration,
+} from '@/lib/config/service-container';
 
 // Singleton instance for API routes
+export interface ApiWebhookServiceOptions {
+  /** When true, clears the cached instance. Useful for tests */
+  reset?: boolean;
+}
+
 let webhookServiceInstance: IWebhookService | null = null;
+let constructing = false;
 
 /**
  * Get the configured webhook service instance for API routes
  * 
  * @returns Configured IWebhookService instance
  */
-export function getApiWebhookService(): IWebhookService {
+export function getApiWebhookService(
+  options: ApiWebhookServiceOptions = {},
+): IWebhookService | undefined {
+  if (options.reset) {
+    webhookServiceInstance = null;
+  }
+
+  if (!webhookServiceInstance && !constructing) {
+    constructing = true;
+    try {
+      const containerService = getServiceContainer().webhook;
+      if (containerService) {
+        webhookServiceInstance = containerService;
+      }
+    } finally {
+      constructing = false;
+    }
+  }
+
   if (!webhookServiceInstance) {
+    const config = getServiceConfiguration();
+    if (config.featureFlags?.webhooks === false) {
+      return undefined;
+    }
+
     webhookServiceInstance =
-      UserManagementConfiguration.getServiceProvider('webhookService') as IWebhookService | undefined;
+      config.webhookService ||
+      (UserManagementConfiguration.getServiceProvider('webhookService') as IWebhookService | undefined);
 
     if (!webhookServiceInstance) {
-      const webhookDataProvider = AdapterRegistry.getInstance().getAdapter<IWebhookDataProvider>('webhook');
+      const webhookDataProvider =
+        AdapterRegistry.getInstance().getAdapter<IWebhookDataProvider>('webhook');
       webhookServiceInstance = new WebhookService(webhookDataProvider);
     }
   }


### PR DESCRIPTION
## Summary
- integrate ServiceContainer with audit, notification, subscription and webhook factories
- add reset option and feature flag checks
- ensure singleton behaviour
- update related unit tests

## Testing
- `npx vitest run --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840a9d76ff883319bf8db51a773d2fa