### PR TITLE
Fix type errors in account pages

### DIFF
--- a/app/account/billing/page.tsx
+++ b/app/account/billing/page.tsx
@@ -4,7 +4,7 @@ import { PlanSelector } from '@/ui/styled/subscription/PlanSelector';
 import { BillingForm } from '@/ui/styled/subscription/BillingForm';
 import { InvoiceList } from '@/ui/styled/subscription/InvoiceList';
 
-export default function BillingPage(): JSX.Element {
+export default function BillingPage() {
   return (
     <div className="container mx-auto py-8 space-y-8 max-w-3xl">
       <h1 className="text-2xl font-bold">Subscription Management</h1>

--- a/app/account/complete-profile/page.tsx
+++ b/app/account/complete-profile/page.tsx
@@ -4,7 +4,7 @@ import '@/lib/i18n';
 import { useTranslation } from 'react-i18next';
 import { ProfileCompletion } from '@/ui/styled/registration/ProfileCompletion';
 
-export default function ProfileCompletionPage(): JSX.Element {
+export default function ProfileCompletionPage() {
   const { t } = useTranslation();
 
   return (

--- a/app/account/profile/page.tsx
+++ b/app/account/profile/page.tsx
@@ -12,17 +12,14 @@ import { ProfileEditor } from '@/ui/styled/profile/ProfileEditor';
 import { useUserProfile } from '@/hooks/user/useUserProfile';
 import { useAccountSettings } from '@/hooks/user/useAccountSettings';
 
-export default function ProfilePage(): JSX.Element {
+export default function ProfilePage() {
   const { t } = useTranslation();
   
   // Use our hooks from the new architecture
-  const { 
-    profile, 
-    isLoading, 
-    error, 
-    updateProfile,
-    uploadAvatar,
-    removeAvatar
+  const {
+    profile,
+    isLoading,
+    error
   } = useUserProfile();
   
   useAccountSettings();
@@ -66,15 +63,8 @@ export default function ProfilePage(): JSX.Element {
           {t('profile.title', 'Manage Your Profile')}
         </h1>
         
-        {/* Use our new ProfileEditor component */}
-        <ProfileEditor 
-          title={t('profile.details.title', 'Profile Details')}
-          description={t('profile.details.description', 'Update your personal information and preferences')}
-          profile={profile}
-          onUpdateProfile={updateProfile}
-          onAvatarUpload={uploadAvatar}
-          onAvatarRemove={removeAvatar}
-        />
+          {/* Use our new ProfileEditor component */}
+          <ProfileEditor />
         
         {/* Password Change Section */}
         <Card>


### PR DESCRIPTION
## Summary
- remove JSX return types from account pages
- adjust profile page to use `useUserProfile` without unused avatar methods
- simplify `ProfileEditor` usage on profile page

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_6844b017b4188331b8a835264bf5465a