### PR TITLE
Add Supabase data export adapter

### DIFF
--- a/src/adapters/data-export/factory.ts
+++ b/src/adapters/data-export/factory.ts
@@ -1,0 +1,24 @@
+import type { IDataExportDataProvider } from '@/core/data-export/IDataExportDataProvider';
+import { SupabaseDataExportProvider } from './supabase/supabase-data-export.provider';
+
+export function createSupabaseDataExportProvider(options: {
+  supabaseUrl: string;
+  supabaseKey: string;
+  [key: string]: any;
+}): IDataExportDataProvider {
+  return new SupabaseDataExportProvider(options.supabaseUrl, options.supabaseKey);
+}
+
+export function createDataExportProvider(config: {
+  type: 'supabase' | string;
+  options: Record<string, any>;
+}): IDataExportDataProvider {
+  switch (config.type) {
+    case 'supabase':
+      return createSupabaseDataExportProvider(config.options);
+    default:
+      throw new Error(`Unsupported data export provider type: ${config.type}`);
+  }
+}
+
+export default createSupabaseDataExportProvider;

--- a/src/adapters/data-export/index.ts
+++ b/src/adapters/data-export/index.ts
@@ -1,0 +1,3 @@
+export * from '@/core/data-export/IDataExportDataProvider';
+export * from './factory';
+export * from './supabase/supabase-data-export.provider';

--- a/src/adapters/data-export/supabase/supabase-data-export.provider.ts
+++ b/src/adapters/data-export/supabase/supabase-data-export.provider.ts
@@ -1,0 +1,124 @@
+import type { IDataExportDataProvider } from '@/core/data-export/IDataExportDataProvider';
+import {
+  createUserDataExport,
+  processUserDataExport,
+  getUserExportData,
+  checkUserExportStatus,
+  getUserDataExportById,
+  getUserDataExportByToken,
+  getUserExportDownloadUrl,
+  isUserRateLimited,
+} from '@/lib/exports/export.service';
+import {
+  createCompanyDataExport,
+  processCompanyDataExport,
+  getCompanyExportData,
+  checkCompanyExportStatus,
+  getCompanyDataExportById,
+  getCompanyDataExportByToken,
+  getCompanyExportDownloadUrl,
+  isCompanyRateLimited,
+} from '@/lib/exports/company-export.service';
+import type {
+  ExportOptions,
+  UserDataExport,
+  CompanyDataExport,
+  UserExportData,
+  CompanyExportData,
+  DataExportResponse,
+} from '@/lib/exports/types';
+
+/**
+ * Supabase implementation of {@link IDataExportDataProvider}.
+ *
+ * This provider delegates to utility functions that interact with Supabase
+ * tables and storage.
+ */
+export class SupabaseDataExportProvider implements IDataExportDataProvider {
+  // No configuration needed for now since lib functions use a global client
+  constructor(
+    private supabaseUrl?: string,
+    private supabaseKey?: string,
+  ) {}
+
+  async createUserDataExport(
+    userId: string,
+    options: Partial<ExportOptions> = {},
+  ): Promise<UserDataExport | null> {
+    return createUserDataExport(userId, options);
+  }
+
+  async processUserDataExport(exportId: string, userId: string): Promise<void> {
+    await processUserDataExport(exportId, userId);
+  }
+
+  async getUserExportData(userId: string): Promise<UserExportData> {
+    return getUserExportData(userId);
+  }
+
+  async checkUserExportStatus(exportId: string): Promise<DataExportResponse> {
+    return checkUserExportStatus(exportId);
+  }
+
+  async getUserDataExportById(exportId: string): Promise<UserDataExport | null> {
+    return getUserDataExportById(exportId);
+  }
+
+  async getUserDataExportByToken(token: string): Promise<UserDataExport | null> {
+    return getUserDataExportByToken(token);
+  }
+
+  getUserExportDownloadUrl(filePath: string): string {
+    return getUserExportDownloadUrl(filePath);
+  }
+
+  async isUserRateLimited(userId: string): Promise<boolean> {
+    return isUserRateLimited(userId);
+  }
+
+  async createCompanyDataExport(
+    companyId: string,
+    userId: string,
+    options: Partial<ExportOptions> = {},
+  ): Promise<CompanyDataExport | null> {
+    return createCompanyDataExport(companyId, userId, options);
+  }
+
+  async processCompanyDataExport(
+    exportId: string,
+    companyId: string,
+    userId: string,
+  ): Promise<void> {
+    await processCompanyDataExport(exportId, companyId, userId);
+  }
+
+  async getCompanyExportData(companyId: string): Promise<CompanyExportData> {
+    return getCompanyExportData(companyId);
+  }
+
+  async checkCompanyExportStatus(exportId: string): Promise<DataExportResponse> {
+    return checkCompanyExportStatus(exportId);
+  }
+
+  async getCompanyDataExportById(
+    exportId: string,
+  ): Promise<CompanyDataExport | null> {
+    return getCompanyDataExportById(exportId);
+  }
+
+  async getCompanyDataExportByToken(
+    token: string,
+  ): Promise<CompanyDataExport | null> {
+    return getCompanyDataExportByToken(token);
+  }
+
+  getCompanyExportDownloadUrl(filePath: string): string {
+    return getCompanyExportDownloadUrl(filePath);
+  }
+
+  async isCompanyRateLimited(companyId: string): Promise<boolean> {
+    return isCompanyRateLimited(companyId);
+  }
+}
+
+export default SupabaseDataExportProvider;

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -22,6 +22,7 @@ export * from './subscription';
 export * from './organization';
 export * from './admin';
 export * from './csrf';
+export * from './data-export';
 export * from './webhooks';
 export * from './database';
 

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -22,6 +22,7 @@ import { IWebhookDataProvider } from '@/core/webhooks/IWebhookDataProvider';
 import type { ITwoFactorDataProvider } from '@/core/two-factor/ITwoFactorDataProvider';
 import { IOrganizationDataProvider } from '@/core/organization/IOrganizationDataProvider';
 import { IAdminDataProvider } from '@/core/admin/IAdminDataProvider';
+import { IDataExportDataProvider } from '@/core/data-export/IDataExportDataProvider';
 
 
 
@@ -107,6 +108,11 @@ export interface AdapterFactory {
    * Create an API key data provider
    */
   createApiKeyProvider(): ApiKeyDataProvider;
+
+  /**
+   * Create a data export provider
+   */
+  createDataExportProvider?(): IDataExportDataProvider;
 
   /**
    * Create a webhook data provider

--- a/src/adapters/supabase-factory.ts
+++ b/src/adapters/supabase-factory.ts
@@ -40,6 +40,8 @@ import createSupabaseApiKeyProvider from './api-keys/supabase/factory';
 import { createSupabaseWebhookProvider } from './webhooks';
 import createSupabaseAdminProvider from './admin/supabase/factory';
 import createSupabaseTwoFactorProvider from './two-factor/factory';
+import { createSupabaseDataExportProvider } from './data-export/factory';
+import type { IDataExportDataProvider } from '@/core/data-export/IDataExportDataProvider';
 
 
 /**
@@ -168,6 +170,13 @@ export class SupabaseAdapterFactory implements AdapterFactory {
    */
   createApiKeyProvider(): ApiKeyDataProvider {
     return createSupabaseApiKeyProvider(this.options);
+  }
+
+  /**
+   * Create a Supabase data export provider
+   */
+  createDataExportProvider(): IDataExportDataProvider {
+    return createSupabaseDataExportProvider(this.options);
   }
 
   /**

--- a/src/core/data-export/IDataExportDataProvider.ts
+++ b/src/core/data-export/IDataExportDataProvider.ts
@@ -1,0 +1,78 @@
+/**
+ * Data Export Data Provider Interface
+ *
+ * Defines persistence operations for user and company data exports.
+ * Implementations handle database access only and contain no business logic.
+ */
+import type {
+  ExportOptions,
+  UserDataExport,
+  CompanyDataExport,
+  UserExportData,
+  CompanyExportData,
+  DataExportResponse
+} from '@/lib/exports/types';
+
+export interface IDataExportDataProvider {
+  /** Create a new user export request */
+  createUserDataExport(
+    userId: string,
+    options?: Partial<ExportOptions>
+  ): Promise<UserDataExport | null>;
+
+  /** Process a user export immediately */
+  processUserDataExport(exportId: string, userId: string): Promise<void>;
+
+  /** Retrieve all user data for export */
+  getUserExportData(userId: string): Promise<UserExportData>;
+
+  /** Check status of a user export */
+  checkUserExportStatus(exportId: string): Promise<DataExportResponse>;
+
+  /** Get a user export record by id */
+  getUserDataExportById(exportId: string): Promise<UserDataExport | null>;
+
+  /** Get a user export record by download token */
+  getUserDataExportByToken(token: string): Promise<UserDataExport | null>;
+
+  /** Get a public download URL for a user export file */
+  getUserExportDownloadUrl(filePath: string): string;
+
+  /** Determine if the user has recently requested an export */
+  isUserRateLimited(userId: string): Promise<boolean>;
+
+  /** Create a new company export request */
+  createCompanyDataExport(
+    companyId: string,
+    userId: string,
+    options?: Partial<ExportOptions>
+  ): Promise<CompanyDataExport | null>;
+
+  /** Process a company export */
+  processCompanyDataExport(
+    exportId: string,
+    companyId: string,
+    userId: string
+  ): Promise<void>;
+
+  /** Retrieve all company data for export */
+  getCompanyExportData(companyId: string): Promise<CompanyExportData>;
+
+  /** Check status of a company export */
+  checkCompanyExportStatus(exportId: string): Promise<DataExportResponse>;
+
+  /** Get a company export by id */
+  getCompanyDataExportById(exportId: string): Promise<CompanyDataExport | null>;
+
+  /** Get a company export by token */
+  getCompanyDataExportByToken(token: string): Promise<CompanyDataExport | null>;
+
+  /** Get a public download URL for a company export file */
+  getCompanyExportDownloadUrl(filePath: string): string;
+
+  /** Determine if the company has recently requested an export */
+  isCompanyRateLimited(companyId: string): Promise<boolean>;
+}
+
+/** Convenience alias */
+export type DataExportDataProvider = IDataExportDataProvider;

--- a/src/core/data-export/index.ts
+++ b/src/core/data-export/index.ts
@@ -1,0 +1,2 @@
+export * from './interfaces';
+export * from './IDataExportDataProvider';


### PR DESCRIPTION
## Summary
- add `IDataExportDataProvider` core interface for user/company exports
- implement `SupabaseDataExportProvider`
- expose factory and index for data-export adapter
- register provider in adapter registry and supabase factory

## Testing
- `npm run lint`
- `npm run test:coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_6841a26947cc8331bbb78b0d4e8c5bbd