### PR TITLE
Refactor profile routes to use service layer

### DIFF
--- a/app/api/profile/export/route.ts
+++ b/app/api/profile/export/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { supabase } from '@/lib/supabase';
 import { middleware } from '@/middleware';
 import { withExportRateLimit } from '@/middleware/export-rate-limit';
 import {
@@ -11,7 +10,8 @@ import {
   createUserDataExport,
   processUserDataExport,
   getUserExportData,
-  checkUserExportStatus
+  checkUserExportStatus,
+  getUserDataExportById
 } from '@/lib/exports/export.service';
 import { logUserAction } from '@/lib/audit/auditLogger';
 
@@ -180,32 +180,3 @@ async function handleImmediateExport(req: NextRequest) {
   }
 }
 
-/**
- * Helper to get user export by ID
- */
-async function getUserDataExportById(exportId: string) {
-  const { data, error } = await supabase
-    .from('user_data_exports')
-    .select('*')
-    .eq('id', exportId)
-    .single();
-  
-  if (error || !data) return null;
-  
-  return {
-    id: data.id,
-    userId: data.user_id,
-    format: data.format,
-    status: data.status,
-    filePath: data.file_path,
-    downloadToken: data.download_token,
-    createdAt: data.created_at,
-    updatedAt: data.updated_at,
-    completedAt: data.completed_at,
-    expiresAt: data.expires_at,
-    errorMessage: data.error_message,
-    fileSizeBytes: data.file_size_bytes,
-    isLargeDataset: data.is_large_dataset,
-    notificationSent: data.notification_sent
-  };
-}

