### PR TITLE
Add missing TeamMember fields

### DIFF
--- a/src/core/team/models.ts
+++ b/src/core/team/models.ts
@@ -81,14 +81,49 @@ export enum TeamVisibility {
  */
 export interface TeamMember {
   /**
+   * Unique identifier for the team member record
+   */
+  id: string;
+
+  /**
    * ID of the team
    */
   teamId: string;
   
   /**
    * ID of the user
-   */
+  */
   userId: string;
+
+  /**
+   * Full display name of the user
+   */
+  name?: string;
+
+  /**
+   * Email address of the user
+   */
+  email?: string;
+
+  /**
+   * URL of the user's avatar image (optional)
+   */
+  avatarUrl?: string | null;
+
+  /**
+   * Whether this member entry represents the current user
+   */
+  isCurrentUser?: boolean;
+
+  /**
+   * Whether the current user can remove this member
+   */
+  canRemove?: boolean;
+
+  /**
+   * Whether the current user can update this member's role
+   */
+  canUpdateRole?: boolean;
   
   /**
    * Role of the user in the team

--- a/src/services/team/__tests__/mocks/mock-team-service.ts
+++ b/src/services/team/__tests__/mocks/mock-team-service.ts
@@ -46,10 +46,17 @@ export class MockTeamService implements TeamService {
     
     // Add owner as a member
     const ownerMember: TeamMember = {
+      id: `member-${Date.now()}`,
       teamId,
       userId: ownerId,
       role: 'owner',
-      joinedAt: new Date().toISOString()
+      joinedAt: new Date().toISOString(),
+      name: '',
+      email: '',
+      avatarUrl: null,
+      isCurrentUser: false,
+      canRemove: true,
+      canUpdateRole: true
     };
     
     this.mockTeamMembers[teamId] = [ownerMember];
@@ -138,10 +145,17 @@ export class MockTeamService implements TeamService {
     }
     
     const member: TeamMember = {
+      id: `member-${Date.now()}`,
       teamId,
       userId,
       role,
-      joinedAt: new Date().toISOString()
+      joinedAt: new Date().toISOString(),
+      name: '',
+      email: '',
+      avatarUrl: null,
+      isCurrentUser: false,
+      canRemove: true,
+      canUpdateRole: true
     };
     
     this.mockTeamMembers[teamId] = [...existingMembers, member];
@@ -479,10 +493,17 @@ export class MockTeamService implements TeamService {
     // Ensure team has members
     if (!this.mockTeamMembers[team.id]) {
       this.mockTeamMembers[team.id] = [{
+        id: `member-${Date.now()}`,
         teamId: team.id,
         userId: team.ownerId,
         role: 'owner',
-        joinedAt: team.createdAt || new Date().toISOString()
+        joinedAt: team.createdAt || new Date().toISOString(),
+        name: '',
+        email: '',
+        avatarUrl: null,
+        isCurrentUser: false,
+        canRemove: true,
+        canUpdateRole: true
       }];
     }
     


### PR DESCRIPTION
## Summary
- expand the `TeamMember` model with optional display and permission fields
- update mock team service to populate new fields

## Testing
- `npx vitest run --coverage` *(fails: numerous test failures)*

------
https://chatgpt.com/codex/tasks/task_b_6842ec004e788331b30293ef32f0dcdb