### PR TITLE
Implement storage and health service factories

### DIFF
--- a/src/services/health/__tests__/factory.test.ts
+++ b/src/services/health/__tests__/factory.test.ts
@@ -1,29 +1,32 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { getHealthService } from '../factory';
-import { DefaultSystemHealthService } from '../system-health.service';
-import { getServiceContainer } from '@/lib/config/service-container';
+import { createHealthService, getHealthService } from '../factory';
+import { DefaultHealthService } from '../default-health.service';
+import { getAdapter } from '../../adapters';
 
-vi.mock('@/lib/config/service-container', () => ({
-  getServiceContainer: vi.fn(() => ({}))
+vi.mock('../../adapters', () => ({
+  getAdapter: vi.fn(() => ({})),
 }));
 
+const MockGetAdapter = getAdapter as unknown as vi.Mock;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createHealthService', () => {
+  it('creates service using health adapter', () => {
+    const adapter = {} as any;
+    MockGetAdapter.mockReturnValue(adapter);
+    const svc = createHealthService();
+    expect(svc).toBeInstanceOf(DefaultHealthService);
+    expect(MockGetAdapter).toHaveBeenCalledWith('health');
+  });
+});
+
 describe('getHealthService', () => {
-  beforeEach(() => {
-    vi.resetModules();
-    (getServiceContainer as unknown as vi.Mock).mockReturnValue({});
-  });
-
-  it('returns cached service instance', () => {
-    const first = getHealthService({ reset: true });
-    const second = getHealthService();
-    expect(first).toBeInstanceOf(DefaultSystemHealthService);
-    expect(second).toBe(first);
-  });
-
-  it('uses container provided instance if available', () => {
-    const custom = {} as any;
-    (getServiceContainer as unknown as vi.Mock).mockReturnValue({ health: custom });
-    const service = getHealthService({ reset: true });
-    expect(service).toBe(custom);
+  it('returns new service instance', () => {
+    const svc = getHealthService();
+    expect(svc).toBeInstanceOf(DefaultHealthService);
+    expect(MockGetAdapter).toHaveBeenCalledWith('health');
   });
 });

--- a/src/services/health/factory.ts
+++ b/src/services/health/factory.ts
@@ -1,37 +1,12 @@
-import { getServiceContainer } from '@/lib/config/service-container';
-import { DefaultSystemHealthService, HealthService } from './system-health.service';
+import { IHealthService } from '../../core/health/interfaces';
+import { DefaultHealthService } from './default-health.service';
+import { getAdapter } from '../../adapters';
 
-export interface HealthServiceOptions {
-  reset?: boolean;
+export function createHealthService(): IHealthService {
+  const adapter = getAdapter('health');
+  return new DefaultHealthService(adapter);
 }
 
-let cachedService: HealthService | null = null;
-let constructing = false;
-
-export function getHealthService(options: HealthServiceOptions = {}): HealthService {
-  if (options.reset) {
-    cachedService = null;
-  }
-
-  if (cachedService && !options.reset) {
-    return cachedService;
-  }
-
-  if (!constructing) {
-    constructing = true;
-    try {
-      const container = getServiceContainer() as any;
-      if (container.health) {
-        cachedService = container.health as HealthService;
-      }
-    } finally {
-      constructing = false;
-    }
-  }
-
-  if (!cachedService) {
-    cachedService = new DefaultSystemHealthService();
-  }
-
-  return cachedService;
+export function getHealthService(): IHealthService {
+  return createHealthService();
 }

--- a/src/services/health/index.ts
+++ b/src/services/health/index.ts
@@ -1,16 +1,2 @@
-import type { HealthMonitoringService } from '@/core/health/interfaces';
-import { DefaultHealthMonitoringService } from './default-health.service';
-
-export interface HealthServiceConfig {
-  windowMs?: number;
-  thresholds?: { degraded: number; unhealthy: number };
-}
-
-export function createHealthMonitoringService(config: HealthServiceConfig = {}): HealthMonitoringService {
-  const { windowMs, thresholds } = config;
-  return new DefaultHealthMonitoringService(windowMs ?? 60_000, thresholds);
-}
-
-export { DefaultHealthMonitoringService } from './default-health.service';
-export { DefaultSystemHealthService } from './system-health.service';
-export { getHealthService } from './factory';
+export * from './factory';
+export * from './default-health.service';

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,2 @@
+export * from './storage';
+export * from './health';

--- a/src/services/storage/__tests__/factory.test.ts
+++ b/src/services/storage/__tests__/factory.test.ts
@@ -1,20 +1,32 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getStorageService } from '../factory';
-import { SupabaseStorageAdapter } from '@/adapters/storage/supabase/SupabaseStorageAdapter';
+import { createStorageService, getStorageService } from '../factory';
+import { DefaultFileStorageService } from '../DefaultFileStorageService';
+import { getAdapter } from '../../adapters';
 
-vi.mock('@/adapters/storage/supabase/SupabaseStorageAdapter');
+vi.mock('../../adapters', () => ({
+  getAdapter: vi.fn(() => ({})),
+}));
 
-const MockAdapter = SupabaseStorageAdapter as unknown as vi.Mock;
+const MockGetAdapter = getAdapter as unknown as vi.Mock;
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
+describe('createStorageService', () => {
+  it('creates service using storage adapter', () => {
+    const adapter = {} as any;
+    MockGetAdapter.mockReturnValue(adapter);
+    const service = createStorageService();
+    expect(service).toBeInstanceOf(DefaultFileStorageService);
+    expect(MockGetAdapter).toHaveBeenCalledWith('storage');
+  });
+});
+
 describe('getStorageService', () => {
-  it('creates and caches service instance', () => {
-    const service1 = getStorageService({ bucket: 'b', reset: true });
-    const service2 = getStorageService();
-    expect(MockAdapter).toHaveBeenCalledWith('b');
-    expect(service1).toBe(service2);
+  it('returns a new service instance', () => {
+    const svc = getStorageService();
+    expect(svc).toBeInstanceOf(DefaultFileStorageService);
+    expect(MockGetAdapter).toHaveBeenCalledWith('storage');
   });
 });

--- a/src/services/storage/factory.ts
+++ b/src/services/storage/factory.ts
@@ -1,24 +1,12 @@
-import type { FileStorageService } from '@/core/storage/services';
+import type { IStorageService } from '../../core/storage/interfaces';
 import { DefaultFileStorageService } from './DefaultFileStorageService';
-import { SupabaseStorageAdapter } from '@/adapters/storage/supabase/SupabaseStorageAdapter';
+import { getAdapter } from '../../adapters';
 
-export interface StorageServiceOptions {
-  bucket?: string;
-  reset?: boolean;
+export function createStorageService(): IStorageService {
+  const adapter = getAdapter('storage');
+  return new DefaultFileStorageService(adapter);
 }
 
-let cachedService: FileStorageService | null = null;
-
-export function getStorageService(options: StorageServiceOptions = {}): FileStorageService {
-  if (options.reset) {
-    cachedService = null;
-  }
-
-  if (!cachedService) {
-    const bucket = options.bucket || 'files';
-    const adapter = new SupabaseStorageAdapter(bucket);
-    cachedService = new DefaultFileStorageService(adapter);
-  }
-
-  return cachedService;
+export function getStorageService(): IStorageService {
+  return createStorageService();
 }

--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -1,2 +1,2 @@
-export { DefaultFileStorageService } from './DefaultFileStorageService';
-export { getStorageService } from './factory';
+export * from './factory';
+export * from './DefaultFileStorageService';


### PR DESCRIPTION
## Summary
- add create/get factory for storage service using `getAdapter`
- add create/get factory for health service
- simplify service index exports and add central service index
- update corresponding tests

## Testing
- `npx vitest run --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842e44c9d9c83318f313551273f1644