--- a/app/api/profile/logo/route.ts
+++ b/app/api/profile/logo/route.ts
@@ -1,9 +1,9 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { getServiceSupabase } from '@/lib/database/supabase';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { decode } from 'base64-arraybuffer'; // For decoding base64
-import { v4 as uuidv4 } from 'uuid'; // For generating unique filenames
+import { getSessionFromToken } from '@/services/auth/factory';
+import { getApiUserService } from '@/services/user/factory';
 
 // Schema for logo upload request body
 const LogoUploadSchema = z.object({
@@ -13,126 +13,47 @@ const LogoUploadSchema = z.object({
 
 type LogoUploadRequest = z.infer<typeof LogoUploadSchema>;
 
-const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB limit
-const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
-const STORAGE_BUCKET = 'company-logos'; // Define Supabase storage bucket name
 
 // --- POST Handler for uploading company logo --- 
 export async function POST(request: NextRequest) {
-  // 1. Rate Limiting
   const isRateLimited = await checkRateLimit(request);
   if (isRateLimited) {
     return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
   }
 
   try {
-    // 2. Authentication & Get User
     const authHeader = request.headers.get('authorization');
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
       return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
     }
     const token = authHeader.split(' ')[1];
-
-    const supabaseService = getServiceSupabase();
-    const { data: { user }, error: userError } = await supabaseService.auth.getUser(token);
-
-    if (userError || !user) {
-      return NextResponse.json({ error: userError?.message || 'Invalid token' }, { status: 401 });
+    const user = await getSessionFromToken(token);
+    if (!user) {
+      return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
     }
 
-    // 3. Basic Permission Check (Corporate User)
-    const { data: profileData, error: profileError } = await supabaseService
-        .from('profiles')
-        .select('userType')
-        .eq('userId', user.id)
-        .single();
-
-    if (profileError || !profileData) {
-        return NextResponse.json({ error: 'Profile not found or error checking type.' }, { status: 500 });
-    }
-    if (profileData.userType !== 'corporate') {
-        return NextResponse.json({ error: 'Permission denied. Only corporate users can upload company logos.' }, { status: 403 });
-    }
-
-    // 4. Parse and Validate Body
     let body: LogoUploadRequest;
     try {
       body = await request.json();
-    } catch (e) {
+    } catch {
       return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
     }
 
-    const parseResult = LogoUploadSchema.safeParse(body);
-    if (!parseResult.success) {
-      return NextResponse.json({ error: 'Validation failed', details: parseResult.error.format() }, { status: 400 });
+    const parse = LogoUploadSchema.safeParse(body);
+    if (!parse.success) {
+      return NextResponse.json({ error: 'Validation failed', details: parse.error.format() }, { status: 400 });
     }
-    
-    const { logo: base64Logo } = parseResult.data;
 
-    // Extract mime type and decode base64
-    const mimeMatch = base64Logo.match(/^data:(.+);base64,/);
-    if (!mimeMatch || mimeMatch.length < 2) {
-      return NextResponse.json({ error: 'Invalid base64 image format.' }, { status: 400 });
-    }
-    const mimeType = mimeMatch[1];
-    const base64Data = base64Logo.replace(/^data:.+;base64,/, '');
+    const base64Data = parse.data.logo.replace(/^data:.+;base64,/, '');
     const fileBuffer = decode(base64Data);
 
-    // 5. Validate File Type and Size
-    if (!ALLOWED_MIME_TYPES.includes(mimeType)) {
-      return NextResponse.json({ error: `Invalid file type. Allowed types: ${ALLOWED_MIME_TYPES.join(', ')}` }, { status: 400 });
-    }
-    if (fileBuffer.byteLength > MAX_FILE_SIZE) {
-       return NextResponse.json({ error: `File size exceeds the maximum limit of ${MAX_FILE_SIZE / (1024 * 1024)}MB.` }, { status: 400 });
+    const service = getApiUserService();
+    const result = await service.uploadCompanyLogo(user.id, user.id, fileBuffer);
+    if (!result.success || !result.url) {
+      return NextResponse.json({ error: result.error || 'Failed to upload logo' }, { status: 500 });
     }
 
-    // 6. Upload to Supabase Storage
-    const fileExtension = mimeType.split('/')[1]; // e.g., 'png'
-    const uniqueFilename = `${user.id}-${uuidv4()}.${fileExtension}`;
-    const filePath = `${user.id}/${uniqueFilename}`; // Store under user-specific folder
-
-    const { error: uploadError } = await supabaseService.storage
-      .from(STORAGE_BUCKET)
-      .upload(filePath, fileBuffer, {
-        contentType: mimeType,
-        upsert: true, // Overwrite if file exists (e.g., re-upload)
-      });
-
-    if (uploadError) {
-      console.error(`Supabase storage upload error for user ${user.id}:`, uploadError);
-      return NextResponse.json({ error: 'Failed to upload logo.', details: uploadError.message }, { status: 500 });
-    }
-
-    // 7. Get Public URL
-    const { data: urlData } = supabaseService.storage
-      .from(STORAGE_BUCKET)
-      .getPublicUrl(filePath);
-
-    if (!urlData || !urlData.publicUrl) {
-        console.error(`Failed to get public URL for ${filePath}`);
-        // Consider deleting the uploaded file if URL retrieval fails?
-        return NextResponse.json({ error: 'File uploaded but failed to get URL.' }, { status: 500 });
-    }
-    const publicUrl = urlData.publicUrl;
-
-    // 8. Update Profile Table
-    const { error: updateProfileError } = await supabaseService
-      .from('profiles')
-      .update({ 
-          companyLogoUrl: publicUrl,
-          updatedAt: new Date().toISOString()
-      })
-      .eq('userId', user.id);
-
-    if (updateProfileError) {
-      console.error(`Failed to update profile with logo URL for user ${user.id}:`, updateProfileError);
-      // Consider deleting the uploaded file if profile update fails?
-      return NextResponse.json({ error: 'Logo uploaded but failed to update profile.', details: updateProfileError.message }, { status: 500 });
-    }
-
-    // 9. Handle Success
-    console.log(`Company logo uploaded for user ${user.id}: ${publicUrl}`);
-    return NextResponse.json({ companyLogoUrl: publicUrl });
+    return NextResponse.json({ companyLogoUrl: result.url });
 
   } catch (error) {
     console.error('Unexpected error in POST /api/profile/logo:', error);
@@ -142,86 +63,32 @@ export async function POST(request: NextRequest) {
 
 // --- DELETE Handler for removing company logo ---
 export async function DELETE(request: NextRequest) {
-    // 1. Rate Limiting
     const isRateLimited = await checkRateLimit(request);
     if (isRateLimited) {
       return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
     }
-  
+
     try {
-      // 2. Authentication & Get User
       const authHeader = request.headers.get('authorization');
       if (!authHeader || !authHeader.startsWith('Bearer ')) {
         return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
       }
       const token = authHeader.split(' ')[1];
-  
-      const supabaseService = getServiceSupabase();
-      const { data: { user }, error: userError } = await supabaseService.auth.getUser(token);
-  
-      if (userError || !user) {
-        return NextResponse.json({ error: userError?.message || 'Invalid token' }, { status: 401 });
-      }
-  
-      // 3. Fetch profile to get current logo URL and check permissions
-      const { data: profileData, error: profileError } = await supabaseService
-          .from('profiles')
-          .select('userId, userType, companyLogoUrl') 
-          .eq('userId', user.id)
-          .single();
-  
-      if (profileError || !profileData) {
-          return NextResponse.json({ error: 'Profile not found or error checking permissions.' }, { status: profileError?.code === 'PGRST116' ? 404 : 500 });
-      }
-      if (profileData.userType !== 'corporate') {
-          return NextResponse.json({ error: 'Permission denied. Only corporate users can remove company logos.' }, { status: 403 });
-      }
-      
-      const currentLogoUrl = profileData.companyLogoUrl;
-
-      // 4. Update Profile Table (set companyLogoUrl to null)
-      const { error: updateError } = await supabaseService
-        .from('profiles')
-        .update({ 
-            companyLogoUrl: null, // Set to null
-            updatedAt: new Date().toISOString()
-        })
-        .eq('userId', user.id);
-  
-      if (updateError) {
-        console.error(`Supabase error clearing logo URL for user ${user.id}:`, updateError);
-        return NextResponse.json({ error: 'Failed to remove logo reference from profile.', details: updateError.message }, { status: 500 });
-      }
-  
-      // 5. Delete Logo from Storage (Optional but recommended)
-      if (currentLogoUrl) {
-          try {
-              // Extract the file path from the URL
-              // Assumes URL format: https://<project_ref>.supabase.co/storage/v1/object/public/company-logos/<user_id>/<filename>
-              const urlParts = currentLogoUrl.split('/');
-              const filePath = urlParts.slice(urlParts.indexOf(STORAGE_BUCKET) + 1).join('/');
-              
-              if (filePath) {
-                 console.log(`Attempting to delete logo file from storage: ${filePath}`);
-                 const { error: deleteError } = await supabaseService.storage
-                    .from(STORAGE_BUCKET)
-                    .remove([filePath]);
-                 if (deleteError) {
-                    console.error(`Failed to delete logo file ${filePath} from storage:`, deleteError);
-                    // Log error but don't necessarily fail the request, as profile is updated
-                 }
-              }
-          } catch (e) {
-              console.error('Error parsing or deleting logo file from storage:', e);
-          }
+      const user = await getSessionFromToken(token);
+      if (!user) {
+        return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
       }
 
-      // 6. Handle Success
-      console.log(`Company logo removed for user ${user.id}`);
+      const service = getApiUserService();
+      const result = await service.deleteCompanyLogo(user.id, user.id);
+      if (!result.success) {
+        return NextResponse.json({ error: result.error || 'Failed to remove logo' }, { status: 500 });
+      }
+
       return NextResponse.json({ message: 'Company logo removed successfully.' });
-  
+
     } catch (error) {
       console.error('Unexpected error in DELETE /api/profile/logo:', error);
       return NextResponse.json({ error: 'An internal server error occurred.' }, { status: 500 });
     }
-  } 
+  }


### PR DESCRIPTION
## Summary
- refactor privacy settings API to use auth and user services
- move notifications API to notification service
- simplify logo upload/remove using user service
- remove direct supabase calls from export routes
- fetch export downloads via service utility

## Testing
- `npx vitest run --coverage` *(fails: Adapter not registered)*

------
https://chatgpt.com/codex/tasks/task_b_6841728a09088331bc5d267844669938