### PR TITLE
Refactor backup code verification and oauth initiation

### DIFF
--- a/app/api/2fa/backup-codes/verify/route.ts
+++ b/app/api/2fa/backup-codes/verify/route.ts
@@ -1,100 +1,17 @@
-import { NextResponse } from 'next/server';
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
 import { z } from 'zod';
-import crypto from 'crypto';
+import { createApiHandler } from '@/lib/api/route-helpers';
+import { createSuccessResponse, ApiError, ERROR_CODES } from '@/lib/api/common';
 
-const verifySchema = z.object({
-  code: z.string().min(8).max(10), // e.g., XXXX-XXXX
-});
+const VerifySchema = z.object({ code: z.string().min(8).max(10) });
 
-function hashCode(code: string): string {
-  // Use a secure hash for production (e.g., bcrypt or scrypt). For demo, use SHA256.
-  return crypto.createHash('sha256').update(code).digest('hex');
-}
-
-export async function POST(request: Request): Promise<NextResponse> {
-  try {
-    const body = await request.json();
-    const { code } = verifySchema.parse(body);
-
-    // Initialize Supabase client
-    const cookieStore = cookies();
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      {
-        cookies: {
-          get(name: string) {
-            return cookieStore.get(name)?.value;
-          },
-          set(name: string, value: string, options: Record<string, unknown>) {
-            cookieStore.set({ name, value, ...options });
-          },
-          remove(name: string, options: Record<string, unknown>) {
-            cookieStore.set({ name, value: '', ...options });
-          },
-        },
-      }
-    );
-
-    // Verify user authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Authentication required' },
-        { status: 401 }
-      );
+export const POST = createApiHandler(
+  VerifySchema,
+  async (_req, auth, data, services) => {
+    const result = await services.twoFactor!.verifyBackupCode(auth.userId, data.code);
+    if (!result.success) {
+      throw new ApiError(ERROR_CODES.INVALID_REQUEST, result.error || 'Invalid code', 400);
     }
-
-    // Get backup codes from user metadata
-    const storedCodes: string[] = user.user_metadata?.backupCodes || [];
-    if (!storedCodes.length) {
-      return NextResponse.json(
-        { error: 'No backup codes found. Please generate new codes.' },
-        { status: 400 }
-      );
-    }
-
-    // For security, hash the input code and compare to stored hashes
-    // (If stored codes are unhashed, compare directly, but recommend hashing in production)
-    const codeHash = hashCode(code.replace(/-/g, '').toUpperCase());
-    const storedHashes = storedCodes.map((c) => hashCode(c.replace(/-/g, '').toUpperCase()));
-    const matchIdx = storedHashes.findIndex((h) => h === codeHash);
-
-    if (matchIdx === -1) {
-      return NextResponse.json(
-        { error: 'Invalid backup code.' },
-        { status: 400 }
-      );
-    }
-
-    // Remove the used code
-    const updatedCodes = [...storedCodes];
-    updatedCodes.splice(matchIdx, 1);
-
-    // Update user metadata
-    const { error: updateError } = await supabase.auth.updateUser({
-      data: {
-        backupCodes: updatedCodes,
-      },
-    });
-    if (updateError) {
-      return NextResponse.json(
-        { error: updateError.message },
-        { status: 500 }
-      );
-    }
-
-    // Optionally: log the event (audit log)
-    // TODO: Add audit logging here
-
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    console.error('Error verifying backup code:', error);
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'An unexpected error occurred' },
-      { status: 500 }
-    );
-  }
-}
+    return createSuccessResponse(result);
+  },
+  { requireAuth: true }
+);

--- a/src/core/two-factor/interfaces.ts
+++ b/src/core/two-factor/interfaces.ts
@@ -39,6 +39,12 @@ export interface TwoFactorService {
   /** Generate a new set of backup codes for a user */
   regenerateBackupCodes(userId: string): Promise<BackupCodesResponse>;
 
+  /** Verify a backup code and consume it */
+  verifyBackupCode(
+    userId: string,
+    code: string
+  ): Promise<TwoFactorVerifyResponse>;
+
   /** Begin WebAuthn registration flow */
   startWebAuthnRegistration(userId: string): Promise<TwoFactorSetupResponse>;
 


### PR DESCRIPTION
## Summary
- refactor OAuth init route to use AuthService rather than Supabase client
- add backup code verification to TwoFactor service
- use service-based handler for backup code verify route

## Testing
- `npm test` *(fails: The current testing environment is not configured to support act(...))*
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_684176ac48348331bad44a0a46e503d7