### PR TITLE
Fix session info typings

### DIFF
--- a/src/ui/styled/profile/SessionManagement.tsx
+++ b/src/ui/styled/profile/SessionManagement.tsx
@@ -51,20 +51,20 @@ const SessionManagement: React.FC = () => {
                   </thead>
                   <tbody>
                     {sessions.map((session) => (
-                      <tr key={session.id} className={session.is_current ? 'bg-blue-50' : ''}>
+                      <tr key={session.id} className={session.isCurrent ? 'bg-blue-50' : ''}>
                         <td className="px-4 py-2">
-                          {session.user_agent || 'Unknown'}
-                          {session.is_current && (
+                          {session.userAgent || 'Unknown'}
+                          {session.isCurrent && (
                             <span className="ml-2 text-xs text-blue-600 font-semibold">
                               (Current)
                               <span className="sr-only">(Current session)</span>
                             </span>
                           )}
                         </td>
-                        <td className="px-4 py-2">{session.ip_address || '-'}</td>
-                        <td className="px-4 py-2">{session.last_active_at ? new Date(session.last_active_at).toLocaleString() : '-'}</td>
+                        <td className="px-4 py-2">{session.ipAddress || '-'}</td>
+                        <td className="px-4 py-2">{session.lastActiveAt ? new Date(session.lastActiveAt).toLocaleString() : '-'}</td>
                         <td className="px-4 py-2">
-                          {session.is_current ? (
+                          {session.isCurrent ? (
                             <span className="text-gray-400">Active</span>
                           ) : (
                             <AlertDialog>

--- a/src/ui/styled/profile/__tests__/SessionManagement.test.tsx
+++ b/src/ui/styled/profile/__tests__/SessionManagement.test.tsx
@@ -11,17 +11,17 @@ vi.mock('@/hooks/session/useSession');
 const mockSessions = [
   {
     id: 'session-1',
-    user_agent: 'Chrome on Windows',
-    ip_address: '192.168.1.1',
-    last_active_at: new Date().toISOString(),
-    is_current: true,
+    userAgent: 'Chrome on Windows',
+    ipAddress: '192.168.1.1',
+    lastActiveAt: new Date().toISOString(),
+    isCurrent: true,
   },
   {
     id: 'session-2',
-    user_agent: 'Safari on iPhone',
-    ip_address: '10.0.0.2',
-    last_active_at: new Date(Date.now() - 100000).toISOString(),
-    is_current: false,
+    userAgent: 'Safari on iPhone',
+    ipAddress: '10.0.0.2',
+    lastActiveAt: new Date(Date.now() - 100000).toISOString(),
+    isCurrent: false,
   },
 ];
 

--- a/src/ui/styled/session/SessionCard.tsx
+++ b/src/ui/styled/session/SessionCard.tsx
@@ -11,8 +11,8 @@ export function SessionCard({ session, isCurrent, onTerminate }: SessionCardProp
   return (
     <div className="border rounded p-2 flex items-center justify-between">
       <div>
-        <div className="font-medium">{session.user_agent || 'Unknown'}</div>
-        <div className="text-xs text-gray-500">{session.ip_address || '-'} | {session.last_active_at ? new Date(session.last_active_at).toLocaleString() : '-'}</div>
+        <div className="font-medium">{session.userAgent || 'Unknown'}</div>
+        <div className="text-xs text-gray-500">{session.ipAddress || '-'} | {session.lastActiveAt ? new Date(session.lastActiveAt).toLocaleString() : '-'}</div>
       </div>
       {isCurrent ? (
         <span className="text-sm text-gray-500">Current</span>

--- a/src/ui/styled/session/SessionList.tsx
+++ b/src/ui/styled/session/SessionList.tsx
@@ -39,13 +39,13 @@ export function SessionList(props: StyledSessionListProps) {
                   {sessions.map(session => (
                     <tr key={session.id} className={session.id === currentSessionId ? 'bg-blue-50' : ''}>
                       <td className="px-4 py-2">
-                        {session.user_agent || 'Unknown'}
+                        {session.userAgent || 'Unknown'}
                         {session.id === currentSessionId && (
                           <span className="ml-2 text-xs text-blue-600 font-semibold">(Current)</span>
                         )}
                       </td>
-                      <td className="px-4 py-2">{session.ip_address || '-'}</td>
-                      <td className="px-4 py-2">{session.last_active_at ? new Date(session.last_active_at).toLocaleString() : '-'}</td>
+                      <td className="px-4 py-2">{session.ipAddress || '-'}</td>
+                      <td className="px-4 py-2">{session.lastActiveAt ? new Date(session.lastActiveAt).toLocaleString() : '-'}</td>
                       <td className="px-4 py-2">
                         {session.id === currentSessionId ? (
                           <span className="text-gray-400">Active</span>


### PR DESCRIPTION
## Summary
- fix styled session components to use camelCase session fields
- update SessionManagement tests to match new field names

## Testing
- `npx vitest run --coverage` *(fails: useConnectedAccountsStore.mockReturnValue is not a function, rate limiting disabled errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6844a8f5a1308331b86637184c474e70