### PR TITLE
Refactor API routes to use service layer

### DIFF
--- a/app/api/audit/permission/export/route.ts
+++ b/app/api/audit/permission/export/route.ts
@@ -1,55 +1,61 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { z } from 'zod';
-import { createAuditProvider } from '@/adapters/audit/factory';
-import { middleware } from '@/middleware';
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { getApiAuditService } from "@/services/audit/factory";
+import { middleware } from "@/middleware";
 
 const querySchema = z.object({
   startDate: z.string().optional(),
   endDate: z.string().optional(),
   userId: z.string().uuid().optional(),
   action: z.string().optional(),
-  status: z.enum(['SUCCESS','FAILURE','INITIATED','COMPLETED']).optional(),
+  status: z.enum(["SUCCESS", "FAILURE", "INITIATED", "COMPLETED"]).optional(),
   ipAddress: z.string().optional(),
   userAgent: z.string().optional(),
   search: z.string().optional(),
   sortBy: z.string().optional(),
-  sortOrder: z.enum(['asc','desc']).optional(),
-  format: z.enum(['csv','json','xlsx','pdf']).default('json')
+  sortOrder: z.enum(["asc", "desc"]).optional(),
+  format: z.enum(["csv", "json", "xlsx", "pdf"]).default("json"),
 });
 
