### PR TITLE
Refactor two API routes to use services

### DIFF
--- a/app/api/2fa/disable/route.ts
+++ b/app/api/2fa/disable/route.ts
@@ -1,100 +1,21 @@
-import { NextResponse } from 'next/server';
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
 import { z } from 'zod';
+import { createApiHandler } from '@/lib/api/route-helpers';
+import { createSuccessResponse, ApiError, ERROR_CODES } from '@/lib/api/common';
 
-// Request schema (optional password confirmation)
-const disableRequestSchema = z.object({
-  password: z.string().optional(),
-});
+const DisableSchema = z.object({ password: z.string().optional() });
 
-export async function POST(request: Request): Promise<NextResponse> {
-  try {
-    // Parse and validate request body
-    const body = await request.json();
-    const { password } = disableRequestSchema.parse(body);
-
-    // Initialize Supabase client
-    const cookieStore = cookies();
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      {
-        cookies: {
-          get(name: string) {
-            return cookieStore.get(name)?.value;
-          },
-          set(name: string, value: string, options: Record<string, unknown>) {
-            cookieStore.set({ name, value, ...options });
-          },
-          remove(name: string, options: Record<string, unknown>) {
-            cookieStore.set({ name, value: '', ...options });
-          },
-        },
-      }
-    );
-
-    // Verify user authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Authentication required' },
-        { status: 401 }
+export const POST = createApiHandler(
+  DisableSchema,
+  async (_req, auth, _data, services) => {
+    const result = await services.twoFactor!.disable(auth.userId, 'totp');
+    if (!result.success) {
+      throw new ApiError(
+        ERROR_CODES.INVALID_REQUEST,
+        result.error || 'Failed to disable MFA',
+        400
       );
     }
-
-    // Verify that 2FA is enabled
-    const totpEnabled = user.user_metadata?.totpEnabled === true;
-    
-    if (!totpEnabled) {
-      return NextResponse.json(
-        { error: 'MFA is not enabled' },
-        { status: 400 }
-      );
-    }
-
-    // If password is provided, verify it (for additional security)
-    if (password) {
-      // Note: Supabase doesn't provide a direct way to verify a password
-      // In a production app, you might want to:
-      // 1. Force a re-login with the provided password
-      // 2. Use a dedicated API with proper password hashing/verification
-      
-      // For this implementation, we'll skip password verification
-      // but note that it would be important for a production app
-      console.warn('Password verification would happen here in a production app');
-    }
-
-    // Disable 2FA by updating user metadata
-    const { error: updateError } = await supabase.auth.updateUser({
-      data: {
-        totpSecret: null,
-        totpEnabled: false,
-        totpVerified: false,
-        mfaMethods: [],
-        backupCodes: null,
-        backupCodesGeneratedAt: null,
-      }
-    });
-    
-    if (updateError) {
-      console.error('Failed to update user metadata:', updateError);
-      return NextResponse.json(
-        { error: updateError.message },
-        { status: 400 }
-      );
-    }
-    
-    return NextResponse.json({
-      success: true,
-      message: '2FA has been disabled successfully',
-    });
-  } catch (error) {
-    console.error('Error disabling 2FA:', error);
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'An unexpected error occurred' },
-      { status: 500 }
-    );
-  }
-} 
+    return createSuccessResponse(result);
+  },
+  { requireAuth: true }
+);

--- a/src/services/session/enforce-session-policies.service.ts
+++ b/src/services/session/enforce-session-policies.service.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { createSessionProvider } from '@/adapters/session/factory';
+import { getSessionTimeout, getMaxSessionsPerUser } from '@/lib/security/security-policy.service';
+
+export interface EnforceResult {
+  success: boolean;
+  message?: string;
+  error?: string;
+}
+
+export async function enforceSessionPolicies(
+  req: NextRequest,
+  res: NextResponse
+): Promise<EnforceResult> {
+  const sessionProvider = createSessionProvider({
+    type: 'supabase',
+    options: {
+      supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',
+      supabaseKey: process.env.SUPABASE_SERVICE_ROLE_KEY || ''
+    }
+  });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get: name => req.cookies.get(name)?.value,
+        set: (name, value, options) => {
+          res.cookies.set({ name, value, ...options });
+        },
+        remove: (name, options) => {
+          res.cookies.set({ name, value: '', ...options });
+        }
+      }
+    }
+  );
+
+  try {
+    const {
+      data: { user },
+      error
+    } = await supabase.auth.getUser();
+    if (error || !user) {
+      return { success: false, error: 'Not authenticated' };
+    }
+
+    const orgId = user.user_metadata?.current_organization_id;
+    if (!orgId) {
+      return { success: true, message: 'No organization policy to enforce' };
+    }
+
+    const sessions = await sessionProvider.listUserSessions(user.id);
+    const timeoutMinutes = await getSessionTimeout(orgId);
+    const maxSessions = await getMaxSessionsPerUser(orgId);
+
+    if (timeoutMinutes > 0) {
+      const timeoutMs = timeoutMinutes * 60 * 1000;
+      const now = Date.now();
+      for (const session of sessions) {
+        if (!session.user_metadata?.last_activity) continue;
+        const last = new Date(session.user_metadata.last_activity).getTime();
+        if (now - last > timeoutMs) {
+          await sessionProvider.deleteUserSession(user.id, session.id);
+        }
+      }
+    }
+
+    if (maxSessions > 0 && sessions.length > maxSessions) {
+      const sorted = [...sessions].sort((a, b) => {
+        const aTime = a.user_metadata?.last_activity
+          ? new Date(a.user_metadata.last_activity).getTime()
+          : new Date(a.created_at).getTime();
+        const bTime = b.user_metadata?.last_activity
+          ? new Date(b.user_metadata.last_activity).getTime()
+          : new Date(b.created_at).getTime();
+        return aTime - bTime;
+      });
+
+      const { data: { session: current } } = await supabase.auth.getSession();
+      const currentId = current?.id;
+      const toRemove = sorted.length - maxSessions;
+      let removed = 0;
+      for (const s of sorted) {
+        if (removed >= toRemove) break;
+        if (s.id !== currentId) {
+          await sessionProvider.deleteUserSession(user.id, s.id);
+          removed++;
+        }
+      }
+    }
+
+    await supabase.auth.updateUser({ data: { last_activity: new Date().toISOString() } });
+    return { success: true, message: 'Session policies enforced' };
+  } catch (err: any) {
+    return { success: false, error: err.message };
+  }
+}


### PR DESCRIPTION
## Summary
- decouple 2FA disable route from Supabase with TwoFactorService
- add session policy enforcement service and use it in API route
- implement disable logic in TwoFactorService

## Testing
- `npx vitest run --coverage` *(fails: Adapter 'user' not registered and act warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68418f3186a08331b102dec63039783e