### PR TITLE
Refactor session API routes to use service layer

### DIFF
--- a/app/api/session/[sessionId]/route.ts
+++ b/app/api/session/[sessionId]/route.ts
@@ -1,21 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getUserFromRequest } from '@/lib/auth/utils';
-import { createSessionProvider } from '@/adapters/session/factory';
+import { getApiSessionService } from '@/services/session/factory';
 
 // DELETE /api/session/:sessionId - Revoke a specific session for the current user
 export async function DELETE(req: NextRequest, { params }: { params: { sessionId: string } }) {
   const user = await getUserFromRequest(req);
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const { sessionId } = params;
-  const provider = createSessionProvider({
-    type: 'supabase',
-    options: {
-      supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',
-      supabaseKey: process.env.SUPABASE_SERVICE_ROLE_KEY || ''
-    }
-  });
+  const service = getApiSessionService();
   try {
-    await provider.deleteUserSession(user.id, sessionId);
+    await service!.revokeUserSession(user.id, sessionId);
     return NextResponse.json({ success: true });
   } catch (error) {
     return NextResponse.json({ error: 'Failed to revoke session' }, { status: 500 });

--- a/app/api/session/__tests__/route.test.ts
+++ b/app/api/session/__tests__/route.test.ts
@@ -1,41 +1,41 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GET, DELETE } from '../route';
 import { withRouteAuth } from '@/middleware/auth';
-import { createSessionProvider } from '@/adapters/session/factory';
+import { getApiSessionService } from '@/services/session/factory';
 import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
 
 vi.mock('@/middleware/auth', () => ({
   withRouteAuth: vi.fn((handler: any) => async (req: any) => handler(req, { userId: 'user-1', role: 'user' })),
 }));
 
-vi.mock('@/adapters/session/factory', () => ({
-  createSessionProvider: vi.fn(),
+vi.mock('@/services/session/factory', () => ({
+  getApiSessionService: vi.fn(),
 }));
 
-interface MockProvider {
+interface MockService {
   listUserSessions?: vi.Mock;
-  deleteAllUserSessions?: vi.Mock;
+  revokeUserSession?: vi.Mock;
 }
 
 describe('/api/session', () => {
   const user = { id: 'user-1', email: 'test@example.com' };
-  let provider: MockProvider;
+  let service: MockService;
 
   beforeEach(() => {
-    provider = {
+    service = {
       listUserSessions: vi.fn().mockResolvedValue([]),
-      deleteAllUserSessions: vi.fn().mockResolvedValue({ success: true, count: 0 }),
+      revokeUserSession: vi.fn().mockResolvedValue({ success: true }),
     };
-    (createSessionProvider as unknown as vi.Mock).mockReturnValue(provider);
+    (getApiSessionService as unknown as vi.Mock).mockReturnValue(service);
   });
 
   it('GET returns sessions for authenticated user', async () => {
-    provider.listUserSessions!.mockResolvedValue([{ id: '1' }]);
+    service.listUserSessions!.mockResolvedValue([{ id: '1' }]);
     const res = await GET(createAuthenticatedRequest('GET', 'http://localhost/api/session'));
     const data = await res.json();
     expect(res.status).toBe(200);
     expect(data.sessions.length).toBe(1);
-    expect(provider.listUserSessions).toHaveBeenCalledWith('user-1');
+    expect(service.listUserSessions).toHaveBeenCalledWith('user-1');
   });
 
   it('GET returns 401 for unauthenticated user', async () => {
@@ -44,19 +44,21 @@ describe('/api/session', () => {
     expect(res.status).toBe(401);
   });
 
-  it('GET returns 500 on provider error', async () => {
-    provider.listUserSessions!.mockRejectedValue(new Error('fail'));
+  it('GET returns 500 on service error', async () => {
+    service.listUserSessions!.mockRejectedValue(new Error('fail'));
     const res = await GET(createAuthenticatedRequest('GET', 'http://localhost/api/session'));
     expect(res.status).toBe(500);
   });
 
   it('DELETE revokes all sessions for authenticated user', async () => {
-    provider.deleteAllUserSessions!.mockResolvedValue({ success: true, count: 2 });
+    service.listUserSessions!.mockResolvedValue([{ id: '1' }, { id: '2' }]);
+    service.revokeUserSession!.mockResolvedValue({ success: true });
     const res = await DELETE(createAuthenticatedRequest('DELETE', 'http://localhost/api/session'));
     const data = await res.json();
     expect(res.status).toBe(200);
     expect(data.success).toBe(true);
-    expect(provider.deleteAllUserSessions).toHaveBeenCalledWith('user-1');
+    expect(service.listUserSessions).toHaveBeenCalledWith('user-1');
+    expect(service.revokeUserSession).toHaveBeenCalledTimes(2);
   });
 
   it('DELETE returns 401 for unauthenticated user', async () => {
@@ -65,8 +67,8 @@ describe('/api/session', () => {
     expect(res.status).toBe(401);
   });
 
-  it('DELETE returns 500 on provider error', async () => {
-    provider.deleteAllUserSessions!.mockRejectedValue(new Error('fail'));
+  it('DELETE returns 500 on service error', async () => {
+    service.listUserSessions!.mockRejectedValue(new Error('fail'));
     const res = await DELETE(createAuthenticatedRequest('DELETE', 'http://localhost/api/session'));
     expect(res.status).toBe(500);
   });

--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -1,20 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getUserFromRequest } from '@/lib/auth/utils';
-import { createSessionProvider } from '@/adapters/session/factory';
+import { getApiSessionService } from '@/services/session/factory';
 
 // GET /api/session - List all active sessions for the current user
 export async function GET(req: NextRequest) {
   const user = await getUserFromRequest(req);
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const provider = createSessionProvider({
-    type: 'supabase',
-    options: {
-      supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',
-      supabaseKey: process.env.SUPABASE_SERVICE_ROLE_KEY || ''
-    }
-  });
+  const service = getApiSessionService();
   try {
-    const sessions = await provider.listUserSessions(user.id);
+    const sessions = await service!.listUserSessions(user.id);
     return NextResponse.json({ sessions });
   } catch (error) {
     return NextResponse.json({ error: 'Failed to fetch sessions' }, { status: 500 });
@@ -25,16 +19,15 @@ export async function GET(req: NextRequest) {
 export async function DELETE(req: NextRequest) {
   const user = await getUserFromRequest(req);
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const provider = createSessionProvider({
-    type: 'supabase',
-    options: {
-      supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',
-      supabaseKey: process.env.SUPABASE_SERVICE_ROLE_KEY || ''
-    }
-  });
+  const service = getApiSessionService();
   try {
-    const result = await provider.deleteAllUserSessions(user.id);
-    return NextResponse.json({ success: result.success, count: result.count });
+    const sessions = await service!.listUserSessions(user.id);
+    let count = 0;
+    for (const session of sessions) {
+      const res = await service!.revokeUserSession(user.id, session.id);
+      if (res.success) count += 1;
+    }
+    return NextResponse.json({ success: true, count });
   } catch (error) {
     return NextResponse.json({ error: 'Failed to revoke sessions' }, { status: 500 });
   }


### PR DESCRIPTION
## Summary
- refactor session routes to use `getApiSessionService`
- update unit tests to mock session service instead of provider

## Testing
- `npx vitest run --coverage` *(fails: Adapter 'user' not registered and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_6841934134308331bf8c9b5c78b0d7ec