-export const GET = middleware(['cors','csrf','rateLimit'], async (req: NextRequest) => {
-  try {
-    const user = (req as any).user;
-    if(!user){
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    const searchParams = Object.fromEntries(new URL(req.url).searchParams);
-    const params = querySchema.parse(searchParams);
-    const provider = createAuditProvider({
-      type: 'supabase',
-      options: {
-        supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',
-        supabaseKey: process.env.SUPABASE_SERVICE_ROLE_KEY || ''
+export const GET = middleware(
+  ["cors", "csrf", "rateLimit"],
+  async (req: NextRequest) => {
+    try {
+      const user = (req as any).user;
+      if (!user) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
       }
-    });
-    const blob = await provider.exportLogs({
-      ...params,
-      page: 1,
-      limit: 1000,
-      resourceType: 'permission'
-    });
-    return new NextResponse(blob, {
-      status: 200,
-      headers: {
-        'Content-Type': blob.type,
-        'Content-Disposition': `attachment; filename="audit-logs.${params.format}"`
+      const searchParams = Object.fromEntries(new URL(req.url).searchParams);
+      const params = querySchema.parse(searchParams);
+      const service = getApiAuditService();
+      if (!service) {
+        return NextResponse.json(
+          { error: "Audit service not available" },
+          { status: 500 },
+        );
       }
-    });
-  } catch (error) {
-    console.error('Permission audit export error:', error);
-    if (error instanceof z.ZodError) {
-      return NextResponse.json({ error: 'Invalid query' }, { status: 400 });
+      const blob = await service.exportLogs({
+        ...params,
+        page: 1,
+        limit: 1000,
+        resourceType: "permission",
+      });
+      return new NextResponse(blob, {
+        status: 200,
+        headers: {
+          "Content-Type": blob.type,
+          "Content-Disposition": `attachment; filename="audit-logs.${params.format}"`,
+        },
+      });
+    } catch (error) {
+      console.error("Permission audit export error:", error);
+      if (error instanceof z.ZodError) {
+        return NextResponse.json({ error: "Invalid query" }, { status: 400 });
+      }
+      return NextResponse.json(
+        { error: "Internal server error" },
+        { status: 500 },
+      );
     }
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
-  }
-});
+  },
+);

--- a/app/api/audit/permission/route.ts
+++ b/app/api/audit/permission/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { z } from 'zod';
-import { createAuditProvider } from '@/adapters/audit/factory';
-import { middleware } from '@/middleware';
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { getApiAuditService } from "@/services/audit/factory";
+import { middleware } from "@/middleware";
 
 const querySchema = z.object({
   startDate: z.string().optional(),
@@ -11,47 +11,56 @@ const querySchema = z.object({
   page: z.number().int().min(1).default(1),
   limit: z.number().int().min(1).max(100).default(20),
   sortBy: z.string().optional(),
-  sortOrder: z.enum(['asc','desc']).optional(),
+  sortOrder: z.enum(["asc", "desc"]).optional(),
 });
 
-export const GET = middleware(['cors','csrf','rateLimit'], async (req: NextRequest) => {
-  try {
-    const user = (req as any).user;
-    if(!user){
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const params = querySchema.parse(
-      Object.fromEntries(new URL(req.url).searchParams.entries())
-    );
-
-    const provider = createAuditProvider({
-      type: 'supabase',
-      options: {
-        supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',
-        supabaseKey: process.env.SUPABASE_SERVICE_ROLE_KEY || ''
+export const GET = middleware(
+  ["cors", "csrf", "rateLimit"],
+  async (req: NextRequest) => {
+    try {
+      const user = (req as any).user;
+      if (!user) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
       }
-    });
 
-    const { logs, count } = await provider.getUserActionLogs({
-      ...params,
-      resourceType: 'permission'
-    });
+      const params = querySchema.parse(
+        Object.fromEntries(new URL(req.url).searchParams.entries()),
+      );
 
-    return NextResponse.json({
-      logs,
-      pagination: {
-        page: params.page,
-        limit: params.limit,
-        total: count,
-        totalPages: Math.ceil(count / params.limit)
+      const service = getApiAuditService();
+      if (!service) {
+        return NextResponse.json(
+          { error: "Audit service not available" },
+          { status: 500 },
+        );
       }
-    });
-  } catch (error) {
-    console.error('Error in permission audit endpoint:', error);
-    if (error instanceof z.ZodError) {
-      return NextResponse.json({ error: 'Invalid query parameters', details: error.errors }, { status: 400 });
+
+      const { logs, count } = await service.getLogs({
+        ...params,
+        resourceType: "permission",
+      });
+
+      return NextResponse.json({
+        logs,
+        pagination: {
+          page: params.page,
+          limit: params.limit,
+          total: count,
+          totalPages: Math.ceil(count / params.limit),
+        },
+      });
+    } catch (error) {
+      console.error("Error in permission audit endpoint:", error);
+      if (error instanceof z.ZodError) {
+        return NextResponse.json(
+          { error: "Invalid query parameters", details: error.errors },
+          { status: 400 },
+        );
+      }
+      return NextResponse.json(
+        { error: "Internal server error" },
+        { status: 500 },
+      );
     }
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
-  }
-});
+  },
+);

--- a/app/api/audit/user-actions/export/route.ts
+++ b/app/api/audit/user-actions/export/route.ts
@@ -1,52 +1,62 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { z } from 'zod';
-import { createAuditProvider } from '@/adapters/audit/factory';
-import { middleware } from '@/middleware';
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { getApiAuditService } from "@/services/audit/factory";
+import { middleware } from "@/middleware";
 
 const querySchema = z.object({
   startDate: z.string().optional(),
   endDate: z.string().optional(),
   userId: z.string().uuid().optional(),
   action: z.string().optional(),
-  status: z.enum(['SUCCESS','FAILURE','INITIATED','COMPLETED']).optional(),
+  status: z.enum(["SUCCESS", "FAILURE", "INITIATED", "COMPLETED"]).optional(),
   resourceType: z.string().optional(),
   resourceId: z.string().optional(),
   ipAddress: z.string().optional(),
   userAgent: z.string().optional(),
   search: z.string().optional(),
   sortBy: z.string().optional(),
-  sortOrder: z.enum(['asc','desc']).optional(),
-  format: z.enum(['csv','json','xlsx','pdf']).default('json')
+  sortOrder: z.enum(["asc", "desc"]).optional(),
+  format: z.enum(["csv", "json", "xlsx", "pdf"]).default("json"),
 });
 
-export const GET = middleware(['cors','csrf','rateLimit'], async (req: NextRequest) => {
-  try {
-    const user = (req as any).user;
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    const searchParams = Object.fromEntries(new URL(req.url).searchParams);
-    const params = querySchema.parse(searchParams);
-    const provider = createAuditProvider({
-      type: 'supabase',
-      options: {
-        supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || '',
-        supabaseKey: process.env.SUPABASE_SERVICE_ROLE_KEY || ''
+export const GET = middleware(
+  ["cors", "csrf", "rateLimit"],
+  async (req: NextRequest) => {
+    try {
+      const user = (req as any).user;
+      if (!user) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
       }
-    });
-    const blob = await provider.exportLogs({ ...params, page: 1, limit: 1000 });
-    return new NextResponse(blob, {
-      status: 200,
-      headers: {
-        'Content-Type': blob.type,
-        'Content-Disposition': `attachment; filename="audit-logs.${params.format}"`
+      const searchParams = Object.fromEntries(new URL(req.url).searchParams);
+      const params = querySchema.parse(searchParams);
+      const service = getApiAuditService();
+      if (!service) {
+        return NextResponse.json(
+          { error: "Audit service not available" },
+          { status: 500 },
+        );
       }
-    });
-  } catch (error) {
-    console.error('Audit log export error:', error);
-    if (error instanceof z.ZodError) {
-      return NextResponse.json({ error: 'Invalid query' }, { status: 400 });
+      const blob = await service.exportLogs({
+        ...params,
+        page: 1,
+        limit: 1000,
+      });
+      return new NextResponse(blob, {
+        status: 200,
+        headers: {
+          "Content-Type": blob.type,
+          "Content-Disposition": `attachment; filename="audit-logs.${params.format}"`,
+        },
+      });
+    } catch (error) {
+      console.error("Audit log export error:", error);
+      if (error instanceof z.ZodError) {
+        return NextResponse.json({ error: "Invalid query" }, { status: 400 });
+      }
+      return NextResponse.json(
+        { error: "Internal server error" },
+        { status: 500 },
+      );
     }
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
-  }
-});
+  },
+);

--- a/app/api/resources/[type]/[id]/ancestors/route.ts
+++ b/app/api/resources/[type]/[id]/ancestors/route.ts
@@ -3,10 +3,9 @@ import { withErrorHandling } from "@/middleware/error-handling";
 import { withRouteAuth } from "@/middleware/auth";
 import { createSuccessResponse } from "@/lib/api/common";
 import { ResourcePermissionResolver } from "@/services/permission/resource-permission-resolver";
-import { getServiceSupabase } from "@/lib/database/supabase";
 
 async function handleGet(type: string, id: string) {
-  const resolver = new ResourcePermissionResolver(getServiceSupabase());
+  const resolver = new ResourcePermissionResolver();
   const ancestors = await resolver.getResourceAncestors(type, id);
   return createSuccessResponse({ ancestors });
 }

--- a/app/api/resources/relationships/route.ts
+++ b/app/api/resources/relationships/route.ts
@@ -1,21 +1,20 @@
-import { NextRequest } from 'next/server';
-import { z } from 'zod';
-import { getServiceSupabase } from '@/lib/database/supabase';
-import { createResourceRelationshipService } from '@/services/resource-relationship/factory';
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { getApiResourceRelationshipService } from "@/services/resource-relationship/factory";
 import {
   createMiddlewareChain,
   errorHandlingMiddleware,
   routeAuthMiddleware,
   validationMiddleware,
-} from '@/middleware/createMiddlewareChain';
-import { createSuccessResponse, createCreatedResponse } from '@/lib/api/common';
+} from "@/middleware/createMiddlewareChain";
+import { createSuccessResponse, createCreatedResponse } from "@/lib/api/common";
 
 const relationshipSchema = z.object({
   parentType: z.string().min(1),
   parentId: z.string().min(1),
   childType: z.string().min(1),
   childId: z.string().min(1),
-  relationshipType: z.string().min(1).default('contains'),
+  relationshipType: z.string().min(1).default("contains"),
 });
 
 const middleware = createMiddlewareChain([
@@ -26,19 +25,19 @@ const middleware = createMiddlewareChain([
 
 async function handleGet(req: NextRequest) {
   const url = new URL(req.url);
-  const parentType = url.searchParams.get('parentType');
-  const parentId = url.searchParams.get('parentId');
-  const childType = url.searchParams.get('childType');
-  const childId = url.searchParams.get('childId');
+  const parentType = url.searchParams.get("parentType");
+  const parentId = url.searchParams.get("parentId");
+  const childType = url.searchParams.get("childType");
+  const childId = url.searchParams.get("childId");
 
   if (!((parentType && parentId) || (childType && childId))) {
     return Response.json(
-      { error: 'Must provide either parent or child resource identifiers' },
-      { status: 400 }
+      { error: "Must provide either parent or child resource identifiers" },
+      { status: 400 },
     );
   }
 
-  const service = createResourceRelationshipService(getServiceSupabase());
+  const service = getApiResourceRelationshipService();
 
   if (parentType && parentId) {
     const children = await service.getChildResources(parentType, parentId);
@@ -52,9 +51,9 @@ async function handleGet(req: NextRequest) {
 async function handlePost(
   req: NextRequest,
   auth: any,
-  data: z.infer<typeof relationshipSchema>
+  data: z.infer<typeof relationshipSchema>,
 ) {
-  const service = createResourceRelationshipService(getServiceSupabase());
+  const service = getApiResourceRelationshipService();
   const relationship = await service.createRelationship({
     ...data,
     createdBy: auth.userId,

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { stripe } from '@/lib/payments/stripe';
-import { createSupabaseSubscriptionProvider } from '@/adapters/subscription/factory';
-import type Stripe from 'stripe';
+import { NextRequest, NextResponse } from "next/server";
+import { stripe } from "@/lib/payments/stripe";
+import { getApiSubscriptionService } from "@/services/subscription/factory";
+import type Stripe from "stripe";
 
 /**
  * Stripe Webhook handler
@@ -9,46 +9,58 @@ import type Stripe from 'stripe';
  * Verifies the event signature and updates subscriptions accordingly.
  */
 export async function POST(request: NextRequest) {
-  const signature = request.headers.get('stripe-signature');
+  const signature = request.headers.get("stripe-signature");
   const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
   if (!webhookSecret) {
-    console.error('STRIPE_WEBHOOK_SECRET not configured');
-    return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
+    console.error("STRIPE_WEBHOOK_SECRET not configured");
+    return NextResponse.json(
+      { error: "Server configuration error" },
+      { status: 500 },
+    );
   }
 
   const payload = await request.text();
   let event: Stripe.Event;
   try {
-    event = stripe.webhooks.constructEvent(payload, signature || '', webhookSecret);
+    event = stripe.webhooks.constructEvent(
+      payload,
+      signature || "",
+      webhookSecret,
+    );
   } catch (err) {
-    console.error('Stripe signature verification failed:', err);
-    return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+    console.error("Stripe signature verification failed:", err);
+    return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
   }
 
   try {
     switch (event.type) {
-      case 'customer.subscription.created':
-      case 'customer.subscription.updated':
-      case 'customer.subscription.deleted': {
+      case "customer.subscription.created":
+      case "customer.subscription.updated":
+      case "customer.subscription.deleted": {
         const subscription = event.data.object as Stripe.Subscription;
         const userId = subscription.metadata?.user_id;
         if (userId) {
-          const provider = createSupabaseSubscriptionProvider({
-            supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
-            supabaseKey: process.env.SUPABASE_SERVICE_ROLE_KEY!
-          });
-          await provider.upsertSubscription({
-            id: subscription.id,
-            userId,
-            planId: subscription.items.data[0]?.price.id ?? '',
-            status: subscription.status,
-            startDate: new Date(subscription.start_date * 1000).toISOString(),
-            endDate: subscription.ended_at ? new Date(subscription.ended_at * 1000).toISOString() : null,
-            renewalDate: new Date(subscription.current_period_end * 1000).toISOString(),
-            canceledAt: subscription.canceled_at ? new Date(subscription.canceled_at * 1000).toISOString() : null,
-            paymentMethod: undefined,
-            metadata: subscription.metadata as any
-          });
+          const service = getApiSubscriptionService();
+          if (service) {
+            await service.reconcileSubscription({
+              id: subscription.id,
+              userId,
+              planId: subscription.items.data[0]?.price.id ?? "",
+              status: subscription.status,
+              startDate: new Date(subscription.start_date * 1000).toISOString(),
+              endDate: subscription.ended_at
+                ? new Date(subscription.ended_at * 1000).toISOString()
+                : null,
+              renewalDate: new Date(
+                subscription.current_period_end * 1000,
+              ).toISOString(),
+              canceledAt: subscription.canceled_at
+                ? new Date(subscription.canceled_at * 1000).toISOString()
+                : null,
+              paymentMethod: undefined,
+              metadata: subscription.metadata as any,
+            });
+          }
         }
         break;
       }
@@ -56,8 +68,11 @@ export async function POST(request: NextRequest) {
         console.log(`Unhandled Stripe event: ${event.type}`);
     }
   } catch (err) {
-    console.error('Error processing Stripe webhook:', err);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    console.error("Error processing Stripe webhook:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
   }
 
   return NextResponse.json({ received: true });


### PR DESCRIPTION
## Summary
- remove direct Supabase usage from audit and resource routes
- switch Stripe webhook to subscription service
- update resource permission resolver usage
- format modified files

## Testing
- `npx vitest run --coverage` *(fails: Transform failed with 1 error)*

------
https://chatgpt.com/codex/tasks/task_b_6841cd927a2883318d5c792ada5b172d