### PR TITLE
Refactor profile export routes to use service layer

### DIFF
--- a/app/api/profile/export/download/route.ts
+++ b/app/api/profile/export/download/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { logUserAction } from '@/lib/audit/auditLogger';
-import { getUserDataExportByToken, getUserExportDownloadUrl } from '@/lib/exports/export.service';
+import { getApiDataExportService } from '@/services/data-export';
 import { ExportStatus } from '@/lib/exports/types';
 
 /**
@@ -11,13 +11,15 @@ export async function GET(req: NextRequest) {
   try {
     const url = new URL(req.url);
     const token = url.searchParams.get('token');
+
+    const service = getApiDataExportService();
     
     if (!token) {
       return NextResponse.json({ error: 'Missing download token' }, { status: 400 });
     }
     
     // Get the export record using the token
-    const exportRecord = await getUserDataExportByToken(token);
+    const exportRecord = await service.getUserDataExportByToken(token);
     
     if (!exportRecord) {
       return NextResponse.json({ 
@@ -36,7 +38,7 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: 'Export file not found' }, { status: 404 });
     }
     
-    const downloadUrl = getUserExportDownloadUrl(exportRecord.filePath);
+    const downloadUrl = service.getUserExportDownloadUrl(exportRecord.filePath);
     const response = await fetch(downloadUrl);
     if (!response.ok) {
       return NextResponse.json({ error: 'Failed to download file' }, { status: 500 });

--- a/src/core/data-export/interfaces.ts
+++ b/src/core/data-export/interfaces.ts
@@ -1,0 +1,18 @@
+export interface DataExportService {
+  createUserDataExport(
+    userId: string,
+    options?: Partial<import('@/lib/exports/types').ExportOptions>
+  ): Promise<import('@/lib/exports/types').UserDataExport | null>;
+
+  processUserDataExport(exportId: string, userId: string): Promise<void>;
+
+  getUserExportData(userId: string): Promise<import('@/lib/exports/types').UserExportData>;
+
+  checkUserExportStatus(exportId: string): Promise<import('@/lib/exports/types').DataExportResponse>;
+
+  getUserDataExportById(exportId: string): Promise<import('@/lib/exports/types').UserDataExport | null>;
+
+  getUserDataExportByToken(token: string): Promise<import('@/lib/exports/types').UserDataExport | null>;
+
+  getUserExportDownloadUrl(filePath: string): string;
+}

--- a/src/services/data-export/default-data-export.service.ts
+++ b/src/services/data-export/default-data-export.service.ts
@@ -1,0 +1,49 @@
+import { DataExportService } from '@/core/data-export/interfaces';
+import {
+  createUserDataExport,
+  processUserDataExport,
+  getUserExportData,
+  checkUserExportStatus,
+  getUserDataExportById,
+  getUserDataExportByToken,
+  getUserExportDownloadUrl,
+} from '@/lib/exports/export.service';
+import type {
+  ExportOptions,
+  UserDataExport,
+  UserExportData,
+  DataExportResponse,
+} from '@/lib/exports/types';
+
+export class DefaultDataExportService implements DataExportService {
+  createUserDataExport(
+    userId: string,
+    options?: Partial<ExportOptions>
+  ): Promise<UserDataExport | null> {
+    return createUserDataExport(userId, options);
+  }
+
+  processUserDataExport(exportId: string, userId: string): Promise<void> {
+    return processUserDataExport(exportId, userId);
+  }
+
+  getUserExportData(userId: string): Promise<UserExportData> {
+    return getUserExportData(userId);
+  }
+
+  checkUserExportStatus(exportId: string): Promise<DataExportResponse> {
+    return checkUserExportStatus(exportId);
+  }
+
+  getUserDataExportById(exportId: string): Promise<UserDataExport | null> {
+    return getUserDataExportById(exportId);
+  }
+
+  getUserDataExportByToken(token: string): Promise<UserDataExport | null> {
+    return getUserDataExportByToken(token);
+  }
+
+  getUserExportDownloadUrl(filePath: string): string {
+    return getUserExportDownloadUrl(filePath);
+  }
+}

--- a/src/services/data-export/factory.ts
+++ b/src/services/data-export/factory.ts
@@ -1,0 +1,23 @@
+/**
+ * Data Export Service Factory for API routes
+ */
+import { DataExportService } from '@/core/data-export/interfaces';
+import { DefaultDataExportService } from './default-data-export.service';
+
+let instance: DataExportService | null = null;
+
+export interface DataExportServiceOptions {
+  reset?: boolean;
+}
+
+export function getApiDataExportService(options: DataExportServiceOptions = {}): DataExportService {
+  if (options.reset) {
+    instance = null;
+  }
+
+  if (!instance) {
+    instance = new DefaultDataExportService();
+  }
+
+  return instance;
+}

--- a/src/services/data-export/index.ts
+++ b/src/services/data-export/index.ts
@@ -1,0 +1,3 @@
+export { DefaultDataExportService } from './default-data-export.service';
+export { getApiDataExportService } from './factory';
+export type { DataExportService } from '@/core/data-export/interfaces';


### PR DESCRIPTION
## Summary
- add DataExportService interface and default service wrapper
- implement API service factory
- refactor profile export routes to use DataExportService

## Testing
- `npx vitest run --coverage` *(fails: Adapter errors and act() warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68417a4c8ed08331a357b741bfa707cd