### PR TITLE
Fix vitest type errors in API tests

### DIFF
--- a/app/api/auth/check-permission/__tests__/route.test.ts
+++ b/app/api/auth/check-permission/__tests__/route.test.ts
@@ -22,7 +22,7 @@ beforeEach(() => {
     permissionService: mockService as PermissionService,
     authService: mockAuth as AuthService,
   });
-  vi.mocked(mockService.hasPermission).mockResolvedValue(true);
+  vi.mocked(mockService.hasPermission!).mockResolvedValue(true);
 });
 
 function createRequest(body: any) {

--- a/app/api/auth/check-permissions/__tests__/route.test.ts
+++ b/app/api/auth/check-permissions/__tests__/route.test.ts
@@ -20,7 +20,7 @@ beforeEach(() => {
     permissionService: mockService as PermissionService,
     authService: mockAuth as AuthService,
   });
-  vi.mocked(mockService.hasPermission).mockResolvedValue(true);
+  vi.mocked(mockService.hasPermission!).mockResolvedValue(true);
 });
 
 function createReq(body: any) {

--- a/app/api/auth/check-role/__tests__/route.test.ts
+++ b/app/api/auth/check-role/__tests__/route.test.ts
@@ -20,7 +20,7 @@ beforeEach(() => {
     permissionService: mockService as PermissionService,
     authService: mockAuth as AuthService,
   });
-  vi.mocked(mockService.hasRole).mockResolvedValue(true);
+  vi.mocked(mockService.hasRole!).mockResolvedValue(true);
 });
 
 function makeReq(body: any) {

--- a/app/api/auth/delete-account/__tests__/route.test.ts
+++ b/app/api/auth/delete-account/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { NextRequest } from 'next/server';
 import { DELETE } from '@app/api/auth/delete-account/route';
 import { getApiAuthService } from '@/services/auth/factory';
@@ -21,7 +21,7 @@ describe('DELETE /api/auth/delete-account', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    (getApiAuthService as unknown as Mock).mockReturnValue(mockAuthService);
     mockAuthService.deleteAccount.mockResolvedValue(undefined);
   });
 

--- a/app/api/auth/mfa/disable/__tests__/route.test.ts
+++ b/app/api/auth/mfa/disable/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { NextRequest } from 'next/server';
 import { POST } from '@app/api/auth/mfa/disable/route';
 import { getApiAuthService } from '@/services/auth/factory';
@@ -22,7 +22,7 @@ describe('POST /api/auth/mfa/disable', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    (getApiAuthService as unknown as Mock).mockReturnValue(mockAuthService);
     mockAuthService.disableMFA.mockResolvedValue({ success: true });
   });
 

--- a/app/api/auth/mfa/enable/__tests__/route.test.ts
+++ b/app/api/auth/mfa/enable/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { POST } from '@app/api/auth/mfa/enable/route';
 import { getApiAuthService } from '@/services/auth/factory';
 import { createRateLimit } from '@/middleware/rateLimit';
@@ -17,7 +17,7 @@ describe('POST /api/auth/mfa/enable', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    (getApiAuthService as unknown as Mock).mockReturnValue(mockAuthService);
     mockAuthService.setupMFA.mockResolvedValue({ success: true });
   });
 

