### PR TITLE
Add validateAuthToken unit tests

### DIFF
--- a/src/middleware/__tests__/validate-auth-token.test.ts
+++ b/src/middleware/__tests__/validate-auth-token.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
+import { validateAuthToken } from '../validate-auth-token';
+import { getSessionFromToken } from '@/services/auth/factory';
+import { extractAuthToken } from '@/lib/auth/utils';
+import { AUTH_ERROR_MAP } from '../auth-errors';
+
+vi.mock('@/services/auth/factory');
+vi.mock('@/lib/auth/utils');
+
+const reqUrl = 'http://localhost';
+
+const mockUser = { id: 'user-1' } as any;
+
+describe('validateAuthToken', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns success for valid token', async () => {
+    const req = createAuthenticatedRequest('GET', reqUrl, undefined, 'valid-token');
+    vi.mocked(extractAuthToken).mockReturnValue('valid-token');
+    vi.mocked(getSessionFromToken).mockResolvedValue(mockUser);
+
+    const result = await validateAuthToken(req);
+
+    expect(getSessionFromToken).toHaveBeenCalledWith('valid-token');
+    expect(result).toEqual({ success: true, user: mockUser });
+  });
+
+  it('returns missing token error when no token present', async () => {
+    const req = createAuthenticatedRequest('GET', reqUrl, undefined, null);
+    vi.mocked(extractAuthToken).mockReturnValue(null);
+
+    const result = await validateAuthToken(req);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe(AUTH_ERROR_MAP.MISSING_TOKEN.code);
+  });
+
+  it('returns invalid token error when session not found', async () => {
+    const req = createAuthenticatedRequest('GET', reqUrl, undefined, 'bad-token');
+    vi.mocked(extractAuthToken).mockReturnValue('bad-token');
+    vi.mocked(getSessionFromToken).mockResolvedValue(null);
+
+    const result = await validateAuthToken(req);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe(AUTH_ERROR_MAP.INVALID_TOKEN.code);
+  });
+
+  it('wraps unexpected errors from session lookup', async () => {
+    const req = createAuthenticatedRequest('GET', reqUrl, undefined, 'token');
+    vi.mocked(extractAuthToken).mockReturnValue('token');
+    vi.mocked(getSessionFromToken).mockRejectedValue(new Error('boom'));
+
+    const result = await validateAuthToken(req);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('SERVER_GENERAL_001');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for validateAuthToken middleware

## Testing
- `npx vitest run --coverage src/middleware/__tests__/validate-auth-token.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_6842e073987c8331b3ec8e03b66db04a