### PR TITLE
Refactor auth routes

### DIFF
--- a/app/api/auth/csrf/route.ts
+++ b/app/api/auth/csrf/route.ts
@@ -1,58 +1,52 @@
-import { type NextRequest } from "next/server";
-import { withSecurity } from '@/middleware/with-security';
-import { getCSRFToken } from "@/middleware/csrf";
-import { logUserAction } from "@/lib/audit/auditLogger";
+import { z } from 'zod';
+import { getCSRFToken } from '@/middleware/csrf';
+import { logUserAction } from '@/lib/audit/auditLogger';
 import {
   createSuccessResponse,
-  withErrorHandling,
   ApiError,
-  ERROR_CODES,
-} from "@/lib/api/common";
+  ERROR_CODES
+} from '@/lib/api/common';
+import { createApiHandler } from '@/lib/api/route-helpers';
 
-async function handleCsrf(req: NextRequest) {
-  const ipAddress = req.headers.get("x-forwarded-for") || "unknown";
-  const userAgent = req.headers.get("user-agent") || "unknown";
+const emptySchema = z.object({});
 
-  try {
-    const token = getCSRFToken(req);
+export const GET = createApiHandler(
+  emptySchema,
+  async (request, _authContext, _data) => {
+    const ipAddress = request.headers.get('x-forwarded-for') || 'unknown';
+    const userAgent = request.headers.get('user-agent') || 'unknown';
 
-    // Log the CSRF token generation
-    await logUserAction({
-      action: "CSRF_TOKEN_GENERATED",
-      status: "SUCCESS",
-      ipAddress,
-      userAgent,
-      targetResourceType: "security",
-    });
+    try {
+      const token = getCSRFToken(request as any);
 
-    return createSuccessResponse({ token });
-  } catch (error) {
-    console.error("CSRF token generation error:", error);
+      await logUserAction({
+        action: 'CSRF_TOKEN_GENERATED',
+        status: 'SUCCESS',
+        ipAddress,
+        userAgent,
+        targetResourceType: 'security'
+      });
 
-    // Log the error
-    await logUserAction({
-      action: "CSRF_TOKEN_ERROR",
-      status: "FAILURE",
-      ipAddress,
-      userAgent,
-      targetResourceType: "security",
-      details: {
-        error: error instanceof Error ? error.message : "Unknown error",
-      },
-    });
+      return createSuccessResponse({ token });
+    } catch (error: any) {
+      await logUserAction({
+        action: 'CSRF_TOKEN_ERROR',
+        status: 'FAILURE',
+        ipAddress,
+        userAgent,
+        targetResourceType: 'security',
+        details: { error: error instanceof Error ? error.message : 'Unknown error' }
+      });
 
-    throw new ApiError(
-      ERROR_CODES.INTERNAL_ERROR,
-      "Failed to generate CSRF token",
-      500,
-    );
+      throw new ApiError(
+        ERROR_CODES.INTERNAL_ERROR,
+        'Failed to generate CSRF token',
+        500
+      );
+    }
+  },
+  {
+    requireAuth: false,
+    rateLimit: { windowMs: 15 * 60 * 1000, max: 60 }
   }
-}
-
-async function handler(req: NextRequest) {
-  return withErrorHandling(handleCsrf, req);
-}
-
-export const GET = withSecurity(handler, {
-  skipMiddlewares: ["csrf"], // Skip CSRF check for the token endpoint
-});
+);

--- a/app/api/auth/oauth/__tests__/route.test.ts
+++ b/app/api/auth/oauth/__tests__/route.test.ts
@@ -3,7 +3,7 @@ let POST: (req: Request) => Promise<Response>;
 // import { NextResponse } from 'next/server';
 import { OAuthProvider } from "@/types/oauth";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { getApiAuthService } from "@/services/auth/factory";
+import { getServiceContainer } from '@/lib/config/service-container';
 
 // --- Mocks ---
 
@@ -46,12 +46,15 @@ vi.mock("next/headers", () => ({
 }));
 
 
-// Mock Auth service
-vi.mock("@/services/auth/factory");
+// Mock service container
+vi.mock('@/lib/config/service-container', () => ({
+  getServiceContainer: vi.fn()
+}));
 const mockService = {
   configureOAuthProvider: vi.fn(),
-  getOAuthAuthorizationUrl: vi.fn(),
+  getOAuthAuthorizationUrl: vi.fn()
 };
+const mockServices = { auth: mockService };
 
 // Mock crypto for deterministic state generation
 const mockStateValue = "deterministic-state-value-1234567890";
@@ -100,9 +103,9 @@ describe("POST /api/auth/oauth", () => {
     process.env.NEXT_PUBLIC_APPLE_REDIRECT_URI =
       "http://localhost:3000/api/auth/oauth/callback";
 
-    (getApiAuthService as vi.Mock).mockReturnValue(mockService);
+    (getServiceContainer as vi.Mock).mockReturnValue(mockServices);
     mockService.getOAuthAuthorizationUrl.mockReturnValue(
-      "https://example.com/auth",
+      'https://example.com/auth'
     );
     POST = (await import("../route")).POST;
   });

--- a/app/api/auth/oauth/disconnect/route.ts
+++ b/app/api/auth/oauth/disconnect/route.ts
@@ -1,9 +1,15 @@
-import { NextResponse, type NextRequest } from "next/server";
+import { type NextRequest } from 'next/server';
 import { z } from "zod";
 import { OAuthProvider } from "@/types/oauth";
 import { createApiHandler } from "@/lib/api/route-helpers";
 import type { AuthContext, ServiceContainer } from "@/core/config/interfaces";
 import { getApiOAuthService } from "@/services/oauth/factory";
+import {
+  createSuccessResponse,
+  ApiError,
+  ERROR_CODES
+} from '@/lib/api/common';
+import { logUserAction } from '@/lib/audit/auditLogger';
 
 // Request schema
 const disconnectRequestSchema = z.object({
@@ -18,16 +24,34 @@ async function handlePost(
 ) {
   const { provider } = data;
   const service = services.oauth ?? getApiOAuthService();
+  const ipAddress = request.headers.get('x-forwarded-for') || 'unknown';
+  const userAgent = request.headers.get('user-agent') || 'unknown';
+
   const result = await service.disconnectProvider(provider);
+
+  await logUserAction({
+    userId: auth.userId,
+    action: 'OAUTH_DISCONNECT',
+    status: result.success ? 'SUCCESS' : 'FAILURE',
+    ipAddress,
+    userAgent,
+    targetResourceType: 'oauth',
+    targetResourceId: provider,
+    details: { error: result.success ? null : result.error }
+  });
+
   if (!result.success) {
-    return NextResponse.json(
-      { error: result.error },
-      { status: result.status ?? 500 },
+    throw new ApiError(
+      ERROR_CODES.INTERNAL_ERROR,
+      result.error || 'Failed to disconnect provider',
+      result.status ?? 500
     );
   }
-  return NextResponse.json({ success: true });
+
+  return createSuccessResponse({ success: true });
 }
 
 export const POST = createApiHandler(disconnectRequestSchema, handlePost, {
   requireAuth: true,
+  rateLimit: { windowMs: 15 * 60 * 1000, max: 10 }
 });

--- a/app/api/auth/oauth/link/__tests__/route.test.ts
+++ b/app/api/auth/oauth/link/__tests__/route.test.ts
@@ -1,9 +1,11 @@
 import { POST } from '../route';
 import { OAuthProvider } from '@/types/oauth';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getApiOAuthService } from '@/services/oauth/factory';
+import { getServiceContainer } from '@/lib/config/service-container';
 
-vi.mock('@/services/oauth/factory');
+vi.mock('@/lib/config/service-container', () => ({
+  getServiceContainer: vi.fn()
+}));
 
 const mockService = {
   linkProvider: vi.fn(),
@@ -19,7 +21,7 @@ const createRequest = (body: object) =>
 describe('POST /api/auth/oauth/link', () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    (getApiOAuthService as vi.Mock).mockReturnValue(mockService);
+    (getServiceContainer as vi.Mock).mockReturnValue({ oauth: mockService });
   });
 
   it('returns error when service fails', async () => {

--- a/app/api/auth/oauth/verify/__tests__/route.test.ts
+++ b/app/api/auth/oauth/verify/__tests__/route.test.ts
@@ -1,7 +1,7 @@
 import { POST } from '../route';
 import { OAuthProvider } from '@/types/oauth';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getApiOAuthService } from '@/services/oauth/factory';
+import { getServiceContainer } from '@/lib/config/service-container';
 
 // Mock cookies
 const mockCookies = new Map<string, any>();
@@ -21,7 +21,9 @@ vi.mock('next/headers', () => ({
   }),
 }));
 
-vi.mock('@/services/oauth/factory');
+vi.mock('@/lib/config/service-container', () => ({
+  getServiceContainer: vi.fn()
+}));
 const mockService = {
   verifyProviderEmail: vi.fn(),
 };
@@ -39,7 +41,7 @@ describe('oauth verify route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCookies.clear();
-    (getApiOAuthService as vi.Mock).mockReturnValue(mockService);
+    (getServiceContainer as vi.Mock).mockReturnValue({ oauth: mockService });
     mockService.verifyProviderEmail.mockResolvedValue({ success: true });
   });
 


### PR DESCRIPTION
## Summary
- use `createApiHandler` for OAuth login initiation
- standardize callback, link, verify and disconnect handlers
- refactor CSRF token endpoint
- update related unit tests

## Testing
- `npx vitest run --coverage` *(fails: Adapter 'user' not registered; environment not configured)*

------
https://chatgpt.com/codex/tasks/task_b_6842ad6d83188331bdee183334e659db