### PR TITLE
Fix OAuth route tests typing

### DIFF
--- a/app/api/auth/oauth/disconnect/__tests__/route.test.ts
+++ b/app/api/auth/oauth/disconnect/__tests__/route.test.ts
@@ -73,11 +73,11 @@ describe('POST /api/auth/oauth/disconnect', () => {
     mockCookies.clear();
     // Assume user is logged in for most tests
     mockSupabaseAuth.getUser.mockResolvedValue({ data: { user: mockLoggedInUser }, error: null });
-    mockPermissionService.hasPermission!.mockResolvedValue(true);
+    vi.mocked(mockPermissionService.hasPermission!).mockResolvedValue(true);
     resetServiceContainer();
     configureServices({
       permissionService: mockPermissionService as PermissionService,
-      authService: { getCurrentUser: vi.fn().mockResolvedValue({ id: loggedInUserId }) } as AuthService,
+      authService: { getCurrentUser: vi.fn().mockResolvedValue({ id: loggedInUserId }) } as unknown as AuthService,
     });
   });
 
@@ -102,7 +102,7 @@ describe('POST /api/auth/oauth/disconnect', () => {
   });
 
 it('should return 403 if user lacks permission', async () => {
-    mockPermissionService.hasPermission.mockResolvedValue(false);
+    vi.mocked(mockPermissionService.hasPermission!).mockResolvedValue(false);
     const request = createRequest({ provider: providerToDisconnect });
     const response = await POST(request);
     const body = await response.json();

--- a/app/api/auth/oauth/link/__tests__/route.test.ts
+++ b/app/api/auth/oauth/link/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 import { POST } from '@app/api/auth/oauth/link/route';
 import { OAuthProvider } from '@/types/oauth';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { getServiceContainer } from '@/lib/config/serviceContainer';
 
 vi.mock('@/lib/config/service-container', () => ({
@@ -21,12 +21,12 @@ const createRequest = (body: object) =>
 describe('POST /api/auth/oauth/link', () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    (getServiceContainer as vi.Mock).mockReturnValue({ oauth: mockService });
+    (getServiceContainer as unknown as Mock).mockReturnValue({ oauth: mockService });
   });
 
   it('returns error when service fails', async () => {
     mockService.linkProvider.mockResolvedValue({ success: false, error: 'err', status: 400 });
-    const res = await POST(createRequest({ provider: OAuthProvider.GITHUB, code: 'x' }));
+    const res = await POST(createRequest({ provider: OAuthProvider.GITHUB, code: 'x' }) as any);
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: 'err' });
     expect(mockService.linkProvider).toHaveBeenCalledWith(OAuthProvider.GITHUB, 'x');
@@ -34,7 +34,7 @@ describe('POST /api/auth/oauth/link', () => {
 
   it('returns success data from service', async () => {
     mockService.linkProvider.mockResolvedValue({ success: true, user: { id: '1' }, linkedProviders: ['g'] });
-    const res = await POST(createRequest({ provider: OAuthProvider.GITHUB, code: 'y' }));
+    const res = await POST(createRequest({ provider: OAuthProvider.GITHUB, code: 'y' }) as any);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ success: true, linkedProviders: ['g'], user: { id: '1' } });
   });

--- a/app/api/auth/oauth/link/route.ts
+++ b/app/api/auth/oauth/link/route.ts
@@ -7,6 +7,7 @@ import {
   ERROR_CODES
 } from '@/lib/api/common';
 import { logUserAction } from '@/lib/audit/auditLogger';
+import { getApiOAuthService } from '@/services/oauth/factory';
 
 const linkRequestSchema = z.object({
   provider: z.nativeEnum(OAuthProvider),
@@ -19,7 +20,8 @@ export const POST = createApiHandler(
     const ipAddress = request.headers.get('x-forwarded-for') || 'unknown';
     const userAgent = request.headers.get('user-agent') || 'unknown';
 
-    const result = await services.oauth.linkProvider(data.provider, data.code);
+    const service = services.oauth ?? getApiOAuthService();
+    const result = await service.linkProvider(data.provider, data.code);
 
     await logUserAction({
       action: 'OAUTH_LINK',

--- a/app/api/auth/oauth/route.ts
+++ b/app/api/auth/oauth/route.ts
@@ -134,7 +134,7 @@ export const POST = createApiHandler(
     }
 
     const state = generateState();
-    const cookieStore = cookies();
+    const cookieStore = await cookies();
     cookieStore.set({
       name: `oauth_state_${data.provider}`,
       value: state,

--- a/app/api/auth/oauth/verify/__tests__/route.test.ts
+++ b/app/api/auth/oauth/verify/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 import { POST } from '@app/api/auth/oauth/verify/route';
 import { OAuthProvider } from '@/types/oauth';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { getServiceContainer } from '@/lib/config/serviceContainer';
 
 // Mock cookies
@@ -41,27 +41,27 @@ describe('oauth verify route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCookies.clear();
-    (getServiceContainer as vi.Mock).mockReturnValue({ oauth: mockService });
+    (getServiceContainer as unknown as Mock).mockReturnValue({ oauth: mockService });
     mockService.verifyProviderEmail.mockResolvedValue({ success: true });
   });
 
   it('returns 401 when unauthenticated', async () => {
     mockService.verifyProviderEmail.mockResolvedValueOnce({ success: false, status: 401, error: 'auth' });
     const request = createRequest({ providerId: OAuthProvider.GITHUB, email: 'new@example.com' });
-    const res = await POST(request);
+    const res = await POST(request as any);
     expect(res.status).toBe(401);
   });
 
   it('returns 409 when email already used by another user', async () => {
     mockService.verifyProviderEmail.mockResolvedValueOnce({ success: false, status: 409, error: 'exists' });
     const request = createRequest({ providerId: OAuthProvider.GITHUB, email: 'existing@example.com' });
-    const res = await POST(request);
+    const res = await POST(request as any);
     expect(res.status).toBe(409);
   });
 
   it('returns success and sends notification', async () => {
     const request = createRequest({ providerId: OAuthProvider.GITHUB, email: 'new@example.com' });
-    const res = await POST(request);
+    const res = await POST(request as any);
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.success).toBe(true);


### PR DESCRIPTION
## Summary
- fix typing in OAuth disconnect route tests
- cast mocks properly in OAuth link/verify route tests
- handle optional service in oauth link route
- await cookies in oauth route for Next.js 15

## Testing
- `vitest run --coverage` *(fails: useConnectedAccountsStore.mockReturnValue is not a function)*

------
https://chatgpt.com/codex/tasks/task_b_68452ca059cc8331a8e9335bc787e0e1