### PR TITLE
Fix TypeScript test compilation errors

### DIFF
--- a/src/ui/styled/account/__tests__/DeleteAccountDialog.test.tsx
+++ b/src/ui/styled/account/__tests__/DeleteAccountDialog.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { vi } from 'vitest'; // Import vi
+import { vi, type Mock } from 'vitest';
 import DeleteAccountDialog from '@/ui/styled/account/DeleteAccountDialog';
 import { useDeleteAccount } from '@/hooks/user/useDeleteAccount';
 import { act } from 'react';
@@ -10,13 +10,13 @@ vi.mock('@/hooks/user/useDeleteAccount');
 
 describe('DeleteAccountDialog', () => {
   let handleClose: ReturnType<typeof vi.fn>;
-  let mockDeleteAccount: vi.Mock<[], Promise<void>>;
+  let mockDeleteAccount: Mock<() => Promise<void>>;
   const mockUseDeleteAccount = vi.mocked(useDeleteAccount);
 
   beforeEach(() => {
     // Reset mocks before each test
     handleClose = vi.fn();
-    mockDeleteAccount = vi.fn<[], Promise<void>>();
+    mockDeleteAccount = vi.fn<() => Promise<void>>();
     mockUseDeleteAccount.mockReturnValue({
       deleteAccount: mockDeleteAccount as () => Promise<void>,
       isLoading: false,

--- a/src/ui/styled/admin/RoleManagementPanel.tsx
+++ b/src/ui/styled/admin/RoleManagementPanel.tsx
@@ -4,7 +4,9 @@ import {
   RoleManagementPanelProps,
 } from '@/ui/headless/admin/RoleManagementPanel';
 
-const RoleManagementPanel: React.FC<RoleManagementPanelProps> = ({ users }) => (
+type StyledRoleManagementPanelProps = Omit<RoleManagementPanelProps, 'children'>;
+
+const RoleManagementPanel: React.FC<StyledRoleManagementPanelProps> = ({ users }) => (
   <HeadlessRoleManagementPanel users={users}>
     {({
       roles,

--- a/src/ui/styled/admin/__tests__/AdminAuditLogs.test.tsx
+++ b/src/ui/styled/admin/__tests__/AdminAuditLogs.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { AdminAuditLogs } from '@/ui/styled/admin/auditLogs/AdminAuditLogs';
+import { AdminAuditLogs } from '@/ui/styled/admin/audit-logs/AdminAuditLogs';
 
 import { __setIsError } from '@/tests/mocks/headlessAdminAuditLogs.mock';
 vi.mock('@/ui/headless/admin/audit-logs/AdminAuditLogs', async () => await import('@/tests/mocks/headlessAdminAuditLogs.mock'));

--- a/src/ui/styled/admin/__tests__/RoleManagementPanel.test.tsx
+++ b/src/ui/styled/admin/__tests__/RoleManagementPanel.test.tsx
@@ -22,8 +22,8 @@ const mockRoles: RoleSchema[] = [
     description: 'Admin role',
     permissions: [PermissionValues.MANAGE_ROLES, PermissionValues.ADMIN_ACCESS],
     isSystem: false,
-    createdAt: '',
-    updatedAt: ''
+    createdAt: new Date(),
+    updatedAt: new Date()
   },
   {
     id: 'r2',
@@ -31,8 +31,8 @@ const mockRoles: RoleSchema[] = [
     description: 'User role',
     permissions: [PermissionValues.VIEW_ANALYTICS],
     isSystem: false,
-    createdAt: '',
-    updatedAt: ''
+    createdAt: new Date(),
+    updatedAt: new Date()
   },
 ];
 


### PR DESCRIPTION
## Summary
- correct vitest mocking imports in delete account dialog test
- fix AdminAuditLogs import path
- adjust role mock dates and typed props for RoleManagementPanel
- update RoleManagementPanel component to omit children prop

## Testing
- `npx tsc -p tsconfig.test.json --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_b_6844aa4fcf7c83319f23dfe9a803cc3c