### PR TITLE
Fix verify-domain tests

### DIFF
--- a/app/api/company/verify-domain/check/__tests__/route.test.ts
+++ b/app/api/company/verify-domain/check/__tests__/route.test.ts
@@ -21,7 +21,7 @@ describe('POST /api/company/verify-domain/check', () => {
 
   test('returns status on success', async () => {
     const req = new NextRequest('http://localhost/api/company/verify-domain/check');
-    const res = await POST(req as any, {} as any);
+    const res = await POST(req as any);
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.data.verified).toBe(true);
@@ -31,7 +31,7 @@ describe('POST /api/company/verify-domain/check', () => {
   test('returns 400 when not verified', async () => {
     service.checkProfileDomainVerification.mockResolvedValueOnce({ verified: false, message: 'no' });
     const req = new NextRequest('http://localhost/api/company/verify-domain/check');
-    const res = await POST(req as any, {} as any);
+    const res = await POST(req as any);
     const json = await res.json();
     expect(res.status).toBe(400);
     expect(json.data.verified).toBe(false);
@@ -40,7 +40,7 @@ describe('POST /api/company/verify-domain/check', () => {
   test('returns 500 on error', async () => {
     service.checkProfileDomainVerification.mockRejectedValueOnce(new Error('fail'));
     const req = new NextRequest('http://localhost/api/company/verify-domain/check');
-    const res = await POST(req as any, {} as any);
+    const res = await POST(req as any);
     const json = await res.json();
     expect(res.status).toBe(500);
     expect(json.error).toBeDefined();

--- a/app/api/company/verify-domain/initiate/__tests__/route.test.ts
+++ b/app/api/company/verify-domain/initiate/__tests__/route.test.ts
@@ -21,7 +21,7 @@ describe('POST /api/company/verify-domain/initiate', () => {
 
   test('returns token on success', async () => {
     const req = new NextRequest('http://localhost/api/company/verify-domain/initiate');
-    const res = await POST(req as any, {} as any);
+    const res = await POST(req as any);
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.data.verificationToken).toBe('token');
@@ -31,7 +31,7 @@ describe('POST /api/company/verify-domain/initiate', () => {
   test('returns 500 on error', async () => {
     service.initiateProfileDomainVerification.mockRejectedValueOnce(new Error('fail'));
     const req = new NextRequest('http://localhost/api/company/verify-domain/initiate');
-    const res = await POST(req as any, {} as any);
+    const res = await POST(req as any);
     const json = await res.json();
     expect(res.status).toBe(500);
     expect(json.error).toBeDefined();


### PR DESCRIPTION
## Summary
- fix verify-domain route tests to pass only the request object

## Testing
- `npx tsc -p tsconfig.test.json --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_b_68452afa51488331ab0801de055232fd