### PR TITLE
Improve verification route security and logging

### DIFF
--- a/app/api/company/domains/[id]/verify-check/__tests__/route.test.ts
+++ b/app/api/company/domains/[id]/verify-check/__tests__/route.test.ts
@@ -69,10 +69,10 @@ describe('Domain Verification Check API', () => {
     
     const response = await POST(request, { params: { id: mockDomainId } });
     expect(response.status).toBe(200);
-    
+
     const data = await response.json();
-    expect(data.verified).toBe(true);
-    expect(data.message).toContain('verified');
+    expect(data.data.verified).toBe(true);
+    expect(data.data.message).toContain('verified');
     
     // Verify DNS lookup was called correctly
     expect(dns.resolveTxt).toHaveBeenCalledWith(mockDomain);
@@ -105,7 +105,7 @@ describe('Domain Verification Check API', () => {
     expect(response.status).toBe(404);
     
     const data = await response.json();
-    expect(data.error).toContain('not found');
+    expect(data.error.message).toContain('not found');
   });
   
   test('returns 400 if verification has not been initiated', async () => {
@@ -119,7 +119,7 @@ describe('Domain Verification Check API', () => {
     expect(response.status).toBe(400);
     
     const data = await response.json();
-    expect(data.error).toContain('not been initiated');
+    expect(data.error.message).toContain('not been initiated');
   });
   
   test('returns unverified status when token is not found in DNS records', async () => {
@@ -134,12 +134,12 @@ describe('Domain Verification Check API', () => {
     expect(response.status).toBe(400);
     
     const data = await response.json();
-    expect(data.verified).toBe(false);
-    expect(data.message).toContain('not found');
-    
+    expect(data.data.verified).toBe(false);
+    expect(data.data.message).toContain('not found');
+
     // Verify DNS lookup was called
     expect(dns.resolveTxt).toHaveBeenCalledWith(mockDomain);
-    
+
     expect(service.checkDomainVerification).toHaveBeenCalledWith(mockDomainId, mockUserId);
   });
   
@@ -155,8 +155,8 @@ describe('Domain Verification Check API', () => {
     expect(response.status).toBe(400);
     
     const data = await response.json();
-    expect(data.verified).toBe(false);
-    expect(data.message).toContain('No TXT records found');
+    expect(data.data.verified).toBe(false);
+    expect(data.data.message).toContain('No TXT records found');
     
     // Verify DNS lookup was called
     expect(dns.resolveTxt).toHaveBeenCalledWith(mockDomain);
@@ -174,8 +174,8 @@ describe('Domain Verification Check API', () => {
     expect(response.status).toBe(400);
     
     const data = await response.json();
-    expect(data.verified).toBe(false);
-    expect(data.message).toContain('error occurred');
+    expect(data.data.verified).toBe(false);
+    expect(data.data.message).toContain('error occurred');
   });
   
   test('returns 500 when database update fails', async () => {

--- a/app/api/company/domains/[id]/verify-check/route.ts
+++ b/app/api/company/domains/[id]/verify-check/route.ts
@@ -1,42 +1,56 @@
-import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
-import { getApiCompanyService } from "@/services/company/factory";
-import { type RouteAuthContext } from "@/middleware/auth";
-import { createApiHandler } from "@/lib/api/route-helpers";
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { getApiCompanyService } from '@/services/company/factory';
+import { createApiHandler } from '@/lib/api/route-helpers';
+import { checkRateLimit } from '@/middleware/rate-limit';
+import { logUserAction } from '@/lib/audit/auditLogger';
+import { ApiError, ERROR_CODES, createSuccessResponse } from '@/lib/api/common';
 
+async function handlePost(request: NextRequest, params: { id: string }, auth: { userId?: string }) {
+  if (await checkRateLimit(request, { windowMs: 15 * 60 * 1000, max: 10 })) {
+    throw new ApiError(ERROR_CODES.OPERATION_FAILED, 'Too many requests', 429);
+  }
 
+  const ipAddress = request.headers.get('x-forwarded-for') || 'unknown';
+  const userAgent = request.headers.get('user-agent') || 'unknown';
 
-async function handlePost(
-  _request: NextRequest,
-  params: { id: string },
-  auth: RouteAuthContext
-) {
   try {
-    const userId = auth.userId!;
-
     const companyService = getApiCompanyService();
-    const result = await companyService.checkDomainVerification(params.id, userId);
+    const result = await companyService.checkDomainVerification(params.id, auth.userId!);
 
-    if (result.verified) {
-      return NextResponse.json({ verified: true, message: result.message });
+    await logUserAction({
+      userId: auth.userId,
+      action: 'DOMAIN_VERIFICATION_CHECK',
+      status: result.verified ? 'SUCCESS' : 'FAILURE',
+      ipAddress,
+      userAgent,
+      targetResourceType: 'company',
+      targetResourceId: params.id,
+    });
+
+    return createSuccessResponse({ verified: result.verified, message: result.message }, result.verified ? 200 : 400);
+  } catch (error: any) {
+    await logUserAction({
+      userId: auth.userId,
+      action: 'DOMAIN_VERIFICATION_CHECK_FAILED',
+      status: 'FAILURE',
+      ipAddress,
+      userAgent,
+      targetResourceType: 'company',
+      targetResourceId: params.id,
+      details: { error: error?.message }
+    });
+
+    const message = error?.message || 'Domain verification failed';
+    if (/not found/i.test(message)) {
+      throw new ApiError(ERROR_CODES.NOT_FOUND, message, 404);
     }
-
-    return NextResponse.json(
-      { verified: false, message: result.message },
-      { status: 400 },
-    );
-  } catch (error) {
-    console.error("Unexpected error in domain verification:", error);
-    return NextResponse.json(
-      { error: "An internal server error occurred." },
-      { status: 500 },
-    );
+    if (/initiated/i.test(message)) {
+      throw new ApiError(ERROR_CODES.INVALID_REQUEST, message, 400);
+    }
+    throw new ApiError(ERROR_CODES.INTERNAL_ERROR, message, 500);
   }
 }
 
 export const POST = (req: NextRequest, ctx: { params: { id: string } }) =>
-  createApiHandler(
-    z.object({}),
-    (r, a) => handlePost(r, ctx.params, a),
-    { requireAuth: true }
-  )(req);
+  createApiHandler(z.object({}), (r, a) => handlePost(r, ctx.params, a), { requireAuth: true })(req);

--- a/app/api/company/domains/[id]/verify-initiate/__tests__/route.test.ts
+++ b/app/api/company/domains/[id]/verify-initiate/__tests__/route.test.ts
@@ -58,11 +58,11 @@ describe('Domain Verification Initiate API', () => {
     
     const response = await POST(request, { params: { id: mockDomainId } });
     expect(response.status).toBe(200);
-    
+
     const data = await response.json();
-    expect(data).toHaveProperty('verificationToken');
-    expect(data.domain).toBe(mockDomain);
-    expect(data.message).toContain('verification initiated');
+    expect(data.data.verificationToken).toBeDefined();
+    expect(data.data.domain).toBe(mockDomain);
+    expect(data.data.message).toContain('verification initiated');
     
     expect(service.initiateDomainVerification).toHaveBeenCalledWith(
       mockDomainId,
@@ -96,7 +96,7 @@ describe('Domain Verification Initiate API', () => {
     expect(response.status).toBe(404);
     
     const data = await response.json();
-    expect(data.error).toContain('not found');
+    expect(data.error.message).toContain('not found');
   });
   
   test('returns 403 if user does not have permission to verify the domain', async () => {
@@ -110,7 +110,7 @@ describe('Domain Verification Initiate API', () => {
     expect(response.status).toBe(403);
     
     const data = await response.json();
-    expect(data.error).toContain('permission');
+    expect(data.error.message).toContain('permission');
   });
   
   test('returns 500 when database update fails', async () => {
@@ -134,11 +134,11 @@ describe('Domain Verification Initiate API', () => {
     
     const response = await POST(request, { params: { id: mockDomainId } });
     const data = await response.json();
-    
+
     // Token should be a string and match expected pattern
-    expect(typeof data.verificationToken).toBe('string');
-    expect(data.verificationToken.length).toBeGreaterThan(10);
-    expect(data.verificationToken).toMatch(/^verificat/);
+    expect(typeof data.data.verificationToken).toBe('string');
+    expect(data.data.verificationToken.length).toBeGreaterThan(10);
+    expect(data.data.verificationToken).toMatch(/^verificat/);
     
     expect(service.initiateDomainVerification).toHaveBeenCalled();
   });

--- a/app/api/company/verify-domain/check/__tests__/route.test.ts
+++ b/app/api/company/verify-domain/check/__tests__/route.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST } from '../route';
+import { getApiCompanyService } from '@/services/company/factory';
+
+vi.mock('@/middleware/rate-limit', () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(false)
+}));
+vi.mock('@/services/company/factory', () => ({
+  getApiCompanyService: vi.fn()
+}));
+
+describe('POST /api/company/verify-domain/check', () => {
+  const service: any = { checkProfileDomainVerification: vi.fn() };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getApiCompanyService).mockReturnValue(service);
+    service.checkProfileDomainVerification.mockResolvedValue({ verified: true, message: 'ok' });
+  });
+
+  test('returns status on success', async () => {
+    const req = new NextRequest('http://localhost/api/company/verify-domain/check');
+    const res = await POST(req as any, {} as any);
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.data.verified).toBe(true);
+    expect(service.checkProfileDomainVerification).toHaveBeenCalled();
+  });
+
+  test('returns 400 when not verified', async () => {
+    service.checkProfileDomainVerification.mockResolvedValueOnce({ verified: false, message: 'no' });
+    const req = new NextRequest('http://localhost/api/company/verify-domain/check');
+    const res = await POST(req as any, {} as any);
+    const json = await res.json();
+    expect(res.status).toBe(400);
+    expect(json.data.verified).toBe(false);
+  });
+
+  test('returns 500 on error', async () => {
+    service.checkProfileDomainVerification.mockRejectedValueOnce(new Error('fail'));
+    const req = new NextRequest('http://localhost/api/company/verify-domain/check');
+    const res = await POST(req as any, {} as any);
+    const json = await res.json();
+    expect(res.status).toBe(500);
+    expect(json.error).toBeDefined();
+  });
+});

--- a/app/api/company/verify-domain/initiate/__tests__/route.test.ts
+++ b/app/api/company/verify-domain/initiate/__tests__/route.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST } from '../route';
+import { getApiCompanyService } from '@/services/company/factory';
+
+vi.mock('@/middleware/rate-limit', () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(false)
+}));
+vi.mock('@/services/company/factory', () => ({
+  getApiCompanyService: vi.fn()
+}));
+
+describe('POST /api/company/verify-domain/initiate', () => {
+  const service: any = { initiateProfileDomainVerification: vi.fn() };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getApiCompanyService).mockReturnValue(service);
+    service.initiateProfileDomainVerification.mockResolvedValue({ domainName: 'example.com', verificationToken: 'token' });
+  });
+
+  test('returns token on success', async () => {
+    const req = new NextRequest('http://localhost/api/company/verify-domain/initiate');
+    const res = await POST(req as any, {} as any);
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.data.verificationToken).toBe('token');
+    expect(service.initiateProfileDomainVerification).toHaveBeenCalled();
+  });
+
+  test('returns 500 on error', async () => {
+    service.initiateProfileDomainVerification.mockRejectedValueOnce(new Error('fail'));
+    const req = new NextRequest('http://localhost/api/company/verify-domain/initiate');
+    const res = await POST(req as any, {} as any);
+    const json = await res.json();
+    expect(res.status).toBe(500);
+    expect(json.error).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- standardize domain verification routes
- add rate limiting and audit logging
- update verification route tests

## Testing
- `vitest run`


------
https://chatgpt.com/codex/tasks/task_b_6842b52f02d88331bc1c152116246cf3