### PR TITLE
Implement health and storage service factories

### DIFF
--- a/src/services/health/factory.ts
+++ b/src/services/health/factory.ts
@@ -1,0 +1,10 @@
+import type { HealthMonitoringService } from '@/core/health/interfaces';
+import { DefaultHealthMonitoringService } from './default-health.service';
+
+export function createHealthService(): HealthMonitoringService {
+  return new DefaultHealthMonitoringService();
+}
+
+export function getHealthService(): HealthMonitoringService {
+  return createHealthService();
+}

--- a/src/services/health/index.ts
+++ b/src/services/health/index.ts
@@ -1,14 +1,2 @@
-import type { HealthMonitoringService } from '@/core/health/interfaces';
-import { DefaultHealthMonitoringService } from './default-health.service';
-
-export interface HealthServiceConfig {
-  windowMs?: number;
-  thresholds?: { degraded: number; unhealthy: number };
-}
-
-export function createHealthMonitoringService(config: HealthServiceConfig = {}): HealthMonitoringService {
-  const { windowMs, thresholds } = config;
-  return new DefaultHealthMonitoringService(windowMs ?? 60_000, thresholds);
-}
-
-export { DefaultHealthMonitoringService } from './default-health.service';
+export * from './factory';
+export * from './default-health.service';

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,2 @@
+export * from './storage';
+export * from './health';

--- a/src/services/storage/factory.ts
+++ b/src/services/storage/factory.ts
@@ -1,0 +1,13 @@
+import type { FileStorageService } from '@/core/storage/services';
+import type { StorageAdapter } from '@/core/storage/interfaces';
+import { DefaultFileStorageService } from './DefaultFileStorageService';
+import { AdapterRegistry } from '@/adapters/registry';
+
+export function createStorageService(): FileStorageService {
+  const adapter = AdapterRegistry.getInstance().getAdapter<StorageAdapter>('storage');
+  return new DefaultFileStorageService(adapter);
+}
+
+export function getStorageService(): FileStorageService {
+  return createStorageService();
+}

--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -1,0 +1,2 @@
+export * from './factory';
+export * from './DefaultFileStorageService';


### PR DESCRIPTION
## Summary
- add `createStorageService` factory and index exports
- add health service factory and update index
- expose storage and health service modules in main services index

## Testing
- `npx vitest run --coverage` *(fails: Adapter 'user' not registered, cannot complete tests)*

------
https://chatgpt.com/codex/tasks/task_b_6842df21c4008331a558616720730a15