### PR TITLE
Refactor domain verification routes

### DIFF
--- a/app/api/company/domains/[id]/verify-check/route.ts
+++ b/app/api/company/domains/[id]/verify-check/route.ts
@@ -1,114 +1,29 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { getServiceSupabase } from "@/lib/database/supabase";
+import { getApiCompanyService } from "@/services/company/factory";
 import { type RouteAuthContext } from "@/middleware/auth";
 import { createApiHandler } from "@/lib/api/route-helpers";
-import { createSuccessResponse } from "@/lib/api/common";
 import dns from "dns/promises";
 
-const supabaseService = getServiceSupabase();
 
 
 async function handlePost(
   _request: NextRequest,
   params: { id: string },
-  auth: RouteAuthContext,
-  services: any
+  auth: RouteAuthContext
 ) {
   try {
     const userId = auth.userId!;
 
-    const { data: domainRecord, error: domainError } = await supabaseService
-      .from("company_domains")
-      .select("*")
-      .eq("id", params.id)
-      .single();
+    const companyService = getApiCompanyService();
+    const result = await companyService.checkDomainVerification(params.id, userId);
 
-    if (domainError || !domainRecord) {
-      console.error(`Error fetching domain ${params.id}:`, domainError);
-      return NextResponse.json({ error: "Domain not found." }, { status: 404 });
-    }
-
-    const profile = await services.addressService.getProfileByUserId(userId);
-    if (!profile || profile.id !== domainRecord.company_id) {
-      return NextResponse.json(
-        { error: "You do not have permission to verify this domain." },
-        { status: 403 },
-      );
-    }
-
-    if (!domainRecord.verification_token) {
-      return NextResponse.json(
-        { error: "Domain verification has not been initiated." },
-        { status: 400 },
-      );
-    }
-
-    const { domain, verification_token } = domainRecord;
-    let isVerified = false;
-    let dnsCheckError: string | null = null;
-
-    try {
-      const dnsPromise = dns.resolveTxt(domain);
-      const timeoutPromise = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("DNS lookup timeout")), 10000),
-      );
-      const records = await Promise.race([dnsPromise, timeoutPromise]);
-
-      for (const recordParts of records as string[][]) {
-        const recordValue = recordParts.join("");
-        if (recordValue === verification_token) {
-          isVerified = true;
-          break;
-        }
-      }
-    } catch (error: any) {
-      if (error.code === "ENOTFOUND" || error.code === "ENODATA") {
-        dnsCheckError = "No TXT records found for the domain.";
-      } else if (error.message === "DNS lookup timeout") {
-        dnsCheckError = "DNS lookup timed out. Please try again later.";
-      } else {
-        dnsCheckError = "An error occurred during DNS lookup.";
-      }
-    }
-
-    const { error: updateError } = await supabaseService
-      .from("company_domains")
-      .update({
-        is_verified: isVerified,
-        verification_date: isVerified ? new Date().toISOString() : null,
-        last_checked: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      })
-      .eq("id", domainRecord.id);
-
-    if (updateError) {
-      console.error(
-        `Error updating domain verification status for ${domain}:`,
-        updateError,
-      );
-      return NextResponse.json(
-        {
-          error: "Failed to update domain verification status.",
-          details: updateError.message,
-        },
-        { status: 500 },
-      );
-    }
-
-    if (isVerified) {
-      return NextResponse.json({
-        verified: true,
-        message: "Domain successfully verified.",
-      });
+    if (result.verified) {
+      return NextResponse.json({ verified: true, message: result.message });
     }
 
     return NextResponse.json(
-      {
-        verified: false,
-        message:
-          dnsCheckError || "Verification token not found in TXT records.",
-      },
+      { verified: false, message: result.message },
       { status: 400 },
     );
   } catch (error) {
@@ -123,6 +38,6 @@ async function handlePost(
 export const POST = (req: NextRequest, ctx: { params: { id: string } }) =>
   createApiHandler(
     z.object({}),
-    (r, a, d, services) => handlePost(r, ctx.params, a, services),
+    (r, a) => handlePost(r, ctx.params, a),
     { requireAuth: true }
   )(req);

--- a/app/api/company/domains/[id]/verify-initiate/route.ts
+++ b/app/api/company/domains/[id]/verify-initiate/route.ts
@@ -1,86 +1,46 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { getServiceSupabase } from "@/lib/database/supabase";
+import { getApiCompanyService } from "@/services/company/factory";
 import { type RouteAuthContext } from "@/middleware/auth";
 import { createApiHandler } from "@/lib/api/route-helpers";
-import { createSuccessResponse } from "@/lib/api/common";
-import { v4 as uuidv4 } from "uuid";
 
-const VERIFICATION_PREFIX = "user-management-verification=";
-
-const supabaseService = getServiceSupabase();
 
 
 async function handlePost(
   _request: NextRequest,
   params: { id: string },
-  auth: RouteAuthContext,
-  services: any
+  auth: RouteAuthContext
 ) {
   try {
     const userId = auth.userId!;
 
-    const { data: domainRecord, error: domainError } = await supabaseService
-      .from("company_domains")
-      .select("*")
-      .eq("id", params.id)
-      .single();
-
-    if (domainError || !domainRecord) {
-      console.error(`Error fetching domain ${params.id}:`, domainError);
-      return NextResponse.json({ error: "Domain not found." }, { status: 404 });
-    }
-
-    const profile = await services.addressService.getProfileByUserId(userId);
-    if (!profile || profile.id !== domainRecord.company_id) {
-      return NextResponse.json(
-        { error: "You do not have permission to verify this domain." },
-        { status: 403 },
-      );
-    }
-
-    const verificationToken = `${VERIFICATION_PREFIX}${uuidv4()}`;
-
-    const { error: updateError } = await supabaseService
-      .from("company_domains")
-      .update({
-        verification_token: verificationToken,
-        is_verified: false,
-        verification_date: null,
-        last_checked: null,
-        updated_at: new Date().toISOString(),
-      })
-      .eq("id", domainRecord.id);
-
-    if (updateError) {
-      console.error(
-        `Error initiating verification for domain ${params.id}:`,
-        updateError,
-      );
-      return NextResponse.json(
-        { error: "Failed to update domain with verification token." },
-        { status: 500 },
-      );
-    }
+    const companyService = getApiCompanyService();
+    const result = await companyService.initiateDomainVerification(
+      params.id,
+      userId,
+    );
 
     return NextResponse.json({
-      domain: domainRecord.domain,
-      verificationToken,
+      domain: result.domain,
+      verificationToken: result.verificationToken,
       message:
         "Domain verification initiated. Add the token as a TXT record in your DNS.",
     });
   } catch (error) {
     console.error("Unexpected error in initiate domain verification:", error);
-    return NextResponse.json(
-      { error: "An internal server error occurred." },
-      { status: 500 },
-    );
+    const message = (error as Error).message || 'An internal server error occurred.';
+    const status = message.includes('not found')
+      ? 404
+      : message.includes('permission')
+        ? 403
+        : 500;
+    return NextResponse.json({ error: message }, { status });
   }
 }
 
 export const POST = (req: NextRequest, ctx: { params: { id: string } }) =>
   createApiHandler(
     z.object({}),
-    (r, a, d, services) => handlePost(r, ctx.params, a, services),
+    (r, a) => handlePost(r, ctx.params, a),
     { requireAuth: true }
   )(req);

--- a/app/api/company/verify-domain/check/route.ts
+++ b/app/api/company/verify-domain/check/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { getServiceSupabase } from '@/lib/database/supabase';
+import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
-import dns from 'dns/promises'; // Import Node.js DNS promises API
 
 export async function POST(request: NextRequest) {
   // 1. Rate Limiting
@@ -25,91 +25,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: userError?.message || 'Invalid token' }, { status: 401 });
     }
 
