### PR TITLE
Refactor profile routes to use service layer

### DIFF
--- a/app/api/profile/logo/route.ts
+++ b/app/api/profile/logo/route.ts
@@ -1,9 +1,9 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { checkRateLimit } from '@/middleware/rate-limit';
-import { decode } from 'base64-arraybuffer'; // For decoding base64
-import { getSessionFromToken } from '@/services/auth/factory';
-import { getApiUserService } from '@/services/user/factory';
+import { decode } from 'base64-arraybuffer';
+import { createApiHandler, emptySchema } from '@/lib/api/route-helpers';
+import { createSuccessResponse } from '@/lib/api/common';
 
 // Schema for logo upload request body
 const LogoUploadSchema = z.object({
@@ -11,84 +11,41 @@ const LogoUploadSchema = z.object({
   filename: z.string().optional(), // Optional filename for content type inference
 });
 
-type LogoUploadRequest = z.infer<typeof LogoUploadSchema>;
-
-
-// --- POST Handler for uploading company logo --- 
-export async function POST(request: NextRequest) {
-  const isRateLimited = await checkRateLimit(request);
-  if (isRateLimited) {
-    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
-  }
-
-  try {
-    const authHeader = request.headers.get('authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
-    }
-    const token = authHeader.split(' ')[1];
-    const user = await getSessionFromToken(token);
-    if (!user) {
-      return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
-    }
-
-    let body: LogoUploadRequest;
-    try {
-      body = await request.json();
-    } catch {
-      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
-    }
-
-    const parse = LogoUploadSchema.safeParse(body);
-    if (!parse.success) {
-      return NextResponse.json({ error: 'Validation failed', details: parse.error.format() }, { status: 400 });
-    }
-
-    const base64Data = parse.data.logo.replace(/^data:.+;base64,/, '');
-    const fileBuffer = decode(base64Data);
-
-    const service = getApiUserService();
-    const result = await service.uploadCompanyLogo(user.id, user.id, fileBuffer);
-    if (!result.success || !result.url) {
-      return NextResponse.json({ error: result.error || 'Failed to upload logo' }, { status: 500 });
-    }
-
-    return NextResponse.json({ companyLogoUrl: result.url });
-
-  } catch (error) {
-    console.error('Unexpected error in POST /api/profile/logo:', error);
-    return NextResponse.json({ error: 'An internal server error occurred.' }, { status: 500 });
-  }
-}
-
-// --- DELETE Handler for removing company logo ---
-export async function DELETE(request: NextRequest) {
+export const POST = createApiHandler(
+  LogoUploadSchema,
+  async (request: NextRequest, { userId }, data, services) => {
     const isRateLimited = await checkRateLimit(request);
     if (isRateLimited) {
       return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
     }
 
-    try {
-      const authHeader = request.headers.get('authorization');
-      if (!authHeader || !authHeader.startsWith('Bearer ')) {
-        return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
-      }
-      const token = authHeader.split(' ')[1];
-      const user = await getSessionFromToken(token);
-      if (!user) {
-        return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
-      }
+    const base64Data = data.logo.replace(/^data:.+;base64,/, '');
+    const fileBuffer = decode(base64Data);
 
-      const service = getApiUserService();
-      const result = await service.deleteCompanyLogo(user.id, user.id);
-      if (!result.success) {
-        return NextResponse.json({ error: result.error || 'Failed to remove logo' }, { status: 500 });
-      }
-
-      return NextResponse.json({ message: 'Company logo removed successfully.' });
-
-    } catch (error) {
-      console.error('Unexpected error in DELETE /api/profile/logo:', error);
-      return NextResponse.json({ error: 'An internal server error occurred.' }, { status: 500 });
+    const result = await services.user.uploadCompanyLogo(userId!, userId!, fileBuffer);
+    if (!result.success || !result.url) {
+      return NextResponse.json({ error: result.error || 'Failed to upload logo' }, { status: 500 });
     }
-  }
+
+    return createSuccessResponse({ companyLogoUrl: result.url });
+  },
+  { requireAuth: true }
+);
+
+export const DELETE = createApiHandler(
+  emptySchema,
+  async (request: NextRequest, { userId }, _data, services) => {
+    const isRateLimited = await checkRateLimit(request);
+    if (isRateLimited) {
+      return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+    }
+
+    const result = await services.user.deleteCompanyLogo(userId!, userId!);
+    if (!result.success) {
+      return NextResponse.json({ error: result.error || 'Failed to remove logo' }, { status: 500 });
+    }
+
+    return createSuccessResponse({ message: 'Company logo removed successfully.' });
+  },
+  { requireAuth: true }
+);

--- a/app/api/profile/privacy/route.ts
+++ b/app/api/profile/privacy/route.ts
@@ -1,137 +1,77 @@
 import { type NextRequest, NextResponse } from 'next/server';
-// import { z } from 'zod'; // Removed unused import
-import { getApiAuthService, getSessionFromToken } from '@/services/auth/factory';
-import { getApiUserService } from '@/services/user/factory';
+import { createApiHandler } from '@/lib/api/route-helpers';
+import { createSuccessResponse } from '@/lib/api/common';
 import { checkRateLimit } from '@/middleware/rate-limit';
-import { profileSchema } from '@/types/database'; // Corrected import path
-import { logUserAction } from '@/lib/audit/auditLogger'; // Added audit logger import
+import { profileSchema } from '@/types/database';
+import { logUserAction } from '@/lib/audit/auditLogger';
 
 // Derive schema specifically for privacy settings update
 const PrivacySettingsUpdateSchema = profileSchema.shape.privacySettings;
 
-// type PrivacySettingsUpdate = z.infer<typeof PrivacySettingsUpdateSchema>; // Removed unused type
 
-// --- PATCH Handler for updating privacy settings --- 
-export async function PATCH(request: NextRequest) {
-  // Get IP and User Agent early
-  const ipAddress = request.ip;
-  const userAgent = request.headers.get('user-agent');
-  let userIdForLogging: string | null = null;
-
-  // 1. Rate Limiting
-  const isRateLimited = await checkRateLimit(request);
-  if (isRateLimited) {
-    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
-  }
-
-  try {
-    // 2. Authentication & Get User
-    const authHeader = request.headers.get('authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+export const PATCH = createApiHandler(
+  PrivacySettingsUpdateSchema,
+  async (request: NextRequest, { userId }, settings, services) => {
+    const ipAddress = request.ip;
+    const userAgent = request.headers.get('user-agent');
+    const isRateLimited = await checkRateLimit(request);
+    if (isRateLimited) {
+      return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
     }
-    const token = authHeader.split(' ')[1];
 
-    const user = await getSessionFromToken(token);
-    const userError = user ? null : new Error('Invalid token');
-
-    if (userError || !user) {
-      // Log unauthorized attempt
-      await logUserAction({
-          action: 'PRIVACY_SETTINGS_UPDATE_UNAUTHORIZED',
-          status: 'FAILURE',
-          ipAddress: ipAddress,
-          userAgent: userAgent,
-          targetResourceType: 'user_profile_privacy',
-          details: { reason: userError?.message ?? 'Invalid token' }
-      });
-      return NextResponse.json({ error: userError?.message || 'Invalid token' }, { status: 401 });
-    }
-    userIdForLogging = user.id; // Store for logging
-
-    // 3. Parse and Validate Body
-    let body;
+    let userIdForLogging: string | null = userId ?? null;
     try {
-      body = await request.json();
-    } catch (e) {
-      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
-    }
+      const result = await services.user.updateUserProfile(
+        userId!,
+        { privacySettings: settings } as any
+      );
 
-    const parseResult = PrivacySettingsUpdateSchema.safeParse(body);
-    if (!parseResult.success) {
-      return NextResponse.json({ error: 'Validation failed', details: parseResult.error.format() }, { status: 400 });
-    }
-    
-    const settingsToUpdate = parseResult.data;
-    
-    console.log(`Updating privacy settings for user ${user.id}:`, settingsToUpdate);
-
-    // 4. Update Profile via service layer
-    const userService = getApiUserService();
-    const result = await userService.updateUserProfile(
-      user.id,
-      { privacySettings: settingsToUpdate } as any
-    );
-    const data = result.profile ? { privacySettings: result.profile.privacySettings } : null;
-    const updateError = result.success ? null : new Error(result.error || 'update failed');
-
-    // 5. Handle Errors
-    if (updateError) {
-      console.error(`Error updating privacy settings for user ${user.id}:`, updateError);
-      
-      // Log the failure
-      await logUserAction({
+      if (!result.success || !result.profile) {
+        await logUserAction({
           userId: userIdForLogging,
           action: 'PRIVACY_SETTINGS_UPDATE_FAILURE',
           status: 'FAILURE',
-          ipAddress: ipAddress,
-          userAgent: userAgent,
+          ipAddress,
+          userAgent,
           targetResourceType: 'user_profile_privacy',
           targetResourceId: userIdForLogging,
-          details: {
-              reason: updateError.message
-          }
-      });
+          details: { reason: result.error || 'update failed' },
+        });
+        return NextResponse.json(
+          { error: 'Failed to update privacy settings.' },
+          { status: 500 }
+        );
+      }
 
-      return NextResponse.json({ error: 'Failed to update privacy settings.', details: updateError.message }, { status: 500 });
-    }
-    
-    if (!data) {
-        // This case might occur if the update didn't find a matching row
-        return NextResponse.json({ error: 'Profile not found or update failed silently.' }, { status: 404 });
-    }
-
-    // 6. Handle Success
-    // Log successful update
-    await logUserAction({
+      await logUserAction({
         userId: userIdForLogging,
         action: 'PRIVACY_SETTINGS_UPDATE_SUCCESS',
         status: 'SUCCESS',
-        ipAddress: ipAddress,
-        userAgent: userAgent,
+        ipAddress,
+        userAgent,
         targetResourceType: 'user_profile_privacy',
         targetResourceId: userIdForLogging,
-        details: { updatedSettings: data.privacySettings } // Log the applied settings
-    });
-    
-    return NextResponse.json(data.privacySettings); // Return the updated privacySettings object
+        details: { updatedSettings: result.profile.privacySettings },
+      });
 
-  } catch (error) {
-    console.error('Unexpected error in PATCH /api/profile/privacy:', error);
-    const message = error instanceof Error ? error.message : 'An unexpected error occurred';
-    
-    // Log the unexpected error
-    await logUserAction({
-        userId: userIdForLogging, // May be null if error happened before user fetch
+      return createSuccessResponse(result.profile.privacySettings);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'An unexpected error occurred';
+      await logUserAction({
+        userId: userIdForLogging,
         action: 'PRIVACY_SETTINGS_UPDATE_UNEXPECTED_ERROR',
         status: 'FAILURE',
-        ipAddress: ipAddress,
-        userAgent: userAgent,
+        ipAddress,
+        userAgent,
         targetResourceType: 'user_profile_privacy',
         targetResourceId: userIdForLogging,
-        details: { error: message }
-    });
-
-    return NextResponse.json({ error: 'An internal server error occurred.' }, { status: 500 });
-  }
-} 
+        details: { error: message },
+      });
+      return NextResponse.json(
+        { error: 'An internal server error occurred.' },
+        { status: 500 }
+      );
+    }
+  },
+  { requireAuth: true }
+);


### PR DESCRIPTION
## Summary
- refactor profile privacy route to use `createApiHandler`
- refactor company logo route to delegate to `UserService`

## Testing
- `npx vitest run --coverage` *(fails: Adapter 'user' not registered, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68419612aa748331881ce51c61d32a4f