### PR TITLE
Implement basic storage API

### DIFF
--- a/app/api/storage/files/__tests__/route.test.ts
+++ b/app/api/storage/files/__tests__/route.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET, DELETE } from '../route';
+import { getStorageService } from '@/services/storage';
+import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
+
+vi.mock('@/services/storage', () => ({ getStorageService: vi.fn() }));
+vi.mock('@/lib/auth/utils', () => ({
+  getUserFromRequest: vi.fn().mockResolvedValue({ id: 'u1' })
+}));
+
+const service = {
+  listFiles: vi.fn().mockResolvedValue(['a']),
+  deleteFile: vi.fn().mockResolvedValue({ success: true }),
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (getStorageService as unknown as vi.Mock).mockReturnValue(service);
+});
+
+describe('files route', () => {
+  it('lists files', async () => {
+    const req = createAuthenticatedRequest('GET', 'http://test');
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.files[0]).toBe('a');
+  });
+
+  it('deletes file', async () => {
+    const req = createAuthenticatedRequest('DELETE', 'http://test');
+    (req as any).json = async () => ({ filePath: 'p' });
+    const res = await DELETE(req);
+    expect(res.status).toBe(200);
+    expect(service.deleteFile).toHaveBeenCalledWith('files', 'p');
+  });
+});

--- a/app/api/storage/files/route.ts
+++ b/app/api/storage/files/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getUserFromRequest } from '@/lib/auth/utils';
+import { getStorageService } from '@/services/storage';
+
+export async function GET(req: NextRequest) {
+  const user = await getUserFromRequest(req);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const storage = getStorageService();
+  const files = await storage.listFiles('files', `${user.id}/`);
+  return NextResponse.json({ files });
+}
+
+export async function DELETE(req: NextRequest) {
+  const user = await getUserFromRequest(req);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { filePath } = await req.json();
+  const storage = getStorageService();
+  await storage.deleteFile('files', filePath);
+  return NextResponse.json({ success: true });
+}

--- a/app/api/storage/upload/__tests__/route.test.ts
+++ b/app/api/storage/upload/__tests__/route.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+import { getStorageService } from '@/services/storage';
+import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
+
+vi.mock('@/services/storage', () => ({ getStorageService: vi.fn() }));
+vi.mock('@/lib/auth/utils', () => ({
+  getUserFromRequest: vi.fn().mockResolvedValue({ id: 'u1' })
+}));
+
+const service = {
+  uploadFile: vi.fn().mockResolvedValue({ success: true, path: 'p' }),
+  getFileUrl: vi.fn().mockResolvedValue('url'),
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (getStorageService as unknown as vi.Mock).mockReturnValue(service);
+});
+
+describe('upload route', () => {
+  it('returns 400 when no file provided', async () => {
+    const req = createAuthenticatedRequest('POST', 'http://test');
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('uploads file and returns url', async () => {
+    const file = new File(['hello'], 'test.txt', { type: 'text/plain' });
+    const fd = new FormData();
+    fd.set('file', file);
+    const req = createAuthenticatedRequest('POST', 'http://test');
+    (req as any).formData = async () => fd;
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.url).toBe('url');
+    expect(service.uploadFile).toHaveBeenCalled();
+  });
+});

--- a/app/api/storage/upload/route.ts
+++ b/app/api/storage/upload/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getUserFromRequest } from '@/lib/auth/utils';
+import { getStorageService } from '@/services/storage';
+
+export async function POST(req: NextRequest) {
+  const user = await getUserFromRequest(req);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const formData = await req.formData();
+    const uploaded = formData.get('file');
+    if (!(uploaded instanceof File)) {
+      return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+    }
+
+    const buffer = await uploaded.arrayBuffer();
+    const storage = getStorageService();
+    const path = `${user.id}/${Date.now()}-${uploaded.name}`;
+    const result = await storage.uploadFile('files', path, buffer, {
+      contentType: uploaded.type,
+    });
+
+    if (!result.success || !result.path) {
+      return NextResponse.json({ error: result.error || 'Upload failed' }, { status: 500 });
+    }
+
+    const url = await storage.getFileUrl('files', result.path);
+
+    return NextResponse.json({ success: true, path: result.path, url });
+  } catch (err) {
+    console.error('Upload error', err);
+    return NextResponse.json({ error: 'Upload failed' }, { status: 500 });
+  }
+}

--- a/src/adapters/storage/supabase/SupabaseStorageAdapter.ts
+++ b/src/adapters/storage/supabase/SupabaseStorageAdapter.ts
@@ -70,6 +70,20 @@ export class SupabaseStorageAdapter implements StorageAdapter {
       return '';
     }
   }
+
+  async list(prefix = ''): Promise<string[]> {
+    try {
+      const { data, error } = await this.supabase.storage
+        .from(this.bucket)
+        .list(prefix);
+      if (error || !data) {
+        return [];
+      }
+      return data.map((f) => `${prefix}${prefix && !prefix.endsWith('/') ? '/' : ''}${f.name}`);
+    } catch {
+      return [];
+    }
+  }
 }
 
 export default SupabaseStorageAdapter;

--- a/src/core/storage/interfaces.ts
+++ b/src/core/storage/interfaces.ts
@@ -69,4 +69,11 @@ export interface StorageAdapter {
    * @returns Publicly accessible URL
    */
   getPublicUrl(path: string): string;
+
+  /**
+   * List files within a given prefix/path.
+   *
+   * @param prefix Optional prefix to filter files by
+   */
+  list(prefix?: string): Promise<string[]>;
 }

--- a/src/core/storage/services.ts
+++ b/src/core/storage/services.ts
@@ -47,4 +47,9 @@ export interface FileStorageService {
    * @returns Public URL string or `null` when not available
    */
   getFileUrl(bucketName: string, filePath: string): Promise<string | null>;
+
+  /**
+   * List files within a bucket under an optional prefix.
+   */
+  listFiles(bucketName: string, prefix?: string): Promise<string[]>;
 }

--- a/src/services/storage/DefaultFileStorageService.ts
+++ b/src/services/storage/DefaultFileStorageService.ts
@@ -61,6 +61,20 @@ export class DefaultFileStorageService implements FileStorageService {
       return null;
     }
   }
+
+  /**
+   * List files from the configured storage provider.
+   */
+  async listFiles(
+    _bucketName: string,
+    prefix = ''
+  ): Promise<string[]> {
+    try {
+      return await this.storageAdapter.list(prefix);
+    } catch {
+      return [];
+    }
+  }
 }
 
 export default DefaultFileStorageService;

--- a/src/services/storage/__tests__/DefaultFileStorageService.test.ts
+++ b/src/services/storage/__tests__/DefaultFileStorageService.test.ts
@@ -7,6 +7,7 @@ function createAdapterMock(): StorageAdapter {
     upload: vi.fn(),
     delete: vi.fn(),
     getPublicUrl: vi.fn(),
+    list: vi.fn(),
   };
 }
 
@@ -54,5 +55,14 @@ describe('DefaultFileStorageService', () => {
     const res = await service.getFileUrl('b', 'p');
     expect(adapter.getPublicUrl).toHaveBeenCalledWith('p');
     expect(res).toBe('url');
+  });
+
+  it('delegates listFiles to adapter', async () => {
+    const adapter = createAdapterMock();
+    (adapter.list as any).mockResolvedValue(['f1']);
+    const service = new DefaultFileStorageService(adapter);
+    const res = await service.listFiles('b', 'prefix');
+    expect(adapter.list).toHaveBeenCalledWith('prefix');
+    expect(res).toEqual(['f1']);
   });
 });

--- a/src/services/storage/__tests__/factory.test.ts
+++ b/src/services/storage/__tests__/factory.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getStorageService } from '../factory';
+import { SupabaseStorageAdapter } from '@/adapters/storage/supabase/SupabaseStorageAdapter';
+
+vi.mock('@/adapters/storage/supabase/SupabaseStorageAdapter');
+
+const MockAdapter = SupabaseStorageAdapter as unknown as vi.Mock;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getStorageService', () => {
+  it('creates and caches service instance', () => {
+    const service1 = getStorageService({ bucket: 'b', reset: true });
+    const service2 = getStorageService();
+    expect(MockAdapter).toHaveBeenCalledWith('b');
+    expect(service1).toBe(service2);
+  });
+});

--- a/src/services/storage/factory.ts
+++ b/src/services/storage/factory.ts
@@ -1,0 +1,24 @@
+import type { FileStorageService } from '@/core/storage/services';
+import { DefaultFileStorageService } from './DefaultFileStorageService';
+import { SupabaseStorageAdapter } from '@/adapters/storage/supabase/SupabaseStorageAdapter';
+
+export interface StorageServiceOptions {
+  bucket?: string;
+  reset?: boolean;
+}
+
+let cachedService: FileStorageService | null = null;
+
+export function getStorageService(options: StorageServiceOptions = {}): FileStorageService {
+  if (options.reset) {
+    cachedService = null;
+  }
+
+  if (!cachedService) {
+    const bucket = options.bucket || 'files';
+    const adapter = new SupabaseStorageAdapter(bucket);
+    cachedService = new DefaultFileStorageService(adapter);
+  }
+
+  return cachedService;
+}

--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -1,0 +1,2 @@
+export { DefaultFileStorageService } from './DefaultFileStorageService';
+export { getStorageService } from './factory';


### PR DESCRIPTION
## Summary
- extend storage interfaces with `list` method
- implement list support in `SupabaseStorageAdapter`
- expose a storage service factory
- add upload and file management API routes
- cover storage service logic with tests

## Testing
- `npx vitest run --coverage` *(fails: Tests failed)*

------
https://chatgpt.com/codex/tasks/task_b_6842e00b35a08331b9a62f3d0d346da0