### PR TITLE
Add organization members API endpoints

### DIFF
--- a/app/api/organizations/[orgId]/__tests__/route.test.ts
+++ b/app/api/organizations/[orgId]/__tests__/route.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET, PUT, DELETE } from '../route';
+import { configureServices, resetServiceContainer } from '@/lib/config/service-container';
+import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
+
+
+describe('[orgId] API', () => {
+  const service = {
+    getOrganization: vi.fn(async () => ({ id: 'o1' })),
+    updateOrganization: vi.fn(async () => ({ success: true, organization: { id: 'o1' } })),
+    deleteOrganization: vi.fn(async () => ({ success: true }))
+  } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetServiceContainer();
+    configureServices({
+      organizationService: service as any,
+      authService: { getCurrentUser: vi.fn().mockResolvedValue({ id: 'u1' }) } as any,
+      userService: {} as any,
+      permissionService: {} as any,
+      teamService: {} as any,
+      ssoService: {} as any,
+      featureFlags: { permissions: false, teams: false, sso: false },
+    });
+  });
+
+  it('GET returns organization', async () => {
+    const res = await GET(createAuthenticatedRequest('GET', 'http://test'), { params: { orgId: 'o1' } });
+    expect(res.status).toBe(200);
+    expect(service.getOrganization).toHaveBeenCalledWith('o1');
+  });
+
+  it('PUT updates organization', async () => {
+    const req = createAuthenticatedRequest('PUT', 'http://test', { name: 'New' });
+    (req as any).json = async () => ({ name: 'New' });
+    const res = await PUT(req, { params: { orgId: 'o1' } });
+    expect(res.status).toBe(200);
+    expect(service.updateOrganization).toHaveBeenCalled();
+  });
+
+  it('DELETE removes organization', async () => {
+    const res = await DELETE(createAuthenticatedRequest('DELETE', 'http://test'), { params: { orgId: 'o1' } });
+    expect(res.status).toBe(200);
+    expect(service.deleteOrganization).toHaveBeenCalledWith('o1');
+  });
+});

--- a/app/api/organizations/[orgId]/members/__tests__/route.test.ts
+++ b/app/api/organizations/[orgId]/members/__tests__/route.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET, POST } from '../route';
+import { configureServices, resetServiceContainer } from '@/lib/config/service-container';
+import { createAuthenticatedRequest } from '@/tests/utils/request-helpers';
+
+
+describe('organization members API', () => {
+  const service = {
+    getOrganizationMembers: vi.fn(async () => []),
+    addOrganizationMember: vi.fn(async () => ({ success: true, member: { organizationId: 'o1', userId: 'u1', role: 'member' } }))
+  } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetServiceContainer();
+    configureServices({
+      organizationService: service as any,
+      authService: { getCurrentUser: vi.fn().mockResolvedValue({ id: 'u1' }) } as any,
+      userService: {} as any,
+      permissionService: {} as any,
+      teamService: {} as any,
+      ssoService: {} as any,
+      featureFlags: { permissions: false, teams: false, sso: false },
+    });
+  });
+
+  it('GET returns members', async () => {
+    const res = await GET(createAuthenticatedRequest('GET', 'http://test'), { params: { orgId: 'o1' } });
+    expect(res.status).toBe(200);
+    expect(service.getOrganizationMembers).toHaveBeenCalledWith('o1');
+  });
+
+  it('POST adds member', async () => {
+    const req = createAuthenticatedRequest('POST', 'http://test', { userId: 'u1', role: 'member' });
+    (req as any).json = async () => ({ userId: 'u1', role: 'member' });
+    const res = await POST(req, { params: { orgId: 'o1' } });
+    expect(res.status).toBe(201);
+    expect(service.addOrganizationMember).toHaveBeenCalledWith('o1', 'u1', 'member');
+  });
+});

