### PR TITLE
Refactor company document API route

### DIFF
--- a/app/api/company/documents/[documentId]/route.ts
+++ b/app/api/company/documents/[documentId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { getServiceSupabase } from "@/lib/database/supabase";
+import { getApiCompanyService } from "@/services/company/factory";
 import { type RouteAuthContext } from "@/middleware/auth";
 import { createApiHandler } from "@/lib/api/route-helpers";
 import { createSuccessResponse } from "@/lib/api/common";
@@ -11,13 +11,12 @@ async function handleDelete(
   _request: NextRequest,
   params: { documentId: string },
   auth: RouteAuthContext,
-  services: any
 ) {
   try {
-    const supabaseService = getServiceSupabase();
+    const companyService = getApiCompanyService();
     const userId = auth.userId!;
 
-    const companyProfile = await services.addressService.getProfileByUserId(userId);
+    const companyProfile = await companyService.getProfileByUserId(userId);
 
     if (!companyProfile) {
       return NextResponse.json(
@@ -26,48 +25,19 @@ async function handleDelete(
       );
     }
 
-    // 4. Get Document
-    const { data: document, error: documentError } = await supabaseService
-      .from("company_documents")
-      .select("*")
-      .eq("id", params.documentId)
-      .eq("company_id", companyProfile.id)
-      .single();
+    const document = await companyService.getDocument(
+      companyProfile.id,
+      params.documentId,
+    );
 
-    if (documentError || !document) {
+    if (!document) {
       return NextResponse.json(
         { error: "Document not found" },
         { status: 404 },
       );
     }
 
-    // 5. Delete File from Storage
-    const { error: storageError } = await supabaseService.storage
-      .from("company-documents")
-      .remove([document.file_path]);
-
-    if (storageError) {
-      console.error("Error deleting file from storage:", storageError);
-      return NextResponse.json(
-        { error: "Failed to delete file" },
-        { status: 500 },
-      );
-    }
-
-    // 6. Delete Document Record
-    const { error: deleteError } = await supabaseService
-      .from("company_documents")
-      .delete()
-      .eq("id", params.documentId)
-      .eq("company_id", companyProfile.id);
-
-    if (deleteError) {
-      console.error("Error deleting document record:", deleteError);
-      return NextResponse.json(
-        { error: "Failed to delete document record" },
-        { status: 500 },
-      );
-    }
+    await companyService.deleteDocument(companyProfile.id, params.documentId);
 
     return createSuccessResponse({ success: true });
   } catch (error) {
@@ -88,6 +58,6 @@ export const DELETE = (
 ) =>
   createApiHandler(
     z.object({}),
-    (r, a, d, services) => handleDelete(r, ctx.params, a, services),
+    (r, a) => handleDelete(r, ctx.params, a),
     { requireAuth: true }
   )(req);

--- a/src/services/company/__tests__/companyService.test.ts
+++ b/src/services/company/__tests__/companyService.test.ts
@@ -2,17 +2,23 @@ import { describe, it, expect, vi } from 'vitest';
 import { DefaultCompanyService } from '../companyService';
 import { getServiceSupabase } from '@/lib/database/supabase';
 
-vi.mock('@/lib/database/supabase', () => ({
-  getServiceSupabase: vi.fn(() => ({
-    from: vi.fn(() => ({
-      select: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          single: vi.fn()
-        }))
-      }))
+vi.mock('@/lib/database/supabase', () => {
+  const single = vi.fn();
+  const remove = vi.fn();
+  const eq: any = vi.fn(() => ({ eq, single }));
+
+  return {
+    getServiceSupabase: vi.fn(() => ({
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({ eq })),
+        insert: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(() => ({ eq })),
+      })),
+      storage: { from: vi.fn(() => ({ remove })) }
     }))
-  }))
-}));
+  };
+});
 
 describe('DefaultCompanyService.getProfileByUserId', () => {
   it('returns profile when found', async () => {
@@ -74,5 +80,21 @@ describe('DefaultCompanyService profile operations', () => {
     const service = new DefaultCompanyService();
     const result = await service.getDomainById('d1');
     expect(result).toEqual({ id: 'd1' });
+  });
+});
+
+describe('DefaultCompanyService document operations', () => {
+  it('deletes document', async () => {
+    const supabase = getServiceSupabase();
+    const single = vi.fn().mockResolvedValue({ data: { id: 'doc1', file_path: 'p1', company_id: 'c1' }, error: null });
+    (supabase.from as any).mockReturnValue({
+      select: vi.fn(() => ({ eq: vi.fn(() => ({ eq: vi.fn(() => ({ single })) })) })),
+      delete: vi.fn(() => ({ eq: vi.fn(() => ({ eq: vi.fn(() => ({ error: null })) })) })),
+    });
+    (supabase.storage.from as any).mockReturnValue({ remove: vi.fn().mockResolvedValue({ error: null }) });
+
+    const service = new DefaultCompanyService();
+    await service.deleteDocument('c1', 'doc1');
+    expect(single).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- decouple company document delete route from Supabase
- add document management methods to `CompanyService`
- test new document delete flow

## Testing
- `npx vitest run --coverage` *(fails: environment issues)*

------
https://chatgpt.com/codex/tasks/task_b_68418183a40083318292ca894b4c0e0c