### PR TITLE
Fix profile and webhook form usage

### DIFF
--- a/src/hooks/user/useProfile.ts
+++ b/src/hooks/user/useProfile.ts
@@ -31,9 +31,7 @@ interface Profile {
 
 
 export const useProfile = () => {
-  const profile = useProfileStore((state) => state.profile);
-  const isLoading = useProfileStore((state) => state.isLoading);
-  const updatePrivacySettings = useProfileStore((state) => state.updatePrivacySettings);
+  const { profile, isLoading } = useProfileStore();
 
   // You could add more selectors here if needed, e.g., specific parts of the profile
   // const avatarUrl = useProfileStore((state) => state.profile?.avatarUrl);
@@ -41,7 +39,5 @@ export const useProfile = () => {
   return {
     profile,
     isLoading,
-    updatePrivacySettings,
-    // Add other selected state/actions here if needed
   };
 };

--- a/src/ui/headless/user/ProfileForm.tsx
+++ b/src/ui/headless/user/ProfileForm.tsx
@@ -32,10 +32,8 @@ export interface ProfileFormProps {
  * Follows the render props pattern to allow for custom UI implementation
  */
 export default function ProfileForm({ children }: ProfileFormProps) {
-  const profile = useProfileStore(state => state.profile);
-  const isProfileLoading = useProfileStore(state => state.isLoading);
-  const fetchProfile = useProfileStore(state => state.fetchProfile);
-  const updateProfile = useProfileStore(state => state.updateProfile);
+  const profileStore = useProfileStore();
+  const { profile, isLoading: isProfileLoading, fetchProfile, updateProfile } = profileStore;
   
   const userEmail = useAuth().user?.email;
   
@@ -97,15 +95,15 @@ export default function ProfileForm({ children }: ProfileFormProps) {
   const onSubmit = useCallback(async (data: ProfileFormData) => {
     try {
       await updateProfile(data);
-      if (!useProfileStore.getState().error) { 
+      if (!profileStore.error) {
         setIsEditing(false);
       }
     } catch (error) {
-      if (process.env.NODE_ENV === 'development') { 
+      if (process.env.NODE_ENV === 'development') {
         console.error("Error updating profile:", error);
       }
     }
-  }, [updateProfile]);
+  }, [updateProfile, profileStore.error]);
 
   const handlePrivacyChange = useCallback(async (checked: boolean) => {
     setIsPrivacyLoading(true);

--- a/src/ui/headless/webhooks/WebhookForm.tsx
+++ b/src/ui/headless/webhooks/WebhookForm.tsx
@@ -63,7 +63,7 @@ export function WebhookForm({
       if (onSubmit) {
         await onSubmit(data);
       } else {
-        await createWebhook(data);
+        await (createWebhook.mutateAsync ? createWebhook.mutateAsync(data) : createWebhook(data));
       }
       // Reset form only on successful submission
       setData({ name: '', url: '', events: [] });


### PR DESCRIPTION
## Summary
- use wrapper hooks instead of selectors in `ProfileForm`
- simplify `useProfile` hook
- correctly call mutation in `WebhookForm`

## Testing
- `vitest run --coverage src/ui/headless/user/__tests__/profileForm.test.tsx src/ui/headless/webhooks/__tests__/WebhookManager.test.tsx` *(fails: Failed to resolve import "@/adapters/apiKeys")*

------
https://chatgpt.com/codex/tasks/task_b_6844aa758c7c8331a1a0a7b1d2157813