--- a/app/api/organizations/[orgId]/members/route.ts
+++ b/app/api/organizations/[orgId]/members/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { createApiHandler, emptySchema } from '@/lib/api/route-helpers';
+import { createSuccessResponse, ApiError, ERROR_CODES } from '@/lib/api/common';
+
+const AddMemberSchema = z.object({
+  userId: z.string().min(1),
+  role: z.string().min(1)
+});
+
+const ParamSchema = z.object({ orgId: z.string().min(1) });
+
+async function handleGet(
+  _req: NextRequest,
+  _auth: any,
+  _data: unknown,
+  services: any,
+  orgId: string
+) {
+  const members = await services.organization.getOrganizationMembers(orgId);
+  return createSuccessResponse({ members });
+}
+
+async function handlePost(
+  _req: NextRequest,
+  _auth: any,
+  data: z.infer<typeof AddMemberSchema>,
+  services: any,
+  orgId: string
+) {
+  const result = await services.organization.addOrganizationMember(orgId, data.userId, data.role);
+  if (!result.success || !result.member) {
+    throw new ApiError(ERROR_CODES.INVALID_REQUEST, result.error || 'Failed to add member', 400);
+  }
+  return createSuccessResponse({ member: result.member }, 201);
+}
+
+export const GET = (req: NextRequest, ctx: { params: { orgId: string } }) => {
+  const parsed = ParamSchema.safeParse(ctx.params);
+  if (!parsed.success) {
+    return NextResponse.json(
+      new ApiError(ERROR_CODES.INVALID_REQUEST, parsed.error.message, 400).toResponse(),
+      { status: 400 }
+    );
+  }
+  return createApiHandler(emptySchema, (r, a, d, s) => handleGet(r, a, d, s, parsed.data.orgId), { requireAuth: true })(req);
+};
+
+export const POST = (req: NextRequest, ctx: { params: { orgId: string } }) => {
+  const parsed = ParamSchema.safeParse(ctx.params);
+  if (!parsed.success) {
+    return NextResponse.json(
+      new ApiError(ERROR_CODES.INVALID_REQUEST, parsed.error.message, 400).toResponse(),
+      { status: 400 }
+    );
+  }
+  return createApiHandler(AddMemberSchema, (r, a, d, s) => handlePost(r, a, d, s, parsed.data.orgId), { requireAuth: true })(req);
+};

