### PR TITLE
Add MFA handler TOTP tests

### DIFF
--- a/src/services/auth/__tests__/mfa-handler.test.ts
+++ b/src/services/auth/__tests__/mfa-handler.test.ts
@@ -1,49 +1,97 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DefaultMFAHandler } from '../mfa-handler';
+import { authenticator, hotp } from 'otplib';
 
-const provider = {
-  setupMFA: vi.fn(),
-  verifyMFA: vi.fn(),
-  disableMFA: vi.fn(),
-  startWebAuthnRegistration: vi.fn(),
-  verifyWebAuthnRegistration: vi.fn()
-};
-
-const handler = new DefaultMFAHandler(provider as any);
+function generateTOTPToken(secret: string, time: number = Date.now()) {
+  const counter = Math.floor(time / 30000);
+  return hotp.generate(secret, counter);
+}
 
 describe('DefaultMFAHandler', () => {
-  it('delegates setup', async () => {
-    provider.setupMFA.mockResolvedValue({ success: true });
-    const res = await handler.setupMFA();
-    expect(provider.setupMFA).toHaveBeenCalled();
-    expect(res.success).toBe(true);
+  let provider: any;
+  let handler: DefaultMFAHandler;
+
+  beforeEach(() => {
+    provider = {
+      setupMFA: vi.fn(),
+      verifyMFA: vi.fn(),
+      disableMFA: vi.fn(),
+      startWebAuthnRegistration: vi.fn(),
+      verifyWebAuthnRegistration: vi.fn(),
+    };
+    handler = new DefaultMFAHandler(provider);
   });
 
-  it('delegates verify', async () => {
-    provider.verifyMFA.mockResolvedValue({ success: true });
-    const res = await handler.verifyMFA('123');
-    expect(provider.verifyMFA).toHaveBeenCalledWith('123');
-    expect(res.success).toBe(true);
+  describe('delegation to provider', () => {
+    it('delegates setup', async () => {
+      provider.setupMFA.mockResolvedValue({ success: true });
+      const res = await handler.setupMFA();
+      expect(provider.setupMFA).toHaveBeenCalled();
+      expect(res.success).toBe(true);
+    });
+
+    it('delegates verify', async () => {
+      provider.verifyMFA.mockResolvedValue({ success: true });
+      const res = await handler.verifyMFA('123');
+      expect(provider.verifyMFA).toHaveBeenCalledWith('123');
+      expect(res.success).toBe(true);
+    });
+
+    it('delegates disable', async () => {
+      provider.disableMFA.mockResolvedValue({ success: true });
+      const res = await handler.disableMFA('456');
+      expect(provider.disableMFA).toHaveBeenCalledWith('456');
+      expect(res.success).toBe(true);
+    });
+
+    it('delegates WebAuthn registration start', async () => {
+      provider.startWebAuthnRegistration.mockResolvedValue({ success: true });
+      const res = await handler.startWebAuthnRegistration();
+      expect(provider.startWebAuthnRegistration).toHaveBeenCalled();
+      expect(res.success).toBe(true);
+    });
+
+    it('delegates WebAuthn registration verification', async () => {
+      provider.verifyWebAuthnRegistration.mockResolvedValue({ success: true });
+      const res = await handler.verifyWebAuthnRegistration('data');
+      expect(provider.verifyWebAuthnRegistration).toHaveBeenCalledWith('data');
+      expect(res.success).toBe(true);
+    });
   });
 
-  it('delegates disable', async () => {
-    provider.disableMFA.mockResolvedValue({ success: true });
-    const res = await handler.disableMFA('456');
-    expect(provider.disableMFA).toHaveBeenCalledWith('456');
-    expect(res.success).toBe(true);
+  describe('TOTP Generation', () => {
+    it('generates a valid TOTP secret', async () => {
+      const secret = await handler.generateTOTPSecret();
+      expect(secret).toMatch(/^[A-Z2-7]{16}$/);
+    });
+
+    it('verifies a valid TOTP token', async () => {
+      const secret = await handler.generateTOTPSecret();
+      const token = generateTOTPToken(secret);
+      const isValid = await handler.verifyTOTP(secret, token);
+      expect(isValid).toBe(true);
+    });
+
+    it('rejects an invalid TOTP token', async () => {
+      const secret = await handler.generateTOTPSecret();
+      const isValid = await handler.verifyTOTP(secret, '000000');
+      expect(isValid).toBe(false);
+    });
   });
 
-  it('delegates WebAuthn registration start', async () => {
-    provider.startWebAuthnRegistration.mockResolvedValue({ success: true });
-    const res = await handler.startWebAuthnRegistration();
-    expect(provider.startWebAuthnRegistration).toHaveBeenCalled();
-    expect(res.success).toBe(true);
-  });
+  describe('Security Edge Cases', () => {
+    it('handles replay attacks', async () => {
+      const secret = await handler.generateTOTPSecret();
+      const token = generateTOTPToken(secret);
+      expect(await handler.verifyTOTP(secret, token)).toBe(true);
+      expect(await handler.verifyTOTP(secret, token)).toBe(false);
+    });
 
-  it('delegates WebAuthn registration verification', async () => {
-    provider.verifyWebAuthnRegistration.mockResolvedValue({ success: true });
-    const res = await handler.verifyWebAuthnRegistration('data');
-    expect(provider.verifyWebAuthnRegistration).toHaveBeenCalledWith('data');
-    expect(res.success).toBe(true);
+    it('handles time window attacks', async () => {
+      const secret = await handler.generateTOTPSecret();
+      const futureToken = generateTOTPToken(secret, Date.now() + 35000);
+      const isValid = await handler.verifyTOTP(secret, futureToken);
+      expect(isValid).toBe(false);
+    });
   });
 });

--- a/src/services/auth/mfa-handler.ts
+++ b/src/services/auth/mfa-handler.ts
@@ -1,5 +1,6 @@
 import type { AuthDataProvider } from '@/adapters/auth/interfaces';
 import type { AuthResult, MFASetupResponse, MFAVerifyResponse } from '@/core/auth/models';
+import { authenticator, hotp } from 'otplib';
 
 export interface MFAHandler {
   setupMFA(): Promise<MFASetupResponse>;
@@ -7,9 +8,13 @@ export interface MFAHandler {
   disableMFA(code: string): Promise<AuthResult>;
   startWebAuthnRegistration(): Promise<MFASetupResponse>;
   verifyWebAuthnRegistration(data: unknown): Promise<MFAVerifyResponse>;
+  generateTOTPSecret(): Promise<string>;
+  verifyTOTP(secret: string, token: string): Promise<boolean>;
 }
 
 export class DefaultMFAHandler implements MFAHandler {
+  private usedTokens = new Map<string, Set<string>>();
+
   constructor(private provider: AuthDataProvider) {}
 
   setupMFA(): Promise<MFASetupResponse> {
@@ -30,5 +35,23 @@ export class DefaultMFAHandler implements MFAHandler {
 
   verifyWebAuthnRegistration(data: unknown): Promise<MFAVerifyResponse> {
     return this.provider.verifyWebAuthnRegistration(data);
+  }
+
+  async generateTOTPSecret(): Promise<string> {
+    return authenticator.generateSecret();
+  }
+
+  async verifyTOTP(secret: string, token: string): Promise<boolean> {
+    const set = this.usedTokens.get(secret) ?? new Set<string>();
+    if (set.has(token)) return false;
+    const counter = Math.floor(Date.now() / 30000);
+    const validCurrent = hotp.generate(secret, counter) === token;
+    const validPrev = hotp.generate(secret, counter - 1) === token;
+    const valid = validCurrent || validPrev;
+    if (valid) {
+      set.add(token);
+      this.usedTokens.set(secret, set);
+    }
+    return valid;
   }
 }


### PR DESCRIPTION
## Summary
- add TOTP secret generation and verification methods in `DefaultMFAHandler`
- create comprehensive tests covering provider delegation and TOTP flows

## Testing
- `npx vitest run --coverage src/services/auth/__tests__/mfa-handler.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_6842e0442930833198d384df71392964