### PR TITLE
Fix permissions management compile issues

### DIFF
--- a/app/admin/permissions/ClientPage.tsx
+++ b/app/admin/permissions/ClientPage.tsx
@@ -3,22 +3,12 @@
 import { Skeleton } from '@/ui/primitives/skeleton';
 import { Alert, AlertDescription } from '@/ui/primitives/alert';
 
+import type React from 'react';
 import { PermissionEditor } from '@/ui/styled/permission/PermissionEditor';
 import { usePermissions } from '@/hooks/permission/usePermissions';
 
-export default function PermissionsManagementPageClient(): JSX.Element {
-  const {
-    permissions,
-    permissionCategories,
-    isLoading,
-    error,
-    createPermission,
-    updatePermission,
-    deletePermission,
-    createCategory,
-    selectedPermission,
-    setSelectedPermission
-  } = usePermissions();
+export default function PermissionsManagementPageClient(): React.JSX.Element {
+  const { isLoading, error } = usePermissions();
 
   return (
     <div className="container py-6 space-y-6">
@@ -39,16 +29,7 @@ export default function PermissionsManagementPageClient(): JSX.Element {
           <AlertDescription>{error}</AlertDescription>
         </Alert>
       ) : (
-        <PermissionEditor
-          permissions={permissions || []}
-          permissionCategories={permissionCategories || []}
-          onCreatePermission={createPermission}
-          onUpdatePermission={updatePermission}
-          onDeletePermission={deletePermission}
-          onCreateCategory={createCategory}
-          selectedPermission={selectedPermission}
-          onSelectPermission={setSelectedPermission}
-        />
+        <PermissionEditor />
       )}
     </div>
   );

--- a/app/admin/permissions/ResourcePermissionPanel.tsx
+++ b/app/admin/permissions/ResourcePermissionPanel.tsx
@@ -6,7 +6,7 @@ import { Select } from '@/ui/primitives/select';
 import { UserManagementConfiguration } from '@/core/config';
 import type { PermissionService } from '@/core/permission/interfaces';
 import { usePermission } from '@/hooks/permission/usePermissions';
-import { PermissionValues } from '@/core/permission/models';
+import { PermissionValues, type Permission } from '@/core/permission/models';
 
 interface ResourcePermission {
   userId: string;
@@ -37,7 +37,7 @@ export default function ResourcePermissionPanel() {
     if (!permissionService || !userId || !permission || !resourceId) return;
     await permissionService.assignResourcePermission(
       userId,
-      permission,
+      permission as Permission,
       resourceType,
       resourceId,
     );
@@ -46,7 +46,12 @@ export default function ResourcePermissionPanel() {
 
   const revokePermission = async (uid: string, perm: string) => {
     if (!permissionService) return;
-    await permissionService.removeResourcePermission(uid, perm, resourceType, resourceId);
+    await permissionService.removeResourcePermission(
+      uid,
+      perm as Permission,
+      resourceType,
+      resourceId,
+    );
     fetchPermissions();
   };
 

--- a/app/admin/permissions/__tests__/ResourcePermissionPanel.test.tsx
+++ b/app/admin/permissions/__tests__/ResourcePermissionPanel.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import ResourcePermissionPanel from '@app/admin/permissions/ResourcePermissionPanel';
 import { usePermission } from '@/hooks/permission/usePermissions';
 import { UserManagementConfiguration } from '@/core/config';
@@ -14,7 +14,7 @@ vi.mock('@/core/config', () => ({ UserManagementConfiguration: { getServiceProvi
 describe('ResourcePermissionPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (UserManagementConfiguration.getServiceProvider as unknown as vi.Mock).mockReturnValue(undefined);
+    (UserManagementConfiguration.getServiceProvider as unknown as Mock).mockReturnValue(undefined);
   });
 
   it('shows loading state while permission check in progress', () => {


### PR DESCRIPTION
## Summary
- fix vitest typing usage in permissions panel test
- simplify permissions management client page
- cast resource permissions to satisfy service API

## Testing
- `npx vitest run --coverage` *(fails: useConnectedAccountsStore.mockReturnValue is not a function)*

------
https://chatgpt.com/codex/tasks/task_b_68452ac4e32c833194936ad85b0a2c77