### PR TITLE
Fix saved search route imports and permissions

### DIFF
--- a/app/api/admin/saved-searches/[id]/__tests__/route.test.ts
+++ b/app/api/admin/saved-searches/[id]/__tests__/route.test.ts
@@ -29,7 +29,7 @@ vi.mock("@/services/saved-search/factory", () => ({
   getApiSavedSearchService: vi.fn(),
 }));
 
-import { getApiSavedSearchService } from "@/services/savedSearch/factory";
+import { getApiSavedSearchService } from "@/services/saved-search/factory";
 
 function createReq(method: string) {
   return {

--- a/app/api/admin/saved-searches/[id]/route.ts
+++ b/app/api/admin/saved-searches/[id]/route.ts
@@ -9,10 +9,11 @@ import {
   errorHandlingMiddleware,
   routeAuthMiddleware,
   validationMiddleware,
-  type RouteAuthContext,
 } from "@/middleware/createMiddlewareChain";
+import type { RouteAuthContext } from "@/middleware/auth";
 import { withSecurity } from "@/middleware/withSecurity";
-import { getApiSavedSearchService } from "@/services/savedSearch/factory";
+import { getApiSavedSearchService } from "@/services/saved-search/factory";
+import { Permission } from "@/lib/rbac/roles";
 
 const updateSavedSearchSchema = z.object({
   name: z.string().min(1).optional(),
@@ -75,12 +76,12 @@ async function deleteSavedSearch(
 
 const baseMiddleware = createMiddlewareChain([
   errorHandlingMiddleware(),
-  routeAuthMiddleware({ requiredPermissions: ["admin.users.list"] }),
+  routeAuthMiddleware({ requiredPermissions: [Permission.ACCESS_ADMIN_DASHBOARD] }),
 ]);
 
 const patchMiddleware = createMiddlewareChain([
   errorHandlingMiddleware(),
-  routeAuthMiddleware({ requiredPermissions: ["admin.users.list"] }),
+  routeAuthMiddleware({ requiredPermissions: [Permission.ACCESS_ADMIN_DASHBOARD] }),
   validationMiddleware(updateSavedSearchSchema),
 ]);
 

--- a/app/api/admin/saved-searches/__tests__/route.test.ts
+++ b/app/api/admin/saved-searches/__tests__/route.test.ts
@@ -30,7 +30,7 @@ vi.mock("@/services/saved-search/factory", () => ({
   getApiSavedSearchService: vi.fn(),
 }));
 
-import { getApiSavedSearchService } from "@/services/savedSearch/factory";
+import { getApiSavedSearchService } from "@/services/saved-search/factory";
 
 function createRequest(method: string) {
   return {

--- a/app/api/admin/saved-searches/route.ts
+++ b/app/api/admin/saved-searches/route.ts
@@ -6,10 +6,11 @@ import {
   errorHandlingMiddleware,
   routeAuthMiddleware,
   validationMiddleware,
-  type RouteAuthContext,
 } from "@/middleware/createMiddlewareChain";
+import type { RouteAuthContext } from "@/middleware/auth";
 import { withSecurity } from "@/middleware/withSecurity";
-import { getApiSavedSearchService } from "@/services/savedSearch/factory";
+import { getApiSavedSearchService } from "@/services/saved-search/factory";
+import { Permission } from "@/lib/rbac/roles";
 
 const savedSearchParamsSchema = z.object({
   query: z.string().optional(),
@@ -63,12 +64,12 @@ async function createSavedSearch(
 
 const getMiddleware = createMiddlewareChain([
   errorHandlingMiddleware(),
-  routeAuthMiddleware({ requiredPermissions: ["admin.users.list"] }),
+  routeAuthMiddleware({ requiredPermissions: [Permission.ACCESS_ADMIN_DASHBOARD] }),
 ]);
 
 const postMiddleware = createMiddlewareChain([
   errorHandlingMiddleware(),
-  routeAuthMiddleware({ requiredPermissions: ["admin.users.list"] }),
+  routeAuthMiddleware({ requiredPermissions: [Permission.ACCESS_ADMIN_DASHBOARD] }),
   validationMiddleware(createSavedSearchSchema),
 ]);
 


### PR DESCRIPTION
## Summary
- fix path for saved-search service imports
- import RouteAuthContext from correct module
- require ACCESS_ADMIN_DASHBOARD permission instead of raw string

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_68452c40092483319907e703cff2d052