--- a/app/api/auth/mfa/verify/route.ts
+++ b/app/api/auth/mfa/verify/route.ts
@@ -26,7 +26,7 @@ export const POST = createApiHandler(
     const userAgent = request.headers.get("user-agent") || "unknown";
 
     try {
-      const { code, method, accessToken, rememberDevice } = data;
+      const { code, method = TwoFactorMethod.TOTP, accessToken, rememberDevice } = data;
 
       // Verify MFA code using the AuthService
       const verifyResult = await services.auth.verifyMfaCode({

--- a/app/api/auth/my-permissions/__tests__/route.test.ts
+++ b/app/api/auth/my-permissions/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { GET } from '@app/api/auth/my-permissions/route';
 import { getApiPermissionService } from '@/services/permission/factory';
 
@@ -19,7 +19,7 @@ const mockService = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  (getApiPermissionService as unknown as vi.Mock).mockReturnValue(mockService);
+  (getApiPermissionService as unknown as Mock).mockReturnValue(mockService);
   mockService.getUserRoles.mockResolvedValue([{ roleId: 'r1' }]);
   mockService.getRoleById.mockResolvedValue({ name: 'ADMIN', permissions: ['P1'] });
 });

--- a/app/api/auth/oauth/__tests__/route.test.ts
+++ b/app/api/auth/oauth/__tests__/route.test.ts
@@ -1,8 +1,9 @@
-let POST: (req: Request) => Promise<Response>;
+import { NextRequest, NextResponse } from 'next/server';
+let POST: (req: NextRequest) => Promise<NextResponse>;
 // import { cookies } from 'next/headers';
 // import { NextResponse } from 'next/server';
 import { OAuthProvider } from "@/types/oauth";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { getServiceContainer } from '@/lib/config/serviceContainer';
 
 // --- Mocks ---
@@ -103,7 +104,7 @@ describe("POST /api/auth/oauth", () => {
     process.env.NEXT_PUBLIC_APPLE_REDIRECT_URI =
       "http://localhost:3000/api/auth/oauth/callback";
 
-    (getServiceContainer as vi.Mock).mockReturnValue(mockServices);
+    (getServiceContainer as Mock).mockReturnValue(mockServices);
     mockService.getOAuthAuthorizationUrl.mockReturnValue(
       'https://example.com/auth'
     );

--- a/app/api/auth/oauth/link/__tests__/route.test.ts
+++ b/app/api/auth/oauth/link/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 import { POST } from '@app/api/auth/oauth/link/route';
 import { OAuthProvider } from '@/types/oauth';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { getServiceContainer } from '@/lib/config/serviceContainer';
 
 vi.mock('@/lib/config/service-container', () => ({
@@ -21,7 +21,7 @@ const createRequest = (body: object) =>
 describe('POST /api/auth/oauth/link', () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    (getServiceContainer as vi.Mock).mockReturnValue({ oauth: mockService });
+    (getServiceContainer as Mock).mockReturnValue({ oauth: mockService });
   });
 
   it('returns error when service fails', async () => {

--- a/app/api/auth/oauth/verify/__tests__/route.test.ts
+++ b/app/api/auth/oauth/verify/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 import { POST } from '@app/api/auth/oauth/verify/route';
 import { OAuthProvider } from '@/types/oauth';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { getServiceContainer } from '@/lib/config/serviceContainer';
 
 // Mock cookies
@@ -41,7 +41,7 @@ describe('oauth verify route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCookies.clear();
-    (getServiceContainer as vi.Mock).mockReturnValue({ oauth: mockService });
+    (getServiceContainer as Mock).mockReturnValue({ oauth: mockService });
     mockService.verifyProviderEmail.mockResolvedValue({ success: true });
   });
 

--- a/app/api/auth/passwordless/__tests__/route.test.ts
+++ b/app/api/auth/passwordless/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { POST } from '@app/api/auth/passwordless/route';
 import { getApiAuthService } from '@/services/auth/factory';
 
@@ -20,7 +20,7 @@ describe('POST /api/auth/passwordless', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    (getApiAuthService as unknown as Mock).mockReturnValue(mockAuthService);
     mockAuthService.sendMagicLink.mockResolvedValue({ success: true });
   });
 

--- a/app/api/auth/refresh-token/__tests__/route.test.ts
+++ b/app/api/auth/refresh-token/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { POST } from '@app/api/auth/refresh-token/route';
 import { getApiAuthService } from '@/services/auth/factory';
 import { createRateLimit } from '@/middleware/rateLimit';
@@ -17,7 +17,7 @@ describe('POST /api/auth/refresh-token', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    (getApiAuthService as unknown as Mock).mockReturnValue(mockAuthService);
     mockAuthService.refreshToken.mockResolvedValue(true);
     mockAuthService.getTokenExpiry.mockReturnValue(123);
   });

--- a/app/api/auth/setup-mfa/__tests__/route.test.ts
+++ b/app/api/auth/setup-mfa/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { POST } from '@app/api/auth/setup-mfa/route';
 import { getApiAuthService } from '@/services/auth/factory';
 
@@ -16,7 +16,7 @@ describe('POST /api/auth/setup-mfa', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    (getApiAuthService as unknown as Mock).mockReturnValue(mockAuthService);
     mockAuthService.setupMFA.mockResolvedValue({ success: true });
   });
 

--- a/app/api/auth/update-password/__tests__/route.test.ts
+++ b/app/api/auth/update-password/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { POST } from '@app/api/auth/update-password/route';
 import { getApiAuthService } from '@/services/auth/factory';
 import { createRateLimit } from '@/middleware/rateLimit';
@@ -26,7 +26,7 @@ describe('POST /api/auth/update-password', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    (getApiAuthService as unknown as Mock).mockReturnValue(mockAuthService);
     mockAuthService.getCurrentUser.mockResolvedValue({ id: '1' });
     mockAuthService.updatePassword.mockResolvedValue(undefined);
     mockAuthService.updatePasswordWithToken.mockResolvedValue({ success: true, user: { id: '1' } });

--- a/app/api/auth/verify-mfa/__tests__/route.test.ts
+++ b/app/api/auth/verify-mfa/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { POST } from '@app/api/auth/verify-mfa/route';
 import { getApiAuthService } from '@/services/auth/factory';
 
@@ -20,7 +20,7 @@ describe('POST /api/auth/verify-mfa', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    (getApiAuthService as unknown as Mock).mockReturnValue(mockAuthService);
     mockAuthService.verifyMFA.mockResolvedValue({ success: true });
   });
 

--- a/app/api/auth/verify-reset-token/__tests__/route.test.ts
+++ b/app/api/auth/verify-reset-token/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { POST } from '@app/api/auth/verify-reset-token/route';
 import { getApiAuthService } from '@/services/auth/factory';
 import { withAuthRateLimit } from '@/middleware/withAuthRateLimit';
@@ -21,7 +21,7 @@ describe('POST /api/auth/verify-reset-token', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    (getApiAuthService as unknown as Mock).mockReturnValue(mockAuthService);
     mockAuthService.verifyPasswordResetToken.mockResolvedValue({ valid: true });
   });
 


### PR DESCRIPTION
## Summary
- fix vi mocked object assertions in API tests
- adjust OAuth test types
- ensure MFA verify route defaults to totp method

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: various unrelated errors)*

------
https://chatgpt.com/codex/tasks/task_b_68452c8135788331aabdd4071b6aa8d1