### PR TITLE
Fix admin export route compile errors

### DIFF
--- a/app/api/admin/export/route.ts
+++ b/app/api/admin/export/route.ts
@@ -8,8 +8,8 @@ import {
   errorHandlingMiddleware,
   routeAuthMiddleware,
   rateLimitMiddleware,
-  type RouteAuthContext,
 } from '@/middleware/createMiddlewareChain';
+import type { RouteAuthContext } from '@/middleware/auth';
 import { withSecurity } from '@/middleware/withSecurity';
 
 
@@ -43,7 +43,7 @@ async function handleGet(req: NextRequest, auth: RouteAuthContext) {
     });
   }
   const permissionService = getApiPermissionService();
-  const isAdmin = await permissionService.hasRole(user.id, 'admin');
+  const isAdmin = await permissionService.hasRole(user.id, 'ADMIN');
   if (!isAdmin) {
     // Log forbidden export attempt
     await logUserAction({

--- a/src/types/nextRequest.ts
+++ b/src/types/nextRequest.ts
@@ -1,0 +1,10 @@
+import 'next/server';
+
+declare module 'next/server' {
+  interface NextRequest {
+    /**
+     * Client IP address if known
+     */
+    ip?: string;
+  }
+}


### PR DESCRIPTION
## Summary
- fix import for `RouteAuthContext`
- ensure role check uses `ADMIN` constant
- add module augmentation for `NextRequest.ip`

## Testing
- `npx vitest run --coverage` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_b_68452c1ebf848331b75740ced0ad742b