### PR TITLE
Refactor OAuth and 2FA routes to use service layer

### DIFF
--- a/app/api/2fa/setup/route.ts
+++ b/app/api/2fa/setup/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
-import { authenticator } from 'otplib';
-import * as qrcode from 'qrcode';
 import { TwoFactorMethod } from '@/types/2fa';
 import { createApiHandler } from '@/lib/api/route-helpers';
 import { createSuccessResponse } from '@/lib/api/common';
@@ -15,80 +13,31 @@ const setupRequestSchema = z.object({
 
 export const POST = createApiHandler(
   setupRequestSchema,
-  async (request: NextRequest, authContext, data, services) => {
+  async (_req: NextRequest, authContext, data, services) => {
     try {
       const user = authContext.user!;
       const { method, phone, email } = data;
 
-      switch (method) {
-      case TwoFactorMethod.TOTP: {
-        try {
-          const setupResult = await services.twoFactor!.setupTOTP(user.id);
-          const appName = 'User Management';
-          const accountName = user.email || user.id;
-          const otpAuthUrl = authenticator.keyuri(accountName, appName, setupResult.secret);
-          const qrCodeDataUrl = await qrcode.toDataURL(otpAuthUrl);
-          return createSuccessResponse({ secret: setupResult.secret, qrCode: qrCodeDataUrl });
-        } catch (error) {
-          console.error('Failed to set up TOTP:', error);
-          return NextResponse.json(
-            { error: error instanceof Error ? error.message : 'Failed to set up TOTP' },
-            { status: 400 }
-          );
-        }
+      const result = await services.twoFactor!.startSetup({
+        userId: user.id,
+        method,
+        phone,
+        email,
+      });
+
+      if (!result.success) {
+        return NextResponse.json(
+          { error: result.error || 'Failed to start 2FA setup' },
+          { status: 400 },
+        );
       }
 
-      case TwoFactorMethod.SMS: {
-        const resolvedPhone = user.user_metadata?.mfaPhone || phone;
-        if (!resolvedPhone) {
-          return NextResponse.json(
-            { error: 'Phone number is required for SMS MFA setup.' },
-            { status: 400 }
-          );
-        }
-        try {
-          await services.twoFactor!.setupSMS(user.id, resolvedPhone);
-          return createSuccessResponse({ success: true });
-        } catch (error) {
-          console.error('Failed to set up SMS MFA:', error);
-          return NextResponse.json(
-            { error: error instanceof Error ? error.message : 'Failed to set up SMS MFA' },
-            { status: 400 }
-          );
-        }
-      }
-
-      case TwoFactorMethod.EMAIL: {
-        const resolvedEmail = user.user_metadata?.mfaEmail || email || user.email;
-        if (!resolvedEmail) {
-          return NextResponse.json(
-            { error: 'Email address is required for Email MFA setup.' },
-            { status: 400 }
-          );
-        }
-        try {
-          await services.twoFactor!.setupEmail(user.id, resolvedEmail);
-          return createSuccessResponse({ success: true, testid: 'email-mfa-setup-success' });
-        } catch (error) {
-          console.error('Failed to set up Email MFA:', error);
-          return NextResponse.json(
-            { error: error instanceof Error ? error.message : 'Failed to send verification email.' },
-            { status: 500 }
-          );
-        }
-      }
-
-        default:
-          return NextResponse.json(
-            { error: `Unsupported MFA method: ${method}` },
-            { status: 400 }
-          );
-      }
+      return createSuccessResponse(result);
     } catch (error) {
       console.error('Error in 2FA setup:', error);
       return NextResponse.json(
         { error: error instanceof Error ? error.message : 'An unexpected error occurred' },
-        { status: 500 }
+        { status: 500 },
       );
     }
   },

--- a/app/api/auth/oauth/link/__tests__/route.test.ts
+++ b/app/api/auth/oauth/link/__tests__/route.test.ts
@@ -1,278 +1,39 @@
 import { POST } from '../route';
 import { OAuthProvider } from '@/types/oauth';
-import { describe, it, expect, vi, beforeEach, MockedFunction } from 'vitest';
-// import { cookies } from 'next/headers'; // Mocked
-// import { createServerClient } from '@supabase/ssr'; // Mocked
-import { logUserAction } from '@/lib/audit/auditLogger'; // Mocked, but type used
-import { sendProviderLinkedNotification } from '@/lib/notifications/sendProviderLinkedNotification';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getApiOAuthService } from '@/services/oauth/factory';
 
-// --- Mocks ---
+vi.mock('@/services/oauth/factory');
 
-// 1. Mock next/headers cookies (same as callback)
-const mockCookies = new Map<string, any>();
-vi.mock('next/headers', () => ({
-  cookies: () => ({
-    get: (key: string) => mockCookies.get(key),
-    set: (key: string | { name: string; [key: string]: any }, value?: string | object) => {
-      if (typeof key === 'string') {
-        mockCookies.set(key, { name: key, value: value, httpOnly: true, secure: true, sameSite: 'lax', maxAge: 600, path: '/', ...((typeof value === 'object') ? value : {}) });
-      } else {
-        mockCookies.set(key.name, { httpOnly: true, secure: true, sameSite: 'lax', maxAge: 600, path: '/', ...key });
-      }
-    },
-    has: (key: string) => mockCookies.has(key),
-    delete: (key: string) => mockCookies.delete(key),
-    getAll: () => Array.from(mockCookies.values()),
-  }),
-}));
-
-// 2. Mock Supabase Client (same as callback)
-const mockSupabaseAuth = {
-  exchangeCodeForSession: vi.fn(),
-  getSession: vi.fn(), // Although not directly called, getUser might use it
-  getUser: vi.fn(),
-};
-const mockFrom = vi.fn();
-const mockSupabaseClient = {
-  auth: mockSupabaseAuth,
-  from: mockFrom,
-};
-vi.mock('@supabase/ssr', () => ({
-  createServerClient: vi.fn(() => mockSupabaseClient),
-}));
-
-interface Builder {
-  select: any; eq: any; maybeSingle: any; insert: any; then: any;
-}
-let builders: Array<{ table: string; builder: Builder }> = [];
-function createBuilder(response: any = { data: null, error: null }): Builder {
-  const builder: any = {
-    select: vi.fn(() => builder),
-    eq: vi.fn(() => builder),
-    maybeSingle: vi.fn(() => Promise.resolve(response)),
-    insert: vi.fn(() => Promise.resolve(response)),
-  };
-  builder.then = (resolve: any, reject?: any) => Promise.resolve(response).then(resolve, reject);
-  return builder;
-}
-
-// 3. Mock Audit Logger (same as callback)
-vi.mock('@/lib/audit/auditLogger', () => ({
-  logUserAction: vi.fn(),
-}));
-vi.mock('@/lib/notifications/sendProviderLinkedNotification', () => ({
-  sendProviderLinkedNotification: vi.fn(),
-}));
-
-const mockLogUserAction = logUserAction as MockedFunction<typeof logUserAction>;
-const mockSendNotification = sendProviderLinkedNotification as MockedFunction<typeof sendProviderLinkedNotification>;
-
-// --- Test Data ---
-const validCode = 'valid-linking-code';
-const loggedInUserId = 'logged-in-user-abc';
-const providerToLink = OAuthProvider.GITHUB;
-const providerToLinkAccountId = 'github-user-789';
-const providerToLinkEmail = 'link@example.com';
-
-const mockLoggedInUser = {
-  id: loggedInUserId,
-  email: 'original@example.com',
-  // ... other fields
+const mockService = {
+  linkProvider: vi.fn(),
 };
 
-const mockProviderUser = {
-  id: 'provider-internal-id-xyz', // This ID might not be the loggedInUserId initially
-  email: providerToLinkEmail,
-  app_metadata: {
-    provider: 'github',
-    provider_id: providerToLinkAccountId,
-    providers: ['github']
-  },
-  // ... other fields
-};
-
-// --- Test Suite ---
+const createRequest = (body: object) =>
+  new Request('http://localhost/api/auth/oauth/link', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
 
 describe('POST /api/auth/oauth/link', () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    mockCookies.clear();
-    builders = [];
-    mockFrom.mockImplementation((table: string) => {
-      const b = createBuilder();
-      builders.push({ table, builder: b });
-      return b;
-    });
-    // Assume user is logged in for most tests
-    mockSupabaseAuth.getUser.mockResolvedValueOnce({ data: { user: mockLoggedInUser }, error: null });
+    (getApiOAuthService as vi.Mock).mockReturnValue(mockService);
   });
 
-  // Helper to create request
-  const createRequest = (body: object) => {
-    return new Request('http://localhost/api/auth/oauth/link', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
-  };
-
-  it('should return 401 if user is not authenticated', async () => {
-    mockSupabaseAuth.getUser.mockReset(); // Override beforeEach mock
-    mockSupabaseAuth.getUser.mockResolvedValueOnce({ data: { user: null }, error: { message: 'Unauthorized', status: 401 } });
-
-    const request = createRequest({ provider: providerToLink, code: validCode });
-    const response = await POST(request);
-    const body = await response.json();
-
-    expect(response.status).toBe(401);
-    expect(body.error).toBe('Authentication required');
+  it('returns error when service fails', async () => {
+    mockService.linkProvider.mockResolvedValue({ success: false, error: 'err', status: 400 });
+    const res = await POST(createRequest({ provider: OAuthProvider.GITHUB, code: 'x' }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'err' });
+    expect(mockService.linkProvider).toHaveBeenCalledWith(OAuthProvider.GITHUB, 'x');
   });
 
-  it('should return 400 if code exchange fails', async () => {
-    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({ data: null, error: { message: 'Invalid code for link', status: 400 } });
-
-    const request = createRequest({ provider: providerToLink, code: 'invalid-code' });
-    const response = await POST(request);
-    const body = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(body.error).toBe('Invalid code for link');
+  it('returns success data from service', async () => {
+    mockService.linkProvider.mockResolvedValue({ success: true, user: { id: '1' }, linkedProviders: ['g'] });
+    const res = await POST(createRequest({ provider: OAuthProvider.GITHUB, code: 'y' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, linkedProviders: ['g'], user: { id: '1' } });
   });
-
-  it('should return 400 if fetching provider user data fails', async () => {
-    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({ data: { session: {} }, error: null }); // Success
-    mockSupabaseAuth.getUser.mockReset();
-    mockSupabaseAuth.getUser
-      .mockResolvedValueOnce({ data: { user: mockLoggedInUser }, error: null }) // Auth check
-      .mockResolvedValueOnce({ data: null, error: { message: 'Provider fetch failed', status: 500 } }); // Provider data fetch
-
-    const request = createRequest({ provider: providerToLink, code: validCode });
-    const response = await POST(request);
-    const body = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(body.error).toBe('Provider fetch failed');
-  });
-
-  it('should return 409 if provider account is already linked', async () => {
-    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({ data: { session: {} }, error: null });
-    mockSupabaseAuth.getUser.mockResolvedValueOnce({ data: { user: mockLoggedInUser }, error: null }) // Auth check
-                         .mockResolvedValueOnce({ data: { user: mockProviderUser }, error: null }); // Provider data fetch
-    const builder = createBuilder({ data: { id: 'existing-link-id', user_id: 'other' }, error: null });
-    mockFrom.mockReturnValueOnce(builder);
-
-    const request = createRequest({ provider: providerToLink, code: validCode });
-    const response = await POST(request);
-    const body = await response.json();
-
-    expect(response.status).toBe(409);
-    expect(body.error).toContain('already linked');
-    expect(mockFrom).toHaveBeenCalledWith('account');
-    expect(builder.select).toHaveBeenCalledWith('id, user_id');
-  });
-
-  it('should return 409 on email collision with another account', async () => {
-    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({ data: { session: {} }, error: null });
-    mockSupabaseAuth.getUser.mockReset();
-    mockSupabaseAuth.getUser
-      .mockResolvedValueOnce({ data: { user: mockLoggedInUser }, error: null })
-      .mockResolvedValueOnce({ data: { user: mockProviderUser }, error: null });
-    const builder1 = createBuilder({ data: null, error: null });
-    const builder2 = createBuilder({ data: { id: 'collision-account-id', user_id: 'other' }, error: null });
-    mockFrom.mockReturnValueOnce(builder1).mockReturnValueOnce(builder2);
-
-    const request = createRequest({ provider: providerToLink, code: validCode });
-    const response = await POST(request);
-    const body = await response.json();
-
-    expect(response.status).toBe(409);
-    expect(body.error).toContain('account with this email already exists');
-    expect(body.collision).toBe(true);
-    expect(mockFrom).toHaveBeenCalledTimes(2);
-  });
-
-  it('should successfully link a new provider account', async () => {
-    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({ data: { session: {} }, error: null });
-    mockSupabaseAuth.getUser.mockReset();
-    mockSupabaseAuth.getUser
-      .mockResolvedValueOnce({ data: { user: mockLoggedInUser }, error: null })
-      .mockResolvedValueOnce({ data: { user: mockProviderUser }, error: null });
-    const builder1 = createBuilder({ data: null, error: null });
-    const builder2 = createBuilder({ data: null, error: null });
-    const builder3 = createBuilder({ data: { id: 'new-link-id' }, error: null });
-    const builder4 = createBuilder({ data: [ { provider: 'google' }, { provider: providerToLink.toLowerCase() } ], error: null });
-    mockFrom
-      .mockReturnValueOnce(builder1)
-      .mockReturnValueOnce(builder2)
-      .mockReturnValueOnce(builder3)
-      .mockReturnValueOnce(builder4);
-
-    const request = createRequest({ provider: providerToLink, code: validCode });
-    const response = await POST(request);
-    const body = await response.json();
-
-    expect(response.status).toBe(200);
-    expect(body.success).toBe(true);
-    expect(body.user).toEqual(mockLoggedInUser);
-    expect(body.linkedProviders).toEqual(['google', providerToLink.toLowerCase()]);
-
-    expect(mockFrom).toHaveBeenCalledTimes(4);
-    expect(mockLogUserAction).toHaveBeenCalledWith(expect.objectContaining({ userId: loggedInUserId, action: 'SSO_LINK', status: 'SUCCESS' }));
-    expect(mockSendNotification).toHaveBeenCalledWith(loggedInUserId, providerToLink);
-  });
-
-  it('should handle errors during prisma account create', async () => {
-    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({ data: { session: {} }, error: null });
-    mockSupabaseAuth.getUser.mockReset();
-    mockSupabaseAuth.getUser
-      .mockResolvedValueOnce({ data: { user: mockLoggedInUser }, error: null })
-      .mockResolvedValueOnce({ data: { user: mockProviderUser }, error: null });
-    const builder1 = createBuilder({ data: null, error: null });
-    const builder2 = createBuilder({ data: null, error: null });
-    const createError = new Error('DB link create failed');
-    const builder3 = createBuilder({ data: null, error: null });
-    builder3.insert = vi.fn(() => Promise.reject(createError));
-    mockFrom
-      .mockReturnValueOnce(builder1)
-      .mockReturnValueOnce(builder2)
-      .mockReturnValueOnce(builder3);
-
-    const request = createRequest({ provider: providerToLink, code: validCode });
-    const response = await POST(request);
-    const body = await response.json();
-
-    expect(response.status).toBe(400); // Should match the error handling block
-    expect(body.error).toBe(createError.message);
-    expect(builder3.insert).toHaveBeenCalledTimes(1);
-    expect(mockLogUserAction).toHaveBeenCalledWith(expect.objectContaining({
-      action: 'SSO_LINK',
-      status: 'FAILURE',
-      details: { error: createError.message },
-    }));
-  });
-
-  it('should return 400 if provider returns no identifier (email or providerId)', async () => {
-    const providerUserWithoutIds = {
-      ...mockProviderUser,
-      email: undefined,
-      app_metadata: { ...mockProviderUser.app_metadata, provider_id: undefined },
-    };
-    mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({ data: { session: {} }, error: null });
-    mockSupabaseAuth.getUser.mockReset();
-    mockSupabaseAuth.getUser
-      .mockResolvedValueOnce({ data: { user: mockLoggedInUser }, error: null }) // Auth check
-      .mockResolvedValueOnce({ data: { user: providerUserWithoutIds }, error: null }); // Provider data fetch
-
-    const request = createRequest({ provider: providerToLink, code: validCode });
-    const response = await POST(request);
-    const body = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(body.error).toContain('Provider did not return a unique identifier');
-    expect(mockFrom).not.toHaveBeenCalled();
-  });
-
-  // TODO: Add tests for:
-  // - Scenario where provider does not return email or providerAccountId
-
-}); 
+});

--- a/src/core/oauth/interfaces.ts
+++ b/src/core/oauth/interfaces.ts
@@ -14,6 +14,21 @@ export interface OAuthService {
     state?: string,
   ): Promise<OAuthCallbackResult>;
 
+  /**
+   * Link an additional OAuth provider to the currently authenticated user.
+   */
+  linkProvider(
+    provider: OAuthProvider,
+    code: string,
+  ): Promise<{
+    success: boolean;
+    error?: string;
+    status?: number;
+    user?: any;
+    linkedProviders?: string[];
+    collision?: boolean;
+  }>;
+
   disconnectProvider(
     provider: OAuthProvider,
   ): Promise<{ success: boolean; error?: string; status?: number }>;

--- a/src/core/two-factor/models.ts
+++ b/src/core/two-factor/models.ts
@@ -3,6 +3,8 @@ export type TwoFactorMethodType = 'totp' | 'sms' | 'email' | 'webauthn';
 export interface TwoFactorSetupPayload {
   userId: string;
   method: TwoFactorMethodType;
+  phone?: string;
+  email?: string;
 }
 
 export interface TwoFactorSetupResponse {


### PR DESCRIPTION
## Summary
- add `linkProvider` to OAuth service interface
- implement provider linking in default OAuth service
- extend 2FA service to handle TOTP and optional phone/email
- simplify 2FA setup route to delegate to service
- replace OAuth link route with service-based version
- add unit test for the new OAuth link route

## Testing
- `CI=true npx vitest run app/api/auth/oauth/link/__tests__/route.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_68418b2e55e48331adb77854be283c67