### PR TITLE
Implement permissions API routes

### DIFF
--- a/app/api/permissions/[id]/__tests__/route.test.ts
+++ b/app/api/permissions/[id]/__tests__/route.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET, PUT } from '../route';
+import { configureServices, resetServiceContainer } from '@/lib/config/service-container';
+import type { AuthService } from '@/core/auth/interfaces';
+import type { PermissionService } from '@/core/permission/interfaces';
+import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
+
+const mockPermission: Partial<PermissionService> = { getAllPermissions: vi.fn() };
+const mockAuth: Partial<AuthService> = { getCurrentUser: vi.fn().mockResolvedValue({ id: 'u1' }) };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  resetServiceContainer();
+  configureServices({ permissionService: mockPermission as PermissionService, authService: mockAuth as AuthService });
+});
+
+describe('permission id API', () => {
+  it('returns details for valid permission', async () => {
+    const res = await GET(createAuthenticatedRequest('GET', 'http://test/api/permissions/VIEW_PROJECTS'));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.data.id).toBe('VIEW_PROJECTS');
+  });
+
+  it('PUT not allowed', async () => {
+    const res = await PUT(createAuthenticatedRequest('PUT', 'http://test/api/permissions/VIEW_PROJECTS'));
+    expect(res.status).toBe(405);
+  });
+});

--- a/app/api/permissions/categories/__tests__/route.test.ts
+++ b/app/api/permissions/categories/__tests__/route.test.ts
@@ -1,30 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { GET, POST } from '../route';
+import { GET } from '../route';
 import { configureServices, resetServiceContainer } from '@/lib/config/service-container';
 import type { PermissionService } from '@/core/permission/interfaces';
 import type { AuthService } from '@/core/auth/interfaces';
 import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
 
-const mockPermissionService: Partial<PermissionService> = { getAllPermissions: vi.fn() };
+const mockPermission: Partial<PermissionService> = { getAllPermissions: vi.fn() };
 const mockAuth: Partial<AuthService> = { getCurrentUser: vi.fn().mockResolvedValue({ id: 'u1' }) };
 
 beforeEach(() => {
   vi.resetAllMocks();
   resetServiceContainer();
-  configureServices({ permissionService: mockPermissionService as PermissionService, authService: mockAuth as AuthService });
+  configureServices({ permissionService: mockPermission as PermissionService, authService: mockAuth as AuthService });
 });
 