--- a/app/api/organizations/[orgId]/route.ts
+++ b/app/api/organizations/[orgId]/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { createApiHandler, emptySchema } from '@/lib/api/route-helpers';
+import { createSuccessResponse, ApiError, ERROR_CODES } from '@/lib/api/common';
+
+const UpdateOrgSchema = z.object({
+  name: z.string().optional(),
+  description: z.string().optional(),
+});
+
+const ParamSchema = z.object({ orgId: z.string().min(1) });
+
+async function handleGet(
+  _req: NextRequest,
+  _auth: any,
+  _data: unknown,
+  services: any,
+  orgId: string
+) {
+  const org = await services.organization.getOrganization(orgId);
+  if (!org) {
+    throw new ApiError(ERROR_CODES.NOT_FOUND, 'Organization not found', 404);
+  }
+  return createSuccessResponse({ organization: org });
+}
+
+async function handlePut(
+  _req: NextRequest,
+  _auth: any,
+  data: z.infer<typeof UpdateOrgSchema>,
+  services: any,
+  orgId: string
+) {
+  const result = await services.organization.updateOrganization(orgId, data);
+  if (!result.success || !result.organization) {
+    throw new ApiError(
+      ERROR_CODES.INVALID_REQUEST,
+      result.error || 'Failed to update organization',
+      400
+    );
+  }
+  return createSuccessResponse({ organization: result.organization });
+}
+
+async function handleDelete(
+  _req: NextRequest,
+  _auth: any,
+  _data: unknown,
+  services: any,
+  orgId: string
+) {
+  const result = await services.organization.deleteOrganization(orgId);
+  if (!result.success) {
+    throw new ApiError(
+      ERROR_CODES.INVALID_REQUEST,
+      result.error || 'Failed to delete organization',
+      400
+    );
+  }
+  return createSuccessResponse({ success: true });
+}
+
+export const GET = (req: NextRequest, ctx: { params: { orgId: string } }) => {
+  const parsed = ParamSchema.safeParse(ctx.params);
+  if (!parsed.success) {
+    return NextResponse.json(
+      new ApiError(ERROR_CODES.INVALID_REQUEST, parsed.error.message, 400).toResponse(),
+      { status: 400 }
+    );
+  }
+  return createApiHandler(emptySchema, (r, a, d, s) => handleGet(r, a, d, s, parsed.data.orgId), { requireAuth: true })(req);
+};
+
+export const PUT = (req: NextRequest, ctx: { params: { orgId: string } }) => {
+  const parsed = ParamSchema.safeParse(ctx.params);
+  if (!parsed.success) {
+    return NextResponse.json(
+      new ApiError(ERROR_CODES.INVALID_REQUEST, parsed.error.message, 400).toResponse(),
+      { status: 400 }
+    );
+  }
+  return createApiHandler(UpdateOrgSchema, (r, a, d, s) => handlePut(r, a, d, s, parsed.data.orgId), { requireAuth: true })(req);
+};
+
+export const DELETE = (req: NextRequest, ctx: { params: { orgId: string } }) => {
+  const parsed = ParamSchema.safeParse(ctx.params);
+  if (!parsed.success) {
+    return NextResponse.json(
+      new ApiError(ERROR_CODES.INVALID_REQUEST, parsed.error.message, 400).toResponse(),
+      { status: 400 }
+    );
+  }
+  return createApiHandler(emptySchema, (r, a, d, s) => handleDelete(r, a, d, s, parsed.data.orgId), { requireAuth: true })(req);
+};

--- a/src/adapters/organization/default-organization-adapter.ts
+++ b/src/adapters/organization/default-organization-adapter.ts
@@ -3,7 +3,9 @@ import type {
   Organization,
   OrganizationCreatePayload,
   OrganizationUpdatePayload,
-  OrganizationResult
+  OrganizationResult,
+  OrganizationMember,
+  OrganizationMemberResult
 } from '@/core/organization/models';
 
 export class DefaultOrganizationAdapter implements IOrganizationDataProvider {
@@ -30,6 +32,14 @@ export class DefaultOrganizationAdapter implements IOrganizationDataProvider {
   }
 
   async deleteOrganization(_id: string): Promise<{ success: boolean; error?: string }> {
+    return { success: false, error: 'Not implemented' };
+  }
+
+  async getMembers(_orgId: string): Promise<OrganizationMember[]> {
+    return [];
+  }
+
+  async addMember(_orgId: string, _userId: string, _role: string): Promise<OrganizationMemberResult> {
     return { success: false, error: 'Not implemented' };
   }
 }

--- a/src/core/organization/IOrganizationDataProvider.ts
+++ b/src/core/organization/IOrganizationDataProvider.ts
@@ -2,7 +2,9 @@ import type {
   Organization,
   OrganizationCreatePayload,
   OrganizationUpdatePayload,
-  OrganizationResult
+  OrganizationResult,
+  OrganizationMember,
+  OrganizationMemberResult
 } from './models';
 
 export interface IOrganizationDataProvider {
@@ -11,4 +13,14 @@ export interface IOrganizationDataProvider {
   getUserOrganizations(userId: string): Promise<Organization[]>;
   updateOrganization(id: string, data: OrganizationUpdatePayload): Promise<OrganizationResult>;
   deleteOrganization(id: string): Promise<{ success: boolean; error?: string }>;
+
+  /**
+   * Get members of an organization.
+   */
+  getMembers(orgId: string): Promise<OrganizationMember[]>;
+
+  /**
+   * Add a member to an organization.
+   */
+  addMember(orgId: string, userId: string, role: string): Promise<OrganizationMemberResult>;
 }

--- a/src/core/organization/interfaces.ts
+++ b/src/core/organization/interfaces.ts
@@ -2,7 +2,9 @@ import type {
   Organization,
   OrganizationCreatePayload,
   OrganizationUpdatePayload,
-  OrganizationResult
+  OrganizationResult,
+  OrganizationMember,
+  OrganizationMemberResult
 } from './models';
 
 /**
@@ -52,12 +54,14 @@ export interface OrganizationService {
    * @returns Object describing whether deletion succeeded
    */
   deleteOrganization(id: string): Promise<{ success: boolean; error?: string }>;
-}
 
