### PR TITLE
Fix user provider import

### DIFF
--- a/src/adapters/supabase-factory.ts
+++ b/src/adapters/supabase-factory.ts
@@ -8,7 +8,7 @@
 
 import { AdapterFactory, AdapterFactoryOptions } from './registry';
 import { AuthDataProvider } from './auth/interfaces';
-import { UserDataProvider } from './user/interfaces';
+import { UserDataProvider } from '@/core/user/IUserDataProvider';
 import { TeamDataProvider } from './team/interfaces';
 import { PermissionDataProvider } from './permission/interfaces';
 import { GdprDataProvider } from './gdpr/interfaces';


### PR DESCRIPTION
## Summary
- fix invalid import for `UserDataProvider` in the Supabase adapter factory

## Testing
- `npx vitest run --coverage`

------
https://chatgpt.com/codex/tasks/task_b_6842f15b5a148331ae7c2f1b431e3a84