-describe('permissions root API', () => {
-  it('GET returns permissions', async () => {
-    mockPermissionService.getAllPermissions!.mockResolvedValue(['READ']);
+describe('permission categories API', () => {
+  it('returns category list', async () => {
     const res = await GET(createAuthenticatedRequest('GET', 'http://test'));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.data.permissions).toEqual(['READ']);
-  });
-
-  it('POST is not allowed', async () => {
-    const res = await POST(createAuthenticatedRequest('POST', 'http://test'));
-    expect(res.status).toBe(405);
+    expect(Array.isArray(body.data.categories)).toBe(true);
+    expect(body.data.categories.length).toBeGreaterThan(0);
   });
 });

--- a/app/api/permissions/categories/route.ts
+++ b/app/api/permissions/categories/route.ts
@@ -1,9 +1,16 @@
-// GET /api/permissions/categories - List all permission categories
-
-import { createProtectedHandler } from '@/middleware/permissions';
+import { NextRequest } from 'next/server';
+import { createApiHandler, emptySchema } from '@/lib/api/route-helpers';
+import { createSuccessResponse } from '@/lib/api/common';
 import { PermissionValues } from '@/core/permission/models';
+import { listPermissionCategories } from '@/lib/rbac/permission-categories';
 
-export const GET = createProtectedHandler(
-  async () => new Response('Not implemented', { status: 501 }),
-  PermissionValues.MANAGE_ROLES,
-);
+async function handleGet(_req: NextRequest) {
+  const categories = listPermissionCategories();
+  return createSuccessResponse({ categories });
+}
+
+export const GET = createApiHandler(emptySchema, handleGet, {
+  requireAuth: true,
+  requiredPermissions: [PermissionValues.MANAGE_ROLES],
+  rateLimit: { windowMs: 15 * 60 * 1000, max: 50 },
+});

--- a/app/api/permissions/route.ts
+++ b/app/api/permissions/route.ts
@@ -1,12 +1,12 @@
-// GET /api/permissions - List all permissions with optional filtering
-// POST /api/permissions - Create a new permission (admin only)
+// GET /api/permissions - List all permissions
+// POST /api/permissions - Not supported (permissions are static)
 
 import { type NextRequest, NextResponse } from 'next/server';
 import { createApiHandler, emptySchema } from '@/lib/api/route-helpers';
 import { createSuccessResponse } from '@/lib/api/common';
 import { PermissionValues } from '@/core/permission/models';
 
-async function handleGet(_req: NextRequest, _authContext: any, _data: any, services: any) {
+async function handleGet(_req: NextRequest, _auth: any, _data: any, services: any) {
   const permissions = await services.permission.getAllPermissions();
   return createSuccessResponse({ permissions });
 }
@@ -14,15 +14,12 @@ async function handleGet(_req: NextRequest, _authContext: any, _data: any, servi
 export const GET = createApiHandler(emptySchema, handleGet, {
   requireAuth: true,
   requiredPermissions: [PermissionValues.MANAGE_ROLES],
+  rateLimit: { windowMs: 15 * 60 * 1000, max: 50 },
 });
 
-export const POST = createApiHandler(
-  emptySchema,
-  async (_req: NextRequest, _authContext: any, _data: any, _services: any) => {
-    return NextResponse.json({ error: 'Not implemented' }, { status: 501 });
-  },
-  {
-    requireAuth: true,
-    requiredPermissions: [PermissionValues.MANAGE_ROLES],
-  }
-);
+export const POST = createApiHandler(emptySchema, async () => {
+  return NextResponse.json({ error: 'Method Not Allowed' }, { status: 405 });
+}, {
+  requireAuth: true,
+  requiredPermissions: [PermissionValues.MANAGE_ROLES],
+});

--- a/src/lib/rbac/permission-categories.ts
+++ b/src/lib/rbac/permission-categories.ts
@@ -1,0 +1,44 @@
+export const PermissionCategory = {
+  USER_MANAGEMENT: 'User Management',
+  ROLE_MANAGEMENT: 'Role Management',
+  ANALYTICS: 'Analytics & Data',
+  SYSTEM_SETTINGS: 'System Settings',
+  TEAM_MANAGEMENT: 'Team Management',
+  BILLING: 'Billing & Subscription',
+  ADMIN_DASHBOARD: 'Admin Dashboard',
+  PROJECT_MANAGEMENT: 'Project Management',
+} as const;
+
+export type PermissionCategory = typeof PermissionCategory[keyof typeof PermissionCategory];
+
+import { PermissionValues, Permission } from '@/core/permission/models';
+
+export const permissionCategoryMap: Record<Permission, PermissionCategory> = {
+  [PermissionValues.ADMIN_ACCESS]: PermissionCategory.USER_MANAGEMENT,
+  [PermissionValues.VIEW_ALL_USER_ACTION_LOGS]: PermissionCategory.USER_MANAGEMENT,
+  [PermissionValues.EDIT_USER_PROFILES]: PermissionCategory.USER_MANAGEMENT,
+  [PermissionValues.DELETE_USER_ACCOUNTS]: PermissionCategory.USER_MANAGEMENT,
+  [PermissionValues.MANAGE_ROLES]: PermissionCategory.ROLE_MANAGEMENT,
+  [PermissionValues.VIEW_ANALYTICS]: PermissionCategory.ANALYTICS,
+  [PermissionValues.EXPORT_DATA]: PermissionCategory.ANALYTICS,
+  [PermissionValues.MANAGE_SETTINGS]: PermissionCategory.SYSTEM_SETTINGS,
+  [PermissionValues.MANAGE_API_KEYS]: PermissionCategory.SYSTEM_SETTINGS,
+  [PermissionValues.INVITE_USERS]: PermissionCategory.TEAM_MANAGEMENT,
+  [PermissionValues.MANAGE_TEAMS]: PermissionCategory.TEAM_MANAGEMENT,
+  [PermissionValues.MANAGE_BILLING]: PermissionCategory.BILLING,
+  [PermissionValues.MANAGE_SUBSCRIPTIONS]: PermissionCategory.BILLING,
+  [PermissionValues.ACCESS_ADMIN_DASHBOARD]: PermissionCategory.ADMIN_DASHBOARD,
+  [PermissionValues.VIEW_ADMIN_DASHBOARD]: PermissionCategory.ADMIN_DASHBOARD,
+  [PermissionValues.INVITE_TEAM_MEMBER]: PermissionCategory.TEAM_MANAGEMENT,
+  [PermissionValues.REMOVE_TEAM_MEMBER]: PermissionCategory.TEAM_MANAGEMENT,
+  [PermissionValues.UPDATE_MEMBER_ROLE]: PermissionCategory.TEAM_MANAGEMENT,
+  [PermissionValues.VIEW_TEAM_MEMBERS]: PermissionCategory.TEAM_MANAGEMENT,
+  [PermissionValues.CREATE_PROJECT]: PermissionCategory.PROJECT_MANAGEMENT,
+  [PermissionValues.DELETE_PROJECT]: PermissionCategory.PROJECT_MANAGEMENT,
+  [PermissionValues.EDIT_PROJECT]: PermissionCategory.PROJECT_MANAGEMENT,
+  [PermissionValues.VIEW_PROJECTS]: PermissionCategory.PROJECT_MANAGEMENT,
+};
+
+export function listPermissionCategories(): PermissionCategory[] {
+  return Array.from(new Set(Object.values(permissionCategoryMap)));
+}


### PR DESCRIPTION
## Summary
- fully implement permissions routes
- add new permission categories helper
- provide tests for new endpoints

## Testing
- `vitest run --coverage` *(fails: `npx: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6842b4b19a9883319124de33eaca20c5