-    // 3. Get Company Profile Domain Info
-    // Assuming company_profiles is linked via user_id
-    const { data: companyProfile, error: profileError } = await supabaseService
-        .from('company_profiles')
-        .select('id, domain_name, domain_verification_token')
-        .eq('user_id', user.id) // Check if user_id is the correct FK
-        .single();
+    const companyService = getApiCompanyService();
+    const result = await companyService.checkProfileDomainVerification(user.id);
 
-    if (profileError) {
-        console.error(`Check Domain: Error fetching company profile for user ${user.id}:`, profileError);
-        return NextResponse.json({ error: 'Failed to fetch company profile.' }, { status: 500 });
-    }
-    if (!companyProfile) {
-        return NextResponse.json({ error: 'Company profile not found.' }, { status: 404 });
-    }
-    if (!companyProfile.domain_name || !companyProfile.domain_verification_token) {
-        return NextResponse.json({ error: 'Domain verification has not been initiated for this company.' }, { status: 400 });
+    if (result.verified) {
+        return NextResponse.json({ verified: true, message: result.message });
     }
 
-    const { domain_name, domain_verification_token } = companyProfile;
-    let isVerified = false;
-    let dnsCheckError: string | null = null;
-
-    // 4. Perform DNS TXT Lookup
-    try {
-        console.log(`Checking TXT records for domain: ${domain_name}`);
-        const records = await dns.resolveTxt(domain_name);
-        // records is an array of arrays of strings (each inner array is one TXT record part)
-        console.log(`Found TXT records for ${domain_name}:`, records);
-
-        // Check if any record contains the verification token
-        for (const recordParts of records) {
-            const recordValue = recordParts.join(''); // Join parts if record is split
-            if (recordValue === domain_verification_token) {
-                console.log(`Verification token found for ${domain_name}`);
-                isVerified = true;
-                break;
-            }
-        }
-    } catch (error: any) {        
-        if (error.code === 'ENOTFOUND' || error.code === 'ENODATA') {
-            console.warn(`No TXT records found for domain ${domain_name}`);
-            dnsCheckError = 'No TXT records found for the domain.';
-            // isVerified remains false
-        } else {
-            console.error(`DNS lookup error for ${domain_name}:`, error);
-            dnsCheckError = 'An error occurred during DNS lookup.';
-            // Keep isVerified false, potentially log this for investigation
-        }
-    }
-
-    // 5. Update Database
-    const { error: updateError } = await supabaseService
-        .from('company_profiles')
-        .update({
-            domain_verified: isVerified,
-            domain_last_checked: new Date().toISOString(),
-            // Optionally clear the token once verified?
-            // domain_verification_token: isVerified ? null : domain_verification_token, 
-            updated_at: new Date().toISOString(),
-        })
-        .eq('id', companyProfile.id);
-
-    if (updateError) {
-        console.error(`Check Domain: Error updating company profile for verification status (user ${user.id}):`, updateError);
-        // Don't fail the request, but report that DB update failed
-        return NextResponse.json({ 
-            verified: isVerified, 
-            message: isVerified ? 'Domain verified, but failed to save status.' : (dnsCheckError || 'Verification failed, and failed to save status.'),
-            error: 'Database update failed.'
-        }, { status: 500 }); 
-    }
-
-    // 6. Return Status
-    if (isVerified) {
-        return NextResponse.json({ 
-            verified: true, 
-            message: 'Domain successfully verified.' 
-        });
-    } else {
-        return NextResponse.json({ 
-            verified: false, 
-            message: dnsCheckError || 'Verification token not found in TXT records.' 
-        }, { status: 400 }); // Use 400 to indicate verification failure
-    }
+    return NextResponse.json({ verified: false, message: result.message }, { status: 400 });
 
   } catch (error) {
     console.error('Unexpected error in POST /api/company/verify-domain/check:', error);

--- a/app/api/company/verify-domain/initiate/route.ts
+++ b/app/api/company/verify-domain/initiate/route.ts
@@ -1,10 +1,8 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { getServiceSupabase } from '@/lib/database/supabase';
+import { getApiCompanyService } from '@/services/company/factory';
 import { checkRateLimit } from '@/middleware/rate-limit';
-import { v4 as uuidv4 } from 'uuid';
 import { URL } from 'url'; // Use Node.js URL parser
-
-const VERIFICATION_PREFIX = 'user-management-verification=';
 
 export async function POST(request: NextRequest) {
   // 1. Rate Limiting
@@ -28,61 +26,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: userError?.message || 'Invalid token' }, { status: 401 });
     }
 
-    // 3. Get Company Profile and Website URL
-    // Assuming company_profiles is linked via user_id
-    // Adjust table/column names if different
-    const { data: companyProfile, error: profileError } = await supabaseService
-        .from('company_profiles')
-        .select('id, website')
-        .eq('user_id', user.id) // Check if user_id is the correct FK
-        .single();
+    const companyService = getApiCompanyService();
+    const result = await companyService.initiateProfileDomainVerification(user.id);
 
-    if (profileError) {
-        console.error(`Error fetching company profile for user ${user.id}:`, profileError);
-        return NextResponse.json({ error: 'Failed to fetch company profile.' }, { status: 500 });
-    }
-    if (!companyProfile) {
-        return NextResponse.json({ error: 'Company profile not found.' }, { status: 404 });
-    }
-    if (!companyProfile.website) {
-        return NextResponse.json({ error: 'Company website URL is not set in the profile. Cannot initiate domain verification.' }, { status: 400 });
-    }
-
-    // 4. Extract Domain Name
-    let domainName: string;
-    try {
-        const url = new URL(companyProfile.website);
-        domainName = url.hostname.replace(/^www\./, ''); // Remove www.
-        if (!domainName) throw new Error('Invalid hostname');
-    } catch (e) {
-        console.error(`Invalid website URL format for user ${user.id}: ${companyProfile.website}`);
-        return NextResponse.json({ error: 'Invalid website URL format in profile.' }, { status: 400 });
-    }
-
-    // 5. Generate Verification Token
-    const verificationToken = `${VERIFICATION_PREFIX}${uuidv4()}`;
-
-    // 6. Update Company Profile in Database
-    const { error: updateError } = await supabaseService
-        .from('company_profiles')
-        .update({
-            domain_name: domainName,
-            domain_verification_token: verificationToken,
-            domain_verified: false, // Reset verification status
-            domain_last_checked: null, // Clear last checked time
-            updated_at: new Date().toISOString(),
-        })
-        .eq('id', companyProfile.id); // Use the company profile ID
-
-    if (updateError) {
-        console.error(`Error updating company profile for domain verification (user ${user.id}):`, updateError);
-        return NextResponse.json({ error: 'Failed to update profile with verification token.' }, { status: 500 });
-    }
-
-    // 7. Return Token and Domain to Frontend
     return NextResponse.json({
-        domainName: domainName,
-        verificationToken: verificationToken,
+        domainName: result.domainName,
+        verificationToken: result.verificationToken,
         message: "Verification initiated. Please add the provided token as a TXT record to your domain's DNS settings."
     });
 


### PR DESCRIPTION
## Summary
- refactor company domain verification API routes to use CompanyService
- add domain verification methods to `CompanyService`
- update related tests to mock service layer

## Testing
- `npx vitest run --coverage` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68417d322e3483319f275efc1537956f