-export interface OrganizationService {
-  createOrganization(ownerId: string, data: OrganizationCreatePayload): Promise<OrganizationResult>;
-  getOrganization(id: string): Promise<Organization | null>;
-  getUserOrganizations(userId: string): Promise<Organization[]>;
-  updateOrganization(id: string, data: OrganizationUpdatePayload): Promise<OrganizationResult>;
-  deleteOrganization(id: string): Promise<{ success: boolean; error?: string }>;
+  /**
+   * List all members of the organization.
+   */
+  getOrganizationMembers(orgId: string): Promise<OrganizationMember[]>;
+
+  /**
+   * Add a user to the organization.
+   */
+  addOrganizationMember(orgId: string, userId: string, role: string): Promise<OrganizationMemberResult>;
 }

--- a/src/core/organization/models.ts
+++ b/src/core/organization/models.ts
@@ -57,3 +57,25 @@ export interface OrganizationResult {
   /** Error message when {@link success} is `false` */
   error?: string;
 }
+
+/**
+ * Organization member entity linking a user to an organization.
+ */
+export interface OrganizationMember {
+  /** Organization identifier */
+  organizationId: string;
+  /** User identifier */
+  userId: string;
+  /** Role of the user within the organization */
+  role: string;
+}
+
+/** Result type for organization membership operations */
+export interface OrganizationMemberResult {
+  /** Whether the operation succeeded */
+  success: boolean;
+  /** Created or updated member */
+  member?: OrganizationMember;
+  /** Error message when {@link success} is `false` */
+  error?: string;
+}

--- a/src/services/organization/default-organization.service.ts
+++ b/src/services/organization/default-organization.service.ts
@@ -4,7 +4,9 @@ import type {
   Organization,
   OrganizationCreatePayload,
   OrganizationUpdatePayload,
-  OrganizationResult
+  OrganizationResult,
+  OrganizationMember,
+  OrganizationMemberResult
 } from '@/core/organization/models';
 
 export class DefaultOrganizationService implements OrganizationService {
@@ -28,5 +30,13 @@ export class DefaultOrganizationService implements OrganizationService {
 
   deleteOrganization(id: string): Promise<{ success: boolean; error?: string }> {
     return this.provider.deleteOrganization(id);
+  }
+
+  getOrganizationMembers(orgId: string): Promise<OrganizationMember[]> {
+    return this.provider.getMembers(orgId);
+  }
+
+  addOrganizationMember(orgId: string, userId: string, role: string): Promise<OrganizationMemberResult> {
+    return this.provider.addMember(orgId, userId, role);
   }
 }


### PR DESCRIPTION
## Summary
- implement GET/PUT/DELETE for `/api/organizations/[orgId]`
- add `/api/organizations/[orgId]/members` endpoint
- extend organization service & providers with membership support
- add basic unit tests for new routes

## Testing
- `vitest run app/api/organizations/[orgId]/__tests__/route.test.ts app/api/organizations/[orgId]/members/__tests__/route.test.ts` *(fails: Adapter 'gdpr' not registered)*

------
https://chatgpt.com/codex/tasks/task_b_6842e02906208331a58e8f29991ff1e8