### PR TITLE
Add Supabase saved search provider

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -23,6 +23,7 @@ export * from './organization';
 export * from './admin';
 export * from './csrf';
 export * from './webhooks';
+export * from './saved-search';
 export * from './database';
 
 

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -19,6 +19,7 @@ import { OAuthDataProvider } from '@/core/oauth/IOAuthDataProvider';
 import { SubscriptionDataProvider } from '@/core/subscription/ISubscriptionDataProvider';
 import { ApiKeyDataProvider } from '@/core/api-keys/IApiKeyDataProvider';
 import { IWebhookDataProvider } from '@/core/webhooks/IWebhookDataProvider';
+import { ISavedSearchDataProvider } from '@/core/saved-search/ISavedSearchDataProvider';
 import type { ITwoFactorDataProvider } from '@/core/two-factor/ITwoFactorDataProvider';
 import { IOrganizationDataProvider } from '@/core/organization/IOrganizationDataProvider';
 import { IAdminDataProvider } from '@/core/admin/IAdminDataProvider';
@@ -112,6 +113,11 @@ export interface AdapterFactory {
    * Create a webhook data provider
    */
   createWebhookProvider?(): IWebhookDataProvider;
+
+  /**
+   * Create a saved search data provider
+   */
+  createSavedSearchProvider?(): ISavedSearchDataProvider;
 }
 
 /**

--- a/src/adapters/saved-search/factory.ts
+++ b/src/adapters/saved-search/factory.ts
@@ -1,0 +1,30 @@
+import type { ISavedSearchDataProvider } from '@/core/saved-search/ISavedSearchDataProvider';
+import { SupabaseSavedSearchProvider } from './supabase/supabase-saved-search.provider';
+
+/**
+ * Create a Supabase saved search data provider instance.
+ */
+export function createSupabaseSavedSearchProvider(options: {
+  supabaseUrl: string;
+  supabaseKey: string;
+  [key: string]: any;
+}): ISavedSearchDataProvider {
+  return new SupabaseSavedSearchProvider(options.supabaseUrl, options.supabaseKey);
+}
+
+/**
+ * Factory helper to create providers based on configuration.
+ */
+export function createSavedSearchProvider(config: {
+  type: 'supabase' | string;
+  options: Record<string, any>;
+}): ISavedSearchDataProvider {
+  switch (config.type) {
+    case 'supabase':
+      return createSupabaseSavedSearchProvider(config.options);
+    default:
+      throw new Error(`Unsupported saved search provider type: ${config.type}`);
+  }
+}
+
+export default createSupabaseSavedSearchProvider;

--- a/src/adapters/saved-search/index.ts
+++ b/src/adapters/saved-search/index.ts
@@ -1,0 +1,3 @@
+export * from '@/core/saved-search/ISavedSearchDataProvider';
+export * from './factory';
+export * from './supabase/supabase-saved-search.provider';

--- a/src/adapters/saved-search/supabase/supabase-saved-search.provider.ts
+++ b/src/adapters/saved-search/supabase/supabase-saved-search.provider.ts
@@ -1,0 +1,124 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import type { ISavedSearchDataProvider } from '@/core/saved-search/ISavedSearchDataProvider';
+import type {
+  SavedSearch,
+  SavedSearchCreatePayload,
+  SavedSearchUpdatePayload
+} from '@/core/saved-search/models';
+
+/**
+ * Supabase implementation of {@link ISavedSearchDataProvider}.
+ *
+ * Provides CRUD operations for saved search records using Supabase
+ * as the persistence layer.
+ */
+export class SupabaseSavedSearchProvider implements ISavedSearchDataProvider {
+  private supabase: SupabaseClient;
+
+  constructor(supabaseUrl: string, supabaseKey: string) {
+    this.supabase = createClient(supabaseUrl, supabaseKey);
+  }
+
+  async listSavedSearches(userId: string): Promise<SavedSearch[]> {
+    const { data, error } = await this.supabase
+      .from('saved_searches')
+      .select('*')
+      .or(`user_id.eq.${userId},is_public.eq.true`)
+      .order('created_at', { ascending: false });
+    if (error || !data) return [];
+    return data.map(r => this.mapRecord(r));
+  }
+
+  async createSavedSearch(payload: SavedSearchCreatePayload): Promise<SavedSearch> {
+    const { data, error } = await this.supabase
+      .from('saved_searches')
+      .insert({
+        user_id: payload.userId,
+        name: payload.name,
+        description: payload.description ?? '',
+        search_params: payload.searchParams,
+        is_public: payload.isPublic ?? false
+      })
+      .select('*')
+      .single();
+    if (error || !data) {
+      throw new Error(error?.message || 'Failed to create saved search');
+    }
+    return this.mapRecord(data);
+  }
+
+  async getSavedSearch(id: string, userId: string): Promise<SavedSearch | null> {
+    const { data, error } = await this.supabase
+      .from('saved_searches')
+      .select('*')
+      .eq('id', id)
+      .or(`user_id.eq.${userId},is_public.eq.true`)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    return data ? this.mapRecord(data) : null;
+  }
+
+  async updateSavedSearch(
+    id: string,
+    userId: string,
+    updates: SavedSearchUpdatePayload
+  ): Promise<SavedSearch> {
+    const { data: existing, error: checkErr } = await this.supabase
+      .from('saved_searches')
+      .select('user_id')
+      .eq('id', id)
+      .single();
+    if (checkErr || !existing) throw new Error('Saved search not found');
+    if (existing.user_id !== userId) {
+      throw new Error('You can only update your own saved searches');
+    }
+    const { data, error } = await this.supabase
+      .from('saved_searches')
+      .update({
+        ...(updates.name && { name: updates.name }),
+        ...(updates.description !== undefined && { description: updates.description }),
+        ...(updates.searchParams && { search_params: updates.searchParams }),
+        ...(updates.isPublic !== undefined && { is_public: updates.isPublic }),
+        updated_at: new Date().toISOString()
+      })
+      .eq('id', id)
+      .select('*')
+      .single();
+    if (error || !data) {
+      throw new Error(error?.message || 'Failed to update saved search');
+    }
+    return this.mapRecord(data);
+  }
+
+  async deleteSavedSearch(id: string, userId: string): Promise<void> {
+    const { data: existing, error: checkErr } = await this.supabase
+      .from('saved_searches')
+      .select('user_id')
+      .eq('id', id)
+      .single();
+    if (checkErr || !existing) throw new Error('Saved search not found');
+    if (existing.user_id !== userId) {
+      throw new Error('You can only delete your own saved searches');
+    }
+    const { error } = await this.supabase
+      .from('saved_searches')
+      .delete()
+      .eq('id', id);
+    if (error) throw new Error(error.message);
+  }
+
+  private mapRecord(record: any): SavedSearch {
+    return {
+      id: record.id,
+      userId: record.user_id,
+      name: record.name,
+      description: record.description,
+      searchParams: record.search_params,
+      isPublic: record.is_public,
+      createdAt: record.created_at,
+      updatedAt: record.updated_at
+    };
+  }
+}
+
+export default SupabaseSavedSearchProvider;

--- a/src/adapters/supabase-factory.ts
+++ b/src/adapters/supabase-factory.ts
@@ -21,6 +21,7 @@ import { IWebhookDataProvider } from '@/core/webhooks/IWebhookDataProvider';
 import { IOrganizationDataProvider } from '@/core/organization/IOrganizationDataProvider';
 import { IAdminDataProvider } from '@/core/admin/IAdminDataProvider';
 import type { ITwoFactorDataProvider } from '@/core/two-factor/ITwoFactorDataProvider';
+import { ISavedSearchDataProvider } from '@/core/saved-search/ISavedSearchDataProvider';
 
 
 // Import domain-specific factories
@@ -40,6 +41,7 @@ import createSupabaseApiKeyProvider from './api-keys/supabase/factory';
 import { createSupabaseWebhookProvider } from './webhooks';
 import createSupabaseAdminProvider from './admin/supabase/factory';
 import createSupabaseTwoFactorProvider from './two-factor/factory';
+import { createSupabaseSavedSearchProvider } from './saved-search/factory';
 
 
 /**
@@ -168,6 +170,13 @@ export class SupabaseAdapterFactory implements AdapterFactory {
    */
   createApiKeyProvider(): ApiKeyDataProvider {
     return createSupabaseApiKeyProvider(this.options);
+  }
+
+  /**
+   * Create a Supabase saved search provider
+   */
+  createSavedSearchProvider(): ISavedSearchDataProvider {
+    return createSupabaseSavedSearchProvider(this.options);
   }
 
   /**

--- a/src/core/saved-search/ISavedSearchDataProvider.ts
+++ b/src/core/saved-search/ISavedSearchDataProvider.ts
@@ -1,0 +1,32 @@
+import type {
+  SavedSearch,
+  SavedSearchCreatePayload,
+  SavedSearchUpdatePayload
+} from './models';
+
+/**
+ * Data provider interface for saved search persistence.
+ *
+ * Implementations are responsible solely for database access and should
+ * not contain business logic.
+ */
+export interface ISavedSearchDataProvider {
+  /** List saved searches visible to the given user */
+  listSavedSearches(userId: string): Promise<SavedSearch[]>;
+
+  /** Persist a new saved search */
+  createSavedSearch(payload: SavedSearchCreatePayload): Promise<SavedSearch>;
+
+  /** Retrieve a saved search by id if accessible */
+  getSavedSearch(id: string, userId: string): Promise<SavedSearch | null>;
+
+  /** Update a saved search owned by the user */
+  updateSavedSearch(
+    id: string,
+    userId: string,
+    updates: SavedSearchUpdatePayload
+  ): Promise<SavedSearch>;
+
+  /** Delete a saved search owned by the user */
+  deleteSavedSearch(id: string, userId: string): Promise<void>;
+}

--- a/src/core/saved-search/index.ts
+++ b/src/core/saved-search/index.ts
@@ -1,2 +1,3 @@
 export * from "./interfaces";
 export * from "./models";
+export * from "./ISavedSearchDataProvider";


### PR DESCRIPTION
## Summary
- implement ISavedSearchDataProvider
- provide SupabaseSavedSearchProvider with CRUD methods
- add factory and index for saved-search adapter
- register provider with adapter system

## Testing
- `npm run lint`
- `npm run test:coverage` *(fails: Adapter not registered etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6841a2a54bb483318542600e8018949e