### PR TITLE
Add Supabase OAuth data provider

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -17,6 +17,7 @@ export * from './gdpr';
 export * from './consent';
 export * from './session';
 export * from './two-factor';
+export * from './oauth';
 export * from './subscription';
 export * from './organization';
 export * from './admin';

--- a/src/adapters/oauth/factory.ts
+++ b/src/adapters/oauth/factory.ts
@@ -1,0 +1,24 @@
+import type { IOAuthDataProvider } from '@/core/oauth/IOAuthDataProvider';
+import { SupabaseOAuthProvider } from './supabase/supabase-oauth.provider';
+
+export function createSupabaseOAuthProvider(options: {
+  supabaseUrl: string;
+  supabaseKey: string;
+  [key: string]: any;
+}): IOAuthDataProvider {
+  return new SupabaseOAuthProvider(options.supabaseUrl, options.supabaseKey);
+}
+
+export function createOAuthProvider(config: {
+  type: 'supabase' | string;
+  options: Record<string, any>;
+}): IOAuthDataProvider {
+  switch (config.type) {
+    case 'supabase':
+      return createSupabaseOAuthProvider(config.options);
+    default:
+      throw new Error(`Unsupported OAuth provider type: ${config.type}`);
+  }
+}
+
+export default createSupabaseOAuthProvider;

--- a/src/adapters/oauth/index.ts
+++ b/src/adapters/oauth/index.ts
@@ -1,0 +1,3 @@
+export * from '@/core/oauth/IOAuthDataProvider';
+export * from './factory';
+export * from './supabase/supabase-oauth.provider';

--- a/src/adapters/oauth/supabase/supabase-oauth.provider.ts
+++ b/src/adapters/oauth/supabase/supabase-oauth.provider.ts
@@ -1,0 +1,126 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { OAuthProvider } from '@/types/oauth';
+import type { IOAuthDataProvider } from '@/core/oauth/IOAuthDataProvider';
+
+export class SupabaseOAuthProvider implements IOAuthDataProvider {
+  private supabase: SupabaseClient;
+
+  constructor(private supabaseUrl: string, private supabaseKey: string) {
+    this.supabase = createClient(supabaseUrl, supabaseKey);
+  }
+
+  async getAuthorizationUrl(provider: OAuthProvider, state?: string): Promise<string> {
+    const { data, error } = await this.supabase.auth.signInWithOAuth({
+      provider,
+      options: {
+        queryParams: state ? { state } : undefined,
+      },
+    });
+    if (error || !data?.url) {
+      throw new Error(error?.message || 'Failed to get authorization URL');
+    }
+    return data.url;
+  }
+
+  async exchangeCode(
+    _provider: OAuthProvider,
+    code: string,
+  ): Promise<{ accessToken: string; refreshToken?: string; expiresAt?: number }> {
+    const { data, error } = await this.supabase.auth.exchangeCodeForSession(code);
+    if (error) {
+      throw new Error(error.message);
+    }
+    return {
+      accessToken: data.session?.access_token ?? '',
+      refreshToken: data.session?.refresh_token ?? undefined,
+      expiresAt: data.session?.expires_at ?? undefined,
+    };
+  }
+
+  async linkProvider(
+    provider: OAuthProvider,
+    code: string,
+  ): Promise<{
+    success: boolean;
+    error?: string;
+    status?: number;
+    user?: any;
+    linkedProviders?: string[];
+    collision?: boolean;
+  }> {
+    const { data: currentUser, error: authError } = await this.supabase.auth.getUser();
+    if (authError || !currentUser?.user) {
+      return { success: false, error: 'Authentication required', status: 401 };
+    }
+
+    const { error } = await this.supabase.auth.exchangeCodeForSession(code);
+    if (error) {
+      return { success: false, error: error.message, status: 400 };
+    }
+
+    const { data: userData, error: userError } = await this.supabase.auth.getUser();
+    if (userError || !userData?.user) {
+      return { success: false, error: userError?.message || 'Failed to fetch user', status: 400 };
+    }
+
+    const linked = userData.user.identities?.map((i: any) => i.provider) ?? [];
+    return { success: true, user: userData.user, linkedProviders: linked };
+  }
+
+  async disconnectProvider(
+    provider: OAuthProvider,
+  ): Promise<{ success: boolean; error?: string; status?: number }> {
+    const { data: userData, error: authError } = await this.supabase.auth.getUser();
+    if (authError || !userData?.user) {
+      return { success: false, error: 'Authentication required', status: 401 };
+    }
+
+    const identity = (userData.user.identities || []).find(
+      (i: any) => i.provider === provider.toLowerCase(),
+    );
+    if (!identity) {
+      return { success: false, error: 'No linked account found for this provider.', status: 400 };
+    }
+
+    const remaining = (userData.user.identities || []).filter(
+      (i: any) => i.identity_id !== identity.identity_id,
+    );
+    if (remaining.length === 0) {
+      return {
+        success: false,
+        error: 'You must have at least one login method (password or another provider) before disconnecting this provider.',
+        status: 400,
+      };
+    }
+
+    const { error } = await this.supabase.auth.unlinkIdentity(identity);
+    if (error) {
+      return { success: false, error: error.message, status: 500 };
+    }
+    return { success: true };
+  }
+
+  async verifyProviderEmail(
+    _providerId: OAuthProvider,
+    email: string,
+  ): Promise<{ success: boolean; error?: string; status?: number }> {
+    const { data: userData, error: authError } = await this.supabase.auth.getUser();
+    if (authError || !userData?.user) {
+      return { success: false, error: 'Authentication required', status: 401 };
+    }
+
+    const { data: existing } = await this.supabase
+      .from('account')
+      .select('user_id')
+      .eq('provider_email', email)
+      .maybeSingle();
+
+    if (existing && existing.user_id !== userData.user.id) {
+      return { success: false, error: 'Email is already linked to another account.', status: 409 };
+    }
+
+    return { success: true };
+  }
+}
+
+export default SupabaseOAuthProvider;

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -15,6 +15,7 @@ import { GdprDataProvider } from '@/core/gdpr/IGdprDataProvider';
 import { IConsentDataProvider } from '@/core/consent/IConsentDataProvider';
 import { SessionDataProvider } from '@/core/session/ISessionDataProvider';
 import { SsoDataProvider } from '@/core/sso/ISsoDataProvider';
+import { OAuthDataProvider } from '@/core/oauth/IOAuthDataProvider';
 import { SubscriptionDataProvider } from '@/core/subscription/ISubscriptionDataProvider';
 import { ApiKeyDataProvider } from '@/core/api-keys/IApiKeyDataProvider';
 import { IWebhookDataProvider } from '@/core/webhooks/IWebhookDataProvider';
@@ -91,6 +92,11 @@ export interface AdapterFactory {
    * Create an SSO data provider
    */
   createSsoProvider(): SsoDataProvider;
+
+  /**
+   * Create an OAuth data provider
+   */
+  createOAuthProvider?(): OAuthDataProvider;
 
   /**
    * Create a subscription data provider

--- a/src/adapters/supabase-factory.ts
+++ b/src/adapters/supabase-factory.ts
@@ -33,6 +33,8 @@ import createSupabaseGdprProvider from './gdpr/factory';
 import createSupabaseConsentProvider from './consent/factory';
 import { createSupabaseSessionProvider } from './session/factory';
 import createSupabaseSsoProvider from './sso/supabase/factory';
+import { createSupabaseOAuthProvider } from './oauth/factory';
+import type { OAuthDataProvider } from './oauth';
 import createSupabaseSubscriptionProvider from './subscription/factory';
 import createSupabaseApiKeyProvider from './api-keys/supabase/factory';
 import { createSupabaseWebhookProvider } from './webhooks';
@@ -145,6 +147,13 @@ export class SupabaseAdapterFactory implements AdapterFactory {
    */
   createSsoProvider(): SsoDataProvider {
     return createSupabaseSsoProvider(this.options);
+  }
+
+  /**
+   * Create a Supabase OAuth provider
+   */
+  createOAuthProvider(): OAuthDataProvider {
+    return createSupabaseOAuthProvider(this.options);
   }
 
   /**

--- a/src/core/oauth/IOAuthDataProvider.ts
+++ b/src/core/oauth/IOAuthDataProvider.ts
@@ -1,0 +1,40 @@
+import { OAuthProvider } from '@/types/oauth';
+
+export interface IOAuthDataProvider {
+  /** Build an authorization URL for the given provider */
+  getAuthorizationUrl(provider: OAuthProvider, state?: string): Promise<string> | string;
+
+  /** Exchange an authorization code for provider tokens */
+  exchangeCode(
+    provider: OAuthProvider,
+    code: string,
+  ): Promise<{ accessToken: string; refreshToken?: string; expiresAt?: number }>;
+
+  /** Link an OAuth provider to the currently authenticated user */
+  linkProvider(
+    provider: OAuthProvider,
+    code: string,
+  ): Promise<{
+    success: boolean;
+    error?: string;
+    status?: number;
+    user?: any;
+    linkedProviders?: string[];
+    collision?: boolean;
+  }>;
+
+  /** Disconnect a previously linked provider from the current user */
+  disconnectProvider(
+    provider: OAuthProvider,
+  ): Promise<{ success: boolean; error?: string; status?: number }>;
+
+  /**
+   * Verify that the given email address belongs to the currently authenticated user for the provider
+   */
+  verifyProviderEmail(
+    providerId: OAuthProvider,
+    email: string,
+  ): Promise<{ success: boolean; error?: string; status?: number }>;
+}
+
+export type OAuthDataProvider = IOAuthDataProvider;


### PR DESCRIPTION
## Summary
- introduce `IOAuthDataProvider` interface
- implement `SupabaseOAuthProvider` supporting OAuth flows
- expose factory methods and index exports for OAuth adapters
- register OAuth provider creation in Supabase factory
- update adapter registry with optional OAuth provider

## Testing
- `npm run test:coverage` *(fails: Adapter 'user' not registered; environment lacks setup)*

------
https://chatgpt.com/codex/tasks/task_b_68419e552b7c8331b7970ba17209b102