### PR TITLE
Refactor API key routes to use services

### DIFF
--- a/app/api/api-keys/[keyId]/__tests__/route.test.ts
+++ b/app/api/api-keys/[keyId]/__tests__/route.test.ts
@@ -14,13 +14,13 @@ vi.mock('@/lib/auth/session', () => ({
   })
 }));
 
-const providerMock = {
-  listKeys: vi.fn(),
-  createKey: vi.fn(),
-  revokeKey: vi.fn()
+const serviceMock = {
+  listApiKeys: vi.fn(),
+  createApiKey: vi.fn(),
+  revokeApiKey: vi.fn(),
 };
-vi.mock('@/adapters/api-keys/factory', () => ({
-  createSupabaseApiKeyProvider: vi.fn(() => providerMock)
+vi.mock('@/services/api-keys/factory', () => ({
+  getApiKeyService: vi.fn(() => serviceMock),
 }));
 
 vi.mock('@/lib/audit/auditLogger', () => ({
@@ -47,7 +47,7 @@ function createMockRequest(method: string) {
 
 describe('API Key Delete API', () => {
   beforeEach(() => {
-    providerMock.revokeKey.mockReset();
+    serviceMock.revokeApiKey.mockReset();
   });
 
   afterEach(() => {
@@ -64,7 +64,7 @@ describe('API Key Delete API', () => {
         scopes: ['read_profile']
       };
 
-      providerMock.revokeKey.mockResolvedValue({ success: true, key: mockKeyData });
+      serviceMock.revokeApiKey.mockResolvedValue({ success: true, key: mockKeyData });
 
       const req = createMockRequest('DELETE');
       const params = { keyId: 'test-key-id' };
@@ -74,7 +74,7 @@ describe('API Key Delete API', () => {
       expect(response.status).toBe(200);
       expect(responseBody).toHaveProperty('message', 'API key revoked successfully');
       
-      expect(providerMock.revokeKey).toHaveBeenCalledWith('test-user-id', 'test-key-id');
+      expect(serviceMock.revokeApiKey).toHaveBeenCalledWith('test-user-id', 'test-key-id');
       
       // Verify audit log was created
       expect(logUserAction).toHaveBeenCalledWith(expect.objectContaining({
@@ -99,7 +99,7 @@ describe('API Key Delete API', () => {
     });
 
     it('should return 404 if API key is not found', async () => {
-      providerMock.revokeKey.mockResolvedValue({ success: false, error: 'API key not found' });
+      serviceMock.revokeApiKey.mockResolvedValue({ success: false, error: 'API key not found' });
 
       const req = createMockRequest('DELETE');
       const params = { keyId: 'non-existent-key' };

--- a/app/api/api-keys/[keyId]/route.ts
+++ b/app/api/api-keys/[keyId]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { checkRateLimit } from '@/middleware/rate-limit';
 import { logUserAction } from '@/lib/audit/auditLogger';
 import { getCurrentUser } from '@/lib/auth/session';
-import { createSupabaseApiKeyProvider } from '@/adapters/api-keys/factory';
+import { getApiKeyService } from '@/services/api-keys/factory';
 
 // DELETE handler to revoke an API key
 export async function DELETE(
@@ -29,12 +29,8 @@ export async function DELETE(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const provider = createSupabaseApiKeyProvider({
-      supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      supabaseKey: process.env.SUPABASE_SERVICE_ROLE_KEY!
-    });
-
-    const revokeResult = await provider.revokeKey(user.id, keyId);
+    const service = getApiKeyService();
+    const revokeResult = await service.revokeApiKey(user.id, keyId);
 
     if (!revokeResult.success) {
       console.error('Error revoking API key:', revokeResult.error);

--- a/app/api/api-keys/__tests__/route.test.ts
+++ b/app/api/api-keys/__tests__/route.test.ts
@@ -14,13 +14,13 @@ vi.mock('@/lib/auth/session', () => ({
   })
 }));
 
-const providerMock = {
-  listKeys: vi.fn(),
-  createKey: vi.fn(),
-  revokeKey: vi.fn()
+const serviceMock = {
+  listApiKeys: vi.fn(),
+  createApiKey: vi.fn(),
+  revokeApiKey: vi.fn(),
 };
-vi.mock('@/adapters/api-keys/factory', () => ({
-  createSupabaseApiKeyProvider: vi.fn(() => providerMock)
+vi.mock('@/services/api-keys/factory', () => ({
+  getApiKeyService: vi.fn(() => serviceMock),
 }));
 
 vi.mock('@/lib/audit/auditLogger', () => ({
@@ -48,9 +48,9 @@ function createMockRequest(method: string, body?: any) {
 
 describe('API Keys API', () => {
   beforeEach(() => {
-    providerMock.listKeys.mockReset();
-    providerMock.createKey.mockReset();
-    providerMock.revokeKey.mockReset();
+    serviceMock.listApiKeys.mockReset();
+    serviceMock.createApiKey.mockReset();
+    serviceMock.revokeApiKey.mockReset();
   });
 
   afterEach(() => {
@@ -79,7 +79,7 @@ describe('API Keys API', () => {
         }
       ];
 
-      providerMock.listKeys.mockResolvedValue(mockApiKeys);
+      serviceMock.listApiKeys.mockResolvedValue(mockApiKeys);
 
       const req = createMockRequest('GET');
       const response = await GET(req);
@@ -89,7 +89,7 @@ describe('API Keys API', () => {
       expect(responseBody).toHaveProperty('keys');
       expect(Array.isArray(responseBody.keys)).toBe(true);
       
-      expect(providerMock.listKeys).toHaveBeenCalledWith('test-user-id');
+      expect(serviceMock.listApiKeys).toHaveBeenCalledWith('test-user-id');
     });
 
     it('should return 401 if user is not authenticated', async () => {
@@ -120,7 +120,7 @@ describe('API Keys API', () => {
         error: null
       };
 
-      providerMock.createKey.mockResolvedValue({
+      serviceMock.createApiKey.mockResolvedValue({
         success: true,
         key: mockInsertResponse.data,
         plaintext: 'test_generatedkey123'
@@ -140,7 +140,7 @@ describe('API Keys API', () => {
       expect(responseBody).toHaveProperty('scopes');
       expect(responseBody).toHaveProperty('key', 'test_generatedkey123');
       
-      expect(providerMock.createKey).toHaveBeenCalledWith('test-user-id', {
+      expect(serviceMock.createApiKey).toHaveBeenCalledWith('test-user-id', {
         name: 'My API Key',
         scopes: ['read_profile'],
         expiresAt: undefined


### PR DESCRIPTION
## Summary
- decouple API key routes from Supabase by using service factory
- update API key route tests to mock service layer
- adjust single API key route to call service
- adapt webhook ID route tests to mock webhook service

## Testing
- `npx vitest run --coverage` *(fails: Adapter 'user' not registered)*

------
https://chatgpt.com/codex/tasks/task_b_68419ea9dcb88331bee3705520e5854a