### PR TITLE
Add company logo methods to UserService

### DIFF
--- a/src/core/user/interfaces.ts
+++ b/src/core/user/interfaces.ts
@@ -6,9 +6,9 @@
  * the contract that any implementation must fulfill.
  */
 
-import { 
-  UserProfile, 
-  ProfileUpdatePayload, 
+import {
+  UserProfile,
+  ProfileUpdatePayload,
   UserPreferences,
   PreferencesUpdatePayload,
   UserProfileResult,
@@ -16,6 +16,11 @@ import {
   UserSearchResult,
   ProfileVisibility
 } from './models';
+import type {
+  FileUploadOptions,
+  FileUploadResult,
+  FileDeleteResult
+} from '@/core/storage/interfaces';
 
 /**
  * Core user management service interface
@@ -79,6 +84,34 @@ export interface UserService {
    * @returns Result object with success status or error
    */
   deleteProfilePicture(userId: string): Promise<{ success: boolean; error?: string }>;
+
+  /**
+   * Upload a company logo for a corporate profile
+   *
+   * @param userId ID of the user performing the upload
+   * @param companyId ID of the company the logo belongs to
+   * @param fileBuffer Raw file contents
+   * @param options Optional upload configuration
+   * @returns Result object with upload details including the public URL
+   */
+  uploadCompanyLogo(
+    userId: string,
+    companyId: string,
+    fileBuffer: ArrayBuffer,
+    options?: FileUploadOptions
+  ): Promise<FileUploadResult>;
+
+  /**
+   * Delete the logo for a company profile
+   *
+   * @param userId ID of the user performing the delete
+   * @param companyId ID of the company whose logo should be deleted
+   * @returns Result object describing the delete outcome
+   */
+  deleteCompanyLogo(
+    userId: string,
+    companyId: string
+  ): Promise<FileDeleteResult>;
   
   /**
    * Update a user's profile visibility settings

--- a/src/services/user/__tests__/mocks/mock-user-service.ts
+++ b/src/services/user/__tests__/mocks/mock-user-service.ts
@@ -13,6 +13,11 @@ import {
   VisibilityLevel
 } from '../../../../core/user/models';
 import { UserType } from '../../../../types/user-type';
+import type {
+  FileUploadOptions,
+  FileUploadResult,
+  FileDeleteResult
+} from '../../../../core/storage/interfaces';
 
 /**
  * Mock implementation of the UserService interface for testing
@@ -145,8 +150,24 @@ export class MockUserService implements UserService {
 
     this.mockProfiles[userId].profilePictureUrl = undefined;
     this.notifyProfileChange(this.mockProfiles[userId]);
-    
+
     return { success: true };
+  });
+
+  uploadCompanyLogo = vi.fn().mockImplementation(async (
+    _userId: string,
+    _companyId: string,
+    _fileBuffer: ArrayBuffer,
+    _options?: FileUploadOptions
+  ): Promise<FileUploadResult> => {
+    return { success: false, error: 'Not implemented' };
+  });
+
+  deleteCompanyLogo = vi.fn().mockImplementation(async (
+    _userId: string,
+    _companyId: string
+  ): Promise<FileDeleteResult> => {
+    return { success: false, error: 'Not implemented' };
   });
 
   updateProfileVisibility = vi.fn().mockImplementation(async (userId: string, visibility: ProfileVisibility): Promise<{ success: boolean; visibility?: ProfileVisibility; error?: string }> => {

--- a/src/services/user/api-user.service.ts
+++ b/src/services/user/api-user.service.ts
@@ -9,6 +9,11 @@ import {
   UserSearchResult,
   ProfileVisibility
 } from '@/core/user/models';
+import type {
+  FileUploadOptions,
+  FileUploadResult,
+  FileDeleteResult
+} from '@/core/storage/interfaces';
 
 /**
  * API-based implementation of {@link UserService} for client-side usage.
@@ -131,6 +136,22 @@ export class ApiUserService implements UserService {
     if (res.status === 204) return { success: true };
     const data = await res.json();
     return { success: res.ok, error: data.error };
+  }
+
+  async uploadCompanyLogo(
+    _userId: string,
+    _companyId: string,
+    _fileBuffer: ArrayBuffer,
+    _options?: FileUploadOptions
+  ): Promise<FileUploadResult> {
+    throw new Error('Method not implemented.');
+  }
+
+  async deleteCompanyLogo(
+    _userId: string,
+    _companyId: string
+  ): Promise<FileDeleteResult> {
+    throw new Error('Method not implemented.');
   }
 
   /**

--- a/src/services/user/default-user.service.ts
+++ b/src/services/user/default-user.service.ts
@@ -9,9 +9,9 @@ import {
   UserService
 } from '@/core/user/interfaces';
 import type { UserDataProvider } from '@/core/user/IUserDataProvider';
-import { 
-  UserProfile, 
-  ProfileUpdatePayload, 
+import {
+  UserProfile,
+  ProfileUpdatePayload,
   UserPreferences,
   PreferencesUpdatePayload,
   UserProfileResult,
@@ -19,6 +19,11 @@ import {
   UserSearchResult,
   ProfileVisibility
 } from '@/core/user/models';
+import type {
+  FileUploadOptions,
+  FileUploadResult,
+  FileDeleteResult
+} from '@/core/storage/interfaces';
 import { UserEventType } from '@/core/user/events';
 import { TypedEventEmitter } from '@/lib/utils/typed-event-emitter';
 import { MemoryCache, getFromBrowser, setInBrowser, removeFromBrowser } from '@/lib/cache';
@@ -189,6 +194,22 @@ export class DefaultUserService
       });
     }
     return result;
+  }
+
+  async uploadCompanyLogo(
+    _userId: string,
+    _companyId: string,
+    _fileBuffer: ArrayBuffer,
+    _options?: FileUploadOptions
+  ): Promise<FileUploadResult> {
+    throw new Error('Method not implemented.');
+  }
+
+  async deleteCompanyLogo(
+    _userId: string,
+    _companyId: string
+  ): Promise<FileDeleteResult> {
+    throw new Error('Method not implemented.');
   }
 
   /**


### PR DESCRIPTION
## Summary
- add `uploadCompanyLogo` and `deleteCompanyLogo` definitions to `UserService`
- expose file storage result types in the user service interface
- stub company logo methods in service implementations and mocks

## Testing
- `npm test` *(fails: expected 500 to be 200; tests cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_684077414fe88331bec2808b6c113f29