### PR TITLE
Refactor export rate limit

### DIFF
--- a/src/core/data-export/interfaces.ts
+++ b/src/core/data-export/interfaces.ts
@@ -15,4 +15,10 @@ export interface DataExportService {
   getUserDataExportByToken(token: string): Promise<import('@/lib/exports/types').UserDataExport | null>;
 
   getUserExportDownloadUrl(filePath: string): string;
+
+  /**
+   * Check if the user has recently requested an export
+   * to enforce rate limiting.
+   */
+  isUserRateLimited(userId: string): Promise<boolean>;
 }

--- a/src/middleware/export-rate-limit.ts
+++ b/src/middleware/export-rate-limit.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { isUserRateLimited } from '@/lib/exports/export.service';
+import { getApiDataExportService } from '@/services/data-export';
 import { isCompanyRateLimited } from '@/lib/exports/company-export.service';
 
 /**
@@ -8,7 +8,8 @@ import { isCompanyRateLimited } from '@/lib/exports/company-export.service';
  * @returns Boolean indicating if user is rate limited
  */
 export async function checkUserExportRateLimit(userId: string): Promise<boolean> {
-  return isUserRateLimited(userId);
+  const service = getApiDataExportService();
+  return service.isUserRateLimited(userId);
 }
 
 /**

--- a/src/services/data-export/default-data-export.service.ts
+++ b/src/services/data-export/default-data-export.service.ts
@@ -7,6 +7,7 @@ import {
   getUserDataExportById,
   getUserDataExportByToken,
   getUserExportDownloadUrl,
+  isUserRateLimited,
 } from '@/lib/exports/export.service';
 import type {
   ExportOptions,
@@ -45,5 +46,9 @@ export class DefaultDataExportService implements DataExportService {
 
   getUserExportDownloadUrl(filePath: string): string {
     return getUserExportDownloadUrl(filePath);
+  }
+
+  isUserRateLimited(userId: string): Promise<boolean> {
+    return isUserRateLimited(userId);
   }
 }


### PR DESCRIPTION
## Summary
- add rate limit check method to `DataExportService`
- implement `isUserRateLimited` in default service
- switch export rate limit middleware to use service

## Testing
- `npx vitest run --coverage` *(fails: Adapter not registered and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_68419aba11088331bb5b88c6038abd72