### PR TITLE
Refactor company notification APIs

### DIFF
--- a/app/api/company/notifications/preferences/[id]/route.ts
+++ b/app/api/company/notifications/preferences/[id]/route.ts
@@ -1,113 +1,16 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getServiceSupabase } from '@/lib/database/supabase';
-import { checkRateLimit } from '@/middleware/rate-limit';
-import { withErrorHandling } from '@/middleware/error-handling';
 import { z } from 'zod';
+import { createApiHandler } from '@/lib/api/route-helpers';
+import type { AuthContext, ServiceContainer } from '@/core/config/interfaces';
 
-// Validation schema for updating a notification preference
 const updateSchema = z.object({
   enabled: z.boolean().optional(),
   channel: z.enum(['email', 'in_app', 'both']).optional(),
 });
 
-// PATCH /api/company/notifications/preferences/[id] - Update a notification preference
-async function handlePatch(
-  request: NextRequest,
-  { params }: { params: { id: string } }
-) {
-  // 1. Rate Limiting
-  const isRateLimited = await checkRateLimit(request);
-  if (isRateLimited) {
-    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
-  }
+async function handlePatch(_req: Request, auth: AuthContext, data: z.infer<typeof updateSchema>, services: ServiceContainer, id: string) {
+  const updated = await services.companyNotification!.updatePreference(auth.userId!, id, data);
+  return new Response(JSON.stringify(updated), { status: 200, headers: { 'Content-Type': 'application/json' } });
+}
 
-  try {
-    // 2. Validate preference ID
-    const preferenceId = params.id;
-    if (!preferenceId) {
-      return NextResponse.json({ error: 'Preference ID is required' }, { status: 400 });
-    }
-
-    // 3. Authentication & Get User
-    const authHeader = request.headers.get('authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
-    }
-    const token = authHeader.split(' ')[1];
-
-    const supabaseService = getServiceSupabase();
-    const { data: { user }, error: userError } = await supabaseService.auth.getUser(token);
-
-    if (userError || !user) {
-      return NextResponse.json({ error: userError?.message || 'Invalid token' }, { status: 401 });
-    }
-
-    // 4. Parse and validate request body
-    const body = await request.json();
-    const validationResult = updateSchema.safeParse(body);
-
-    if (!validationResult.success) {
-      return NextResponse.json({ 
-        error: 'Validation failed', 
-        details: validationResult.error.format() 
-      }, { status: 400 });
-    }
-
-    const updates = validationResult.data;
-
-    // 5. Get the preference details with company info to check permissions
-    const { data: preference, error: preferenceError } = await supabaseService
-      .from('company_notification_preferences')
-      .select(`
-        *,
-        company:company_profiles!inner(id, user_id)
-      `)
-      .eq('id', preferenceId)
-      .single();
-
-    if (preferenceError) {
-      console.error(`Error fetching preference ${preferenceId}:`, preferenceError);
-      return NextResponse.json({ error: 'Notification preference not found.' }, { status: 404 });
-    }
-
-    // 6. Verify user has permission (owns the company profile)
-    if (preference.company.user_id !== user.id) {
-      return NextResponse.json({ error: 'You do not have permission to update this notification preference.' }, { status: 403 });
-    }
-
-    // 7. Special handling for security_alert type
-    if (preference.notification_type === 'security_alert') {
-      // Security alerts are always enabled and sent via both channels
-      if (!updates.enabled && updates.enabled === false) {
-        return NextResponse.json({ error: 'Security alert notifications cannot be disabled.' }, { status: 400 });
-      }
-      if (updates.channel && updates.channel !== 'both') {
-        return NextResponse.json({ error: 'Security alert notifications must use both email and in-app channels.' }, { status: 400 });
-      }
-    }
-
-    // 8. Update the preference
-    const { data: updatedPreference, error: updateError } = await supabaseService
-      .from('company_notification_preferences')
-      .update({
-        ...updates,
-        updated_at: new Date().toISOString()
-      })
-      .eq('id', preferenceId)
-      .select('*')
-      .single();
-
-    if (updateError) {
-      console.error(`Error updating preference ${preferenceId}:`, updateError);
-      return NextResponse.json({ error: 'Failed to update notification preference.' }, { status: 500 });
-    }
-
-    // 9. Return the updated preference
-    return NextResponse.json(updatedPreference);
-
-  } catch (error) {
-    console.error(`Unexpected error in PATCH /api/company/notifications/preferences/${params.id}:`, error);
-    return NextResponse.json({ error: 'An internal server error occurred.' }, { status: 500 });
-  }
-} 
-export const PATCH = (req: NextRequest, ctx: { params: { id: string } }) => withErrorHandling((r) => handlePatch(r, ctx), req);
+export const PATCH = (req: Request, ctx: { params: { id: string } }) =>
+  createApiHandler(updateSchema, (r, a, d, s) => handlePatch(r, a, d, s, ctx.params.id), { requireAuth: true })(req);

--- a/app/api/company/notifications/preferences/route.ts
+++ b/app/api/company/notifications/preferences/route.ts
@@ -1,8 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getServiceSupabase } from '@/lib/database/supabase';
-import { checkRateLimit } from '@/middleware/rate-limit';
-import { withErrorHandling } from '@/middleware/error-handling';
 import { z } from 'zod';
+import { createApiHandler, emptySchema } from '@/lib/api/route-helpers';
+import type { AuthContext, ServiceContainer } from '@/core/config/interfaces';
 
 // Validation schema for creating a new notification preference
 const preferenceSchema = z.object({
@@ -12,191 +10,20 @@ const preferenceSchema = z.object({
   channel: z.enum(['email', 'in_app', 'both']).default('both'),
 });
 
-// GET /api/company/notifications/preferences - Get all notification preferences for the current user's company
-async function handleGet(request: NextRequest) {
-  // 1. Rate Limiting
-  const isRateLimited = await checkRateLimit(request);
-  if (isRateLimited) {
-    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
-  }
-
-  try {
-    // 2. Authentication & Get User
-    const authHeader = request.headers.get('authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
-    }
-    const token = authHeader.split(' ')[1];
-
-    const supabaseService = getServiceSupabase();
-    const { data: { user }, error: userError } = await supabaseService.auth.getUser(token);
-
-    if (userError || !user) {
-      return NextResponse.json({ error: userError?.message || 'Invalid token' }, { status: 401 });
-    }
-
-    // 3. Get Company Profile for the user
-    const { data: companyProfile, error: profileError } = await supabaseService
-      .from('company_profiles')
-      .select('id')
-      .eq('user_id', user.id)
-      .single();
-
-    if (profileError) {
-      console.error(`Error fetching company profile for user ${user.id}:`, profileError);
-      return NextResponse.json({ error: 'Failed to fetch company profile.' }, { status: 500 });
-    }
-    if (!companyProfile) {
-      return NextResponse.json({ error: 'Company profile not found.' }, { status: 404 });
-    }
-
-    // 4. Get Notification Preferences for the company with recipients
-    const { data: preferences, error: preferencesError } = await supabaseService
-      .from('company_notification_preferences')
-      .select(`
-        *,
-        recipients:company_notification_recipients(*)
-      `)
-      .eq('company_id', companyProfile.id);
-
-    if (preferencesError) {
-      console.error(`Error fetching notification preferences for company ${companyProfile.id}:`, preferencesError);
-      return NextResponse.json({ error: 'Failed to fetch notification preferences.' }, { status: 500 });
-    }
-
-    // 5. Return preferences
-    return NextResponse.json({ preferences });
-
-  } catch (error) {
-    console.error('Unexpected error in GET /api/company/notifications/preferences:', error);
-    return NextResponse.json({ error: 'An internal server error occurred.' }, { status: 500 });
-  }
+async function handleGet(_req: Request, auth: AuthContext, _data: unknown, services: ServiceContainer) {
+  const preferences = await services.companyNotification!.getPreferencesForUser(auth.userId!);
+  return new Response(JSON.stringify({ preferences }), { status: 200, headers: { 'Content-Type': 'application/json' } });
 }
 
-// POST /api/company/notifications/preferences - Create a new notification preference
-async function handlePost(request: NextRequest) {
-  // 1. Rate Limiting
-  const isRateLimited = await checkRateLimit(request);
-  if (isRateLimited) {
-    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
-  }
+async function handlePost(_req: Request, auth: AuthContext, data: z.infer<typeof preferenceSchema>, services: ServiceContainer) {
+  const pref = await services.companyNotification!.createPreference(auth.userId!, {
+    companyId: data.company_id,
+    notificationType: data.notification_type,
+    enabled: data.enabled,
+    channel: data.channel,
+  });
+  return new Response(JSON.stringify(pref), { status: 200, headers: { 'Content-Type': 'application/json' } });
+}
 
-  try {
-    // 2. Authentication & Get User
-    const authHeader = request.headers.get('authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
-    }
-    const token = authHeader.split(' ')[1];
-
-    const supabaseService = getServiceSupabase();
-    const { data: { user }, error: userError } = await supabaseService.auth.getUser(token);
-
-    if (userError || !user) {
-      return NextResponse.json({ error: userError?.message || 'Invalid token' }, { status: 401 });
-    }
-
-    // 3. Parse and validate request body
-    const body = await request.json();
-    const validationResult = preferenceSchema.safeParse(body);
-
-    if (!validationResult.success) {
-      return NextResponse.json({ 
-        error: 'Validation failed', 
-        details: validationResult.error.format() 
-      }, { status: 400 });
-    }
-
-    const { company_id, notification_type, enabled, channel } = validationResult.data;
-
-    // 4. Verify the user has access to the company
-    const { data: companyProfile, error: profileError } = await supabaseService
-      .from('company_profiles')
-      .select('id')
-      .eq('id', company_id)
-      .eq('user_id', user.id)
-      .single();
-
-    if (profileError || !companyProfile) {
-      return NextResponse.json({ error: 'You do not have permission to update notification preferences for this company.' }, { status: 403 });
-    }
-
-    // 5. Check if preference already exists
-    const { data: existingPreference } = await supabaseService
-      .from('company_notification_preferences')
-      .select('id')
-      .eq('company_id', company_id)
-      .eq('notification_type', notification_type)
-      .maybeSingle();
-
-    if (existingPreference) {
-      // Update existing preference instead of creating a new one
-      const { data: updatedPreference, error: updateError } = await supabaseService
-        .from('company_notification_preferences')
-        .update({
-          enabled,
-          channel,
-          updated_at: new Date().toISOString()
-        })
-        .eq('id', existingPreference.id)
-        .select('*')
-        .single();
-
-      if (updateError) {
-        console.error(`Error updating notification preference:`, updateError);
-        return NextResponse.json({ error: 'Failed to update notification preference.' }, { status: 500 });
-      }
-
-      return NextResponse.json(updatedPreference);
-    }
-
-    // 6. Special handling for security_alert type
-    let effectiveEnabled = enabled;
-    let effectiveChannel = channel;
-
-    if (notification_type === 'security_alert') {
-      // Security alerts are always enabled and sent via both channels
-      effectiveEnabled = true;
-      effectiveChannel = 'both';
-    }
-
-    // 7. Insert the new preference
-    const { data: newPreference, error: insertError } = await supabaseService
-      .from('company_notification_preferences')
-      .insert({
-        company_id,
-        notification_type,
-        enabled: effectiveEnabled,
-        channel: effectiveChannel,
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString()
-      })
-      .select('*')
-      .single();
-
-    if (insertError) {
-      console.error(`Error inserting notification preference:`, insertError);
-      return NextResponse.json({ error: 'Failed to create notification preference.' }, { status: 500 });
-    }
-
-    // 8. Also add the current admin user as a recipient by default
-    await supabaseService
-      .from('company_notification_recipients')
-      .insert({
-        preference_id: newPreference.id,
-        user_id: user.id,
-        is_admin: true,
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString()
-      });
-
-    // 9. Return the new preference
-    return NextResponse.json(newPreference);
-
-  } catch (error) {
-    console.error('Unexpected error in POST /api/company/notifications/preferences:', error);
-    return NextResponse.json({ error: 'An internal server error occurred.' }, { status: 500 });
-  }
-} 
-export const GET = (req: NextRequest) => withErrorHandling(handleGet, req);
-export const POST = (req: NextRequest) => withErrorHandling(handlePost, req);
+export const GET = createApiHandler(emptySchema, handleGet, { requireAuth: true });
+export const POST = createApiHandler(preferenceSchema, handlePost, { requireAuth: true });

--- a/app/api/company/notifications/recipients/[id]/route.ts
+++ b/app/api/company/notifications/recipients/[id]/route.ts
@@ -1,105 +1,13 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getServiceSupabase } from '@/lib/database/supabase';
-import { checkRateLimit } from '@/middleware/rate-limit';
-import { withErrorHandling } from '@/middleware/error-handling';
+import { createApiHandler, emptySchema } from '@/lib/api/route-helpers';
+import type { AuthContext, ServiceContainer } from '@/core/config/interfaces';
 
-// DELETE /api/company/notifications/recipients/[id] - Delete a notification recipient
-async function handleDelete(
-  request: NextRequest,
-  { params }: { params: { id: string } }
-) {
-  // 1. Rate Limiting
-  const isRateLimited = await checkRateLimit(request);
-  if (isRateLimited) {
-    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
-  }
+async function handleDelete(_req: Request, auth: AuthContext, _data: unknown, services: ServiceContainer, id: string) {
+  await services.companyNotification!.removeRecipient(auth.userId!, id);
+  return new Response(
+    JSON.stringify({ success: true, message: 'Recipient removed successfully' }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+}
 
-  try {
-    // 2. Validate recipient ID
-    const recipientId = params.id;
-    if (!recipientId) {
-      return NextResponse.json({ error: 'Recipient ID is required' }, { status: 400 });
-    }
-
-    // 3. Authentication & Get User
-    const authHeader = request.headers.get('authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
-    }
-    const token = authHeader.split(' ')[1];
-
-    const supabaseService = getServiceSupabase();
-    const { data: { user }, error: userError } = await supabaseService.auth.getUser(token);
-
-    if (userError || !user) {
-      return NextResponse.json({ error: userError?.message || 'Invalid token' }, { status: 401 });
-    }
-
-    // 4. Get the recipient with preference and company info to check permissions
-    const { data: recipient, error: recipientError } = await supabaseService
-      .from('company_notification_recipients')
-      .select(`
-        *,
-        preference:company_notification_preferences!inner(
-          *,
-          company:company_profiles!inner(id, user_id)
-        )
-      `)
-      .eq('id', recipientId)
-      .single();
-
-    if (recipientError) {
-      console.error(`Error fetching recipient ${recipientId}:`, recipientError);
-      return NextResponse.json({ error: 'Notification recipient not found.' }, { status: 404 });
-    }
-
-    // 5. Verify user has permission (owns the company profile)
-    if (recipient.preference.company.user_id !== user.id) {
-      return NextResponse.json({ error: 'You do not have permission to remove this recipient.' }, { status: 403 });
-    }
-
-    // 6. Prevent removing the last admin recipient for security alerts
-    if (recipient.is_admin && 
-        recipient.preference.notification_type === 'security_alert') {
-      // Check if this is the last admin recipient for security alerts
-      const { count, error: countError } = await supabaseService
-        .from('company_notification_recipients')
-        .select('id', { count: 'exact' })
-        .eq('preference_id', recipient.preference_id)
-        .eq('is_admin', true);
-      
-      if (countError) {
-        console.error('Error counting admin recipients:', countError);
-        return NextResponse.json({ error: 'Failed to verify if this is the last admin recipient.' }, { status: 500 });
-      }
-      
-      if (count === 1) {
-        return NextResponse.json({ 
-          error: 'Cannot remove the last admin recipient for security alerts. Add another admin recipient first.' 
-        }, { status: 400 });
-      }
-    }
-
-    // 7. Delete the recipient
-    const { error: deleteError } = await supabaseService
-      .from('company_notification_recipients')
-      .delete()
-      .eq('id', recipientId);
-
-    if (deleteError) {
-      console.error(`Error deleting recipient ${recipientId}:`, deleteError);
-      return NextResponse.json({ error: 'Failed to delete recipient.' }, { status: 500 });
-    }
-
-    // 8. Return success
-    return NextResponse.json({ 
-      success: true, 
-      message: 'Recipient removed successfully' 
-    });
-
-  } catch (error) {
-    console.error(`Unexpected error in DELETE /api/company/notifications/recipients/${params.id}:`, error);
-    return NextResponse.json({ error: 'An internal server error occurred.' }, { status: 500 });
-  }
-} 
-export const DELETE = (req: NextRequest, ctx: { params: { id: string } }) => withErrorHandling((r) => handleDelete(r, ctx), req);
+export const DELETE = (req: Request, ctx: { params: { id: string } }) =>
+  createApiHandler(emptySchema, (r, a, d, s) => handleDelete(r, a, d, s, ctx.params.id), { requireAuth: true })(req);

--- a/app/api/company/notifications/recipients/route.ts
+++ b/app/api/company/notifications/recipients/route.ts
@@ -1,17 +1,7 @@
-import { NextRequest } from 'next/server';
-import { getServiceSupabase } from '@/lib/database/supabase';
-import { checkRateLimit } from '@/middleware/rate-limit';
-import { withErrorHandling } from '@/middleware/error-handling';
-import {
-  createCreatedResponse,
-  createForbiddenError,
-  createUnauthorizedError,
-  createValidationError,
-  createServerError,
-  ApiError,
-  ERROR_CODES,
-} from '@/lib/api/common';
 import { z } from 'zod';
+import { createApiHandler } from '@/lib/api/route-helpers';
+import type { AuthContext, ServiceContainer } from '@/core/config/interfaces';
+import { createCreatedResponse, createValidationError, createForbiddenError, createUnauthorizedError, createServerError } from '@/lib/api/common';
 
 // Validation schema for adding a new recipient
 const recipientSchema = z.object({
@@ -22,140 +12,14 @@ const recipientSchema = z.object({
 });
 
 // POST /api/company/notifications/recipients - Add a new notification recipient
-async function handlePost(request: NextRequest) {
-  // 1. Rate Limiting
-  const isRateLimited = await checkRateLimit(request);
-  if (isRateLimited) {
-    throw new (createServerError('Too many requests'));
-  }
-
-  try {
-    // 2. Authentication & Get User
-    const authHeader = request.headers.get('authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      throw createUnauthorizedError();
-    }
-    const token = authHeader.split(' ')[1];
-
-    const supabaseService = getServiceSupabase();
-    const { data: { user }, error: userError } = await supabaseService.auth.getUser(token);
-
-    if (userError || !user) {
-      throw createUnauthorizedError(userError?.message || 'Invalid token');
-    }
-
-    // 3. Parse and validate request body
-    const body = await request.json();
-    const validationResult = recipientSchema.safeParse(body);
-
-    if (!validationResult.success) {
-      throw createValidationError('Validation failed', validationResult.error.format());
-    }
-
-    const { company_id, preference_id, email, is_admin } = validationResult.data;
-
-    // 4. Verify the user has access to the company
-    const { data: companyProfile, error: profileError } = await supabaseService
-      .from('company_profiles')
-      .select('id')
-      .eq('id', company_id)
-      .eq('user_id', user.id)
-      .single();
-
-    if (profileError || !companyProfile) {
-      throw createForbiddenError('You do not have permission to add recipients for this company.');
-    }
-    
-    // 5. Check if this is a duplicate email for the company's notifications
-    const { data: existingRecipients } = await supabaseService
-      .from('company_notification_recipients')
-      .select('*, preference:company_notification_preferences!inner(company_id)')
-      .eq('email', email)
-      .eq('preference.company_id', company_id);
-    
-    if (existingRecipients && existingRecipients.length > 0) {
-      throw createValidationError('This email address is already receiving notifications for this company.');
-    }
-    
-    // 6. Get all notification preferences for the company if no specific preference_id is provided
-    let preferencesToUpdate: {id: string}[] = [];
-    
-    if (preference_id) {
-      const { data: specificPreference, error: prefError } = await supabaseService
-        .from('company_notification_preferences')
-        .select('id')
-        .eq('id', preference_id)
-        .eq('company_id', company_id)
-        .single();
-        
-      if (prefError || !specificPreference) {
-        throw createValidationError('The specified notification preference does not exist or belongs to a different company.');
-      }
-      
-      preferencesToUpdate = [specificPreference];
-    } else {
-      // Get all preferences for this company
-      const { data: allPreferences, error: allPrefError } = await supabaseService
-        .from('company_notification_preferences')
-        .select('id')
-        .eq('company_id', company_id);
-        
-      if (allPrefError || !allPreferences || allPreferences.length === 0) {
-        // Create default preferences if none exist
-        const notificationTypes = ['new_member_domain', 'domain_verified', 'domain_verification_failed', 'security_alert'];
-        const defaultPreferences = notificationTypes.map(type => ({
-          company_id,
-          notification_type: type,
-          enabled: type === 'security_alert', // Only security alerts enabled by default
-          channel: 'both',
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString()
-        }));
-        
-        const { data: createdPreferences, error: createError } = await supabaseService
-          .from('company_notification_preferences')
-          .insert(defaultPreferences)
-          .select('id');
-          
-        if (createError || !createdPreferences) {
-          console.error('Error creating default preferences:', createError);
-          throw createServerError('Failed to create notification preferences.');
-        }
-        
-        preferencesToUpdate = createdPreferences;
-      } else {
-        preferencesToUpdate = allPreferences;
-      }
-    }
-    
-    // 7. Add recipient to all relevant preferences
-    const recipients = preferencesToUpdate.map(pref => ({
-      preference_id: pref.id,
-      email,
-      is_admin,
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString()
-    }));
-    
-    const { data: addedRecipients, error: addError } = await supabaseService
-      .from('company_notification_recipients')
-      .insert(recipients)
-      .select();
-      
-    if (addError) {
-      console.error('Error adding recipients:', addError);
-      throw createServerError('Failed to add recipient.');
-    }
-    
-    // 8. Return success
-    return createCreatedResponse({
-      recipients: addedRecipients,
-      message: 'Recipient added successfully',
-    });
-
-  } catch (error) {
-    console.error('Unexpected error in POST /api/company/notifications/recipients:', error);
-    throw createServerError('An internal server error occurred');
-  }
+async function handlePost(_req: Request, auth: AuthContext, data: z.infer<typeof recipientSchema>, services: ServiceContainer) {
+  const result = await services.companyNotification!.addRecipient(auth.userId!, {
+    companyId: data.company_id,
+    preferenceId: data.preference_id ?? undefined,
+    email: data.email,
+    isAdmin: data.is_admin,
+  });
+  return createCreatedResponse({ recipients: result.recipients, message: 'Recipient added successfully' });
 }
-export const POST = (req: NextRequest) => withErrorHandling(handlePost, req);
+
+export const POST = createApiHandler(recipientSchema, handlePost, { requireAuth: true });

--- a/src/core/company-notification/interfaces.ts
+++ b/src/core/company-notification/interfaces.ts
@@ -1,0 +1,38 @@
+import type {
+  CompanyNotificationPreference,
+  CompanyNotificationRecipient,
+  NotificationType,
+  NotificationChannel,
+} from '@/types/company';
+
+export interface CompanyNotificationService {
+  getPreferencesForUser(userId: string): Promise<CompanyNotificationPreference[]>;
+
+  createPreference(
+    userId: string,
+    data: {
+      companyId: string;
+      notificationType: NotificationType;
+      enabled: boolean;
+      channel: NotificationChannel;
+    }
+  ): Promise<CompanyNotificationPreference>;
+
+  updatePreference(
+    userId: string,
+    preferenceId: string,
+    updates: { enabled?: boolean; channel?: NotificationChannel }
+  ): Promise<CompanyNotificationPreference>;
+
+  addRecipient(
+    userId: string,
+    data: {
+      companyId: string;
+      preferenceId?: string;
+      email: string;
+      isAdmin: boolean;
+    }
+  ): Promise<{ recipients: CompanyNotificationRecipient[] }>;
+
+  removeRecipient(userId: string, recipientId: string): Promise<void>;
+}

--- a/src/core/config/interfaces.ts
+++ b/src/core/config/interfaces.ts
@@ -54,6 +54,7 @@ export interface ServiceContainer {
   // TODO: Add other services as their interfaces become available
   role?: RoleService;
   address?: CompanyAddressService;
+  companyNotification?: import("@/core/company-notification/interfaces").CompanyNotificationService;
   resourceRelationship?: ResourceRelationshipService;
 }
 
@@ -155,7 +156,8 @@ export interface ServiceConfig {
    * Custom address service implementation (for company addresses)
    */
   addressService?: CompanyAddressService;
-  
+  companyNotificationService?: import("@/core/company-notification/interfaces").CompanyNotificationService;
+
   /**
    * Custom resource relationship service implementation
    */

--- a/src/lib/config/service-container.ts
+++ b/src/lib/config/service-container.ts
@@ -57,6 +57,7 @@ import { getApiAdminService } from '@/services/admin/factory';
 import { getApiRoleService } from '@/services/role/factory';
 import { getApiAddressService } from '@/services/address/factory';
 import { getApiResourceRelationshipService } from '@/services/resource-relationship/factory';
+import { getApiCompanyNotificationService } from '@/services/company-notification/factory';
 
 // TODO: Import additional service factories as they become available
 // import { getApiRoleService } from '@/services/role/factory';
@@ -229,6 +230,13 @@ export function getServiceContainer(overrides?: Partial<ServiceContainer>): Serv
   } else if (!serviceInstances.address && globalServiceConfig.featureFlags?.addresses !== false) {
     serviceInstances.address = getApiAddressService();
   }
+
+  // Create company notification service if not cached
+  if (!serviceInstances.companyNotification && globalServiceConfig.companyNotificationService) {
+    serviceInstances.companyNotification = globalServiceConfig.companyNotificationService;
+  } else if (!serviceInstances.companyNotification) {
+    serviceInstances.companyNotification = getApiCompanyNotificationService();
+  }
   
   // Create resource relationship service if not cached
   if (!serviceInstances.resourceRelationship && globalServiceConfig.resourceRelationshipService) {
@@ -260,6 +268,7 @@ export function getServiceContainer(overrides?: Partial<ServiceContainer>): Serv
     admin: overrides?.admin || serviceInstances.admin,
     role: overrides?.role || serviceInstances.role,
     address: overrides?.address || serviceInstances.address,
+    companyNotification: overrides?.companyNotification || serviceInstances.companyNotification,
     resourceRelationship: overrides?.resourceRelationship || serviceInstances.resourceRelationship,
   };
 }
@@ -401,6 +410,13 @@ export function getConfiguredRoleService(override?: RoleService): RoleService | 
  */
 export function getConfiguredAddressService(override?: CompanyAddressService): CompanyAddressService | undefined {
   return override || globalServiceConfig.addressService || getApiAddressService();
+}
+
+/**
+ * Get a specific service with fallback to global configuration
+ */
+export function getConfiguredCompanyNotificationService(override?: import("@/core/company-notification/interfaces").CompanyNotificationService): import("@/core/company-notification/interfaces").CompanyNotificationService {
+  return override || globalServiceConfig.companyNotificationService || getApiCompanyNotificationService();
 }
 
 /**

--- a/src/services/company-notification/default-company-notification.service.ts
+++ b/src/services/company-notification/default-company-notification.service.ts
@@ -1,0 +1,272 @@
+import { getServiceSupabase } from '@/lib/database/supabase';
+import type {
+  CompanyNotificationPreference,
+  CompanyNotificationRecipient,
+  NotificationType,
+  NotificationChannel,
+} from '@/types/company';
+import type { CompanyNotificationService } from '@/core/company-notification/interfaces';
+
+export class DefaultCompanyNotificationService implements CompanyNotificationService {
+  constructor(private supabase = getServiceSupabase()) {}
+
+  async getPreferencesForUser(userId: string): Promise<CompanyNotificationPreference[]> {
+    const { data: company, error: profileError } = await this.supabase
+      .from('company_profiles')
+      .select('id')
+      .eq('user_id', userId)
+      .single();
+    if (profileError || !company) {
+      throw new Error('Failed to fetch company profile');
+    }
+
+    const { data, error } = await this.supabase
+      .from('company_notification_preferences')
+      .select('*, recipients:company_notification_recipients(*)')
+      .eq('company_id', company.id);
+
+    if (error) {
+      throw new Error('Failed to fetch notification preferences');
+    }
+    return (data || []) as CompanyNotificationPreference[];
+  }
+
+  async createPreference(
+    userId: string,
+    data: {
+      companyId: string;
+      notificationType: NotificationType;
+      enabled: boolean;
+      channel: NotificationChannel;
+    }
+  ): Promise<CompanyNotificationPreference> {
+    const { data: company, error: profileError } = await this.supabase
+      .from('company_profiles')
+      .select('id')
+      .eq('id', data.companyId)
+      .eq('user_id', userId)
+      .single();
+    if (profileError || !company) {
+      throw new Error('You do not have permission to update notification preferences for this company');
+    }
+
+    const { data: existing } = await this.supabase
+      .from('company_notification_preferences')
+      .select('id')
+      .eq('company_id', data.companyId)
+      .eq('notification_type', data.notificationType)
+      .maybeSingle();
+
+    const effectiveEnabled = data.notificationType === 'security_alert' ? true : data.enabled;
+    const effectiveChannel = data.notificationType === 'security_alert' ? 'both' : data.channel;
+
+    if (existing) {
+      const { data: updated, error } = await this.supabase
+        .from('company_notification_preferences')
+        .update({
+          enabled: effectiveEnabled,
+          channel: effectiveChannel,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', existing.id)
+        .select('*')
+        .single();
+      if (error || !updated) {
+        throw new Error('Failed to update notification preference');
+      }
+      return updated as CompanyNotificationPreference;
+    }
+
+    const { data: newPref, error: insertError } = await this.supabase
+      .from('company_notification_preferences')
+      .insert({
+        company_id: data.companyId,
+        notification_type: data.notificationType,
+        enabled: effectiveEnabled,
+        channel: effectiveChannel,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .select('*')
+      .single();
+
+    if (insertError || !newPref) {
+      throw new Error('Failed to create notification preference');
+    }
+
+    await this.supabase.from('company_notification_recipients').insert({
+      preference_id: newPref.id,
+      user_id: userId,
+      is_admin: true,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+
+    return newPref as CompanyNotificationPreference;
+  }
+
+  async updatePreference(
+    userId: string,
+    preferenceId: string,
+    updates: { enabled?: boolean; channel?: NotificationChannel }
+  ): Promise<CompanyNotificationPreference> {
+    const { data: pref, error } = await this.supabase
+      .from('company_notification_preferences')
+      .select('*, company:company_profiles!inner(id, user_id)')
+      .eq('id', preferenceId)
+      .single();
+    if (error || !pref) {
+      throw new Error('Notification preference not found');
+    }
+    if (pref.company.user_id !== userId) {
+      throw new Error('You do not have permission to update this notification preference');
+    }
+
+    if (pref.notification_type === 'security_alert') {
+      if (updates.enabled === false) {
+        throw new Error('Security alert notifications cannot be disabled.');
+      }
+      if (updates.channel && updates.channel !== 'both') {
+        throw new Error('Security alert notifications must use both email and in-app channels.');
+      }
+    }
+
+    const { data: updated, error: updateError } = await this.supabase
+      .from('company_notification_preferences')
+      .update({ ...updates, updated_at: new Date().toISOString() })
+      .eq('id', preferenceId)
+      .select('*')
+      .single();
+    if (updateError || !updated) {
+      throw new Error('Failed to update notification preference');
+    }
+    return updated as CompanyNotificationPreference;
+  }
+
+  async addRecipient(
+    userId: string,
+    data: { companyId: string; preferenceId?: string; email: string; isAdmin: boolean }
+  ): Promise<{ recipients: CompanyNotificationRecipient[] }> {
+    const { data: company, error: profileError } = await this.supabase
+      .from('company_profiles')
+      .select('id')
+      .eq('id', data.companyId)
+      .eq('user_id', userId)
+      .single();
+    if (profileError || !company) {
+      throw new Error('You do not have permission to add recipients for this company.');
+    }
+
+    const { data: existing } = await this.supabase
+      .from('company_notification_recipients')
+      .select('*, preference:company_notification_preferences!inner(company_id)')
+      .eq('email', data.email)
+      .eq('preference.company_id', data.companyId);
+    if (existing && existing.length > 0) {
+      throw new Error('This email address is already receiving notifications for this company.');
+    }
+
+    let preferences: { id: string }[] = [];
+    if (data.preferenceId) {
+      const { data: pref, error } = await this.supabase
+        .from('company_notification_preferences')
+        .select('id')
+        .eq('id', data.preferenceId)
+        .eq('company_id', data.companyId)
+        .single();
+      if (error || !pref) {
+        throw new Error('The specified notification preference does not exist or belongs to a different company.');
+      }
+      preferences = [pref];
+    } else {
+      const { data: allPrefs, error } = await this.supabase
+        .from('company_notification_preferences')
+        .select('id')
+        .eq('company_id', data.companyId);
+      if (error || !allPrefs || allPrefs.length === 0) {
+        const types: NotificationType[] = [
+          'new_member_domain',
+          'domain_verified',
+          'domain_verification_failed',
+          'security_alert',
+        ];
+        const defaults = types.map(t => ({
+          company_id: data.companyId,
+          notification_type: t,
+          enabled: t === 'security_alert',
+          channel: 'both' as NotificationChannel,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }));
+        const { data: created, error: createError } = await this.supabase
+          .from('company_notification_preferences')
+          .insert(defaults)
+          .select('id');
+        if (createError || !created) {
+          throw new Error('Failed to create notification preferences.');
+        }
+        preferences = created as { id: string }[];
+      } else {
+        preferences = allPrefs as { id: string }[];
+      }
+    }
+
+    const recipients = preferences.map(pref => ({
+      preference_id: pref.id,
+      email: data.email,
+      is_admin: data.isAdmin,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }));
+
+    const { data: added, error: addError } = await this.supabase
+      .from('company_notification_recipients')
+      .insert(recipients)
+      .select();
+
+    if (addError || !added) {
+      throw new Error('Failed to add recipient.');
+    }
+
+    return { recipients: added as CompanyNotificationRecipient[] };
+  }
+
+  async removeRecipient(userId: string, recipientId: string): Promise<void> {
+    const { data: recipient, error } = await this.supabase
+      .from('company_notification_recipients')
+      .select(`*, preference:company_notification_preferences!inner(*, company:company_profiles!inner(id, user_id))`)
+      .eq('id', recipientId)
+      .single();
+    if (error || !recipient) {
+      throw new Error('Notification recipient not found.');
+    }
+    if (recipient.preference.company.user_id !== userId) {
+      throw new Error('You do not have permission to remove this recipient.');
+    }
+
+    if (
+      recipient.is_admin &&
+      recipient.preference.notification_type === 'security_alert'
+    ) {
+      const { count, error: countError } = await this.supabase
+        .from('company_notification_recipients')
+        .select('id', { count: 'exact' })
+        .eq('preference_id', recipient.preference_id)
+        .eq('is_admin', true);
+      if (countError) {
+        throw new Error('Failed to verify if this is the last admin recipient.');
+      }
+      if (count === 1) {
+        throw new Error('Cannot remove the last admin recipient for security alerts. Add another admin recipient first.');
+      }
+    }
+
+    const { error: deleteError } = await this.supabase
+      .from('company_notification_recipients')
+      .delete()
+      .eq('id', recipientId);
+    if (deleteError) {
+      throw new Error('Failed to delete recipient.');
+    }
+  }
+}

--- a/src/services/company-notification/factory.ts
+++ b/src/services/company-notification/factory.ts
@@ -1,0 +1,37 @@
+import { DefaultCompanyNotificationService } from './default-company-notification.service';
+import type { CompanyNotificationService } from '@/core/company-notification/interfaces';
+import { getServiceContainer } from '@/lib/config/service-container';
+
+export interface ApiCompanyNotificationServiceOptions {
+  reset?: boolean;
+}
+
+let instance: CompanyNotificationService | null = null;
+let constructing = false;
+
+export function getApiCompanyNotificationService(
+  options: ApiCompanyNotificationServiceOptions = {}
+): CompanyNotificationService {
+  if (options.reset) {
+    instance = null;
+  }
+
+  if (!instance && !constructing) {
+    constructing = true;
+    try {
+      const container = getServiceContainer();
+      const existing = (container as any).companyNotification as CompanyNotificationService | undefined;
+      if (existing) {
+        instance = existing;
+      }
+    } finally {
+      constructing = false;
+    }
+  }
+
+  if (!instance) {
+    instance = new DefaultCompanyNotificationService();
+  }
+
+  return instance;
+}

--- a/src/services/company-notification/index.ts
+++ b/src/services/company-notification/index.ts
@@ -1,0 +1,3 @@
+export { DefaultCompanyNotificationService } from './default-company-notification.service';
+export { getApiCompanyNotificationService } from './factory';
+export type { CompanyNotificationService } from '@/core/company-notification/interfaces';


### PR DESCRIPTION
## Summary
- create CompanyNotificationService with Supabase implementation
- register the new service in the service container
- update service container interfaces
- refactor company notification API routes to use the service layer

## Testing
- `npx vitest run --coverage` *(fails: environment not configured)*

------
https://chatgpt.com/codex/tasks/task_b_68414f39d7b483319772dac66535e707