### PR TITLE
Fix address service property

### DIFF
--- a/app/api/addresses/[id]/__tests__/route.test.ts
+++ b/app/api/addresses/[id]/__tests__/route.test.ts
@@ -22,7 +22,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   resetServiceContainer();
   configureServices({
-    addressService: service as AddressService,
+    personalAddressService: service as AddressService,
     authService: authService as AuthService,
   });
 });

--- a/app/api/addresses/default/[id]/__tests__/route.test.ts
+++ b/app/api/addresses/default/[id]/__tests__/route.test.ts
@@ -22,7 +22,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   resetServiceContainer();
   configureServices({
-    addressService: service as AddressService,
+    personalAddressService: service as AddressService,
     authService: authService as AuthService,
   });
 });

--- a/src/core/config/interfaces.ts
+++ b/src/core/config/interfaces.ts
@@ -54,6 +54,8 @@ export interface ServiceContainer {
   // TODO: Add other services as their interfaces become available
   role?: RoleService;
   address?: CompanyAddressService;
+  /** Personal address service for managing user addresses */
+  addressService: AddressService;
   companyNotification?: import("@/core/companyNotification/interfaces").CompanyNotificationService;
   resourceRelationship?: ResourceRelationshipService;
   oauth?: import('@/core/oauth/interfaces').OAuthService;
@@ -157,6 +159,10 @@ export interface ServiceConfig {
    * Custom address service implementation (for company addresses)
    */
   addressService?: CompanyAddressService;
+  /**
+   * Custom personal address service implementation
+   */
+  personalAddressService?: AddressService;
   oauthService?: import('@/core/oauth/interfaces').OAuthService;
   companyNotificationService?: import("@/core/companyNotification/interfaces").CompanyNotificationService;
 

--- a/src/lib/config/serviceContainer.ts
+++ b/src/lib/config/serviceContainer.ts
@@ -29,7 +29,7 @@ import type { ConsentService } from '@/core/consent/interfaces';
 import type { AuditService } from '@/core/audit/interfaces';
 import type { AdminService } from '@/core/admin/interfaces';
 import type { RoleService } from '@/core/role/interfaces';
-import type { CompanyAddressService } from '@/core/address/interfaces';
+import type { AddressService, CompanyAddressService } from '@/core/address/interfaces';
 import type { ResourceRelationshipService } from '@/core/resourceRelationship/interfaces';
 import type { OAuthService } from '@/core/oauth/interfaces';
 
@@ -56,7 +56,7 @@ import { getApiConsentService } from '@/services/consent/factory';
 import { getApiAuditService } from '@/services/audit/factory';
 import { getApiAdminService } from '@/services/admin/factory';
 import { getApiRoleService } from '@/services/role/factory';
-import { getApiAddressService } from '@/services/address/factory';
+import { getApiAddressService, getApiPersonalAddressService } from '@/services/address/factory';
 import { getApiResourceRelationshipService } from '@/services/resourceRelationship/factory';
 import { getApiCompanyNotificationService } from '@/services/companyNotification/factory';
 import { getApiOAuthService } from '@/services/oauth/factory';
@@ -233,6 +233,13 @@ export function getServiceContainer(overrides?: Partial<ServiceContainer>): Serv
     serviceInstances.address = getApiAddressService();
   }
 
+  // Create personal address service if not cached
+  if (!serviceInstances.addressService && globalServiceConfig.personalAddressService) {
+    serviceInstances.addressService = globalServiceConfig.personalAddressService;
+  } else if (!serviceInstances.addressService && globalServiceConfig.featureFlags?.addresses !== false) {
+    serviceInstances.addressService = getApiPersonalAddressService();
+  }
+
   // Create OAuth service if not cached
   if (!serviceInstances.oauth && globalServiceConfig.oauthService) {
     serviceInstances.oauth = globalServiceConfig.oauthService;
@@ -277,6 +284,7 @@ export function getServiceContainer(overrides?: Partial<ServiceContainer>): Serv
     admin: overrides?.admin || serviceInstances.admin,
     role: overrides?.role || serviceInstances.role,
     address: overrides?.address || serviceInstances.address,
+    addressService: overrides?.addressService || serviceInstances.addressService,
     oauth: overrides?.oauth || serviceInstances.oauth,
     companyNotification: overrides?.companyNotification || serviceInstances.companyNotification,
     resourceRelationship: overrides?.resourceRelationship || serviceInstances.resourceRelationship,
@@ -420,6 +428,19 @@ export function getConfiguredRoleService(override?: RoleService): RoleService | 
  */
 export function getConfiguredAddressService(override?: CompanyAddressService): CompanyAddressService | undefined {
   return override || globalServiceConfig.addressService || getApiAddressService();
+}
+
+/**
+ * Get a personal address service with fallback to global configuration
+ */
+export function getConfiguredPersonalAddressService(
+  override?: AddressService,
+): AddressService | undefined {
+  return (
+    override ||
+    globalServiceConfig.personalAddressService ||
+    getApiPersonalAddressService()
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- add `addressService` for personal addresses in ServiceContainer
- support optional override via `personalAddressService` config
- wire up factory to supply personal address service
- update address tests to use new config property

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run test -- --run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_68452bfabd2c8331a4a05933c4803bf2