### PR TITLE
Fix auth context types for company routes

### DIFF
--- a/app/api/company/documents/[documentId]/route.ts
+++ b/app/api/company/documents/[documentId]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { getApiCompanyService } from "@/services/company/factory";
-import { type RouteAuthContext } from "@/middleware/auth";
+import type { AuthContext } from "@/core/config/interfaces";
 import { createApiHandler } from "@/lib/api/routeHelpers";
 import { createSuccessResponse } from "@/lib/api/common";
 
@@ -10,7 +10,7 @@ import { createSuccessResponse } from "@/lib/api/common";
 async function handleDelete(
   _request: NextRequest,
   params: { documentId: string },
-  auth: RouteAuthContext,
+  auth: AuthContext,
 ) {
   try {
     const companyService = getApiCompanyService();

--- a/app/api/company/documents/route.ts
+++ b/app/api/company/documents/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { z } from "zod";
 import { getApiCompanyService } from "@/services/company/factory";
-import { type RouteAuthContext } from "@/middleware/auth";
+import type { AuthContext } from "@/core/config/interfaces";
 import { withSecurity } from "@/middleware/withSecurity";
 import { createApiHandler } from "@/lib/api/routeHelpers";
 import {
@@ -40,7 +40,7 @@ const ALLOWED_MIME_TYPES = [
 // --- POST Handler for uploading company documents ---
 async function handlePost(
   _request: NextRequest,
-  auth: RouteAuthContext,
+  auth: AuthContext,
   data: DocumentUploadRequest,
 ) {
   try {
@@ -86,7 +86,7 @@ async function handlePost(
 // --- GET Handler for fetching company documents ---
 async function handleGet(
   request: NextRequest,
-  auth: RouteAuthContext,
+  auth: AuthContext,
   _data: unknown,
 ) {
   try {

--- a/app/api/company/domains/[id]/route.ts
+++ b/app/api/company/domains/[id]/route.ts
@@ -10,6 +10,7 @@ import {
 import { z } from "zod";
 import { checkPermission } from "@/lib/auth/permissionCheck";
 import { PermissionValues } from "@/core/permission/models";
+import { type RouteAuthContext } from "@/middleware/auth";
 
 // Validation schema for updating a domain
 const domainUpdateSchema = z.object({

--- a/app/api/company/domains/__tests__/route.test.ts
+++ b/app/api/company/domains/__tests__/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest';
-import { GET, POST, DELETE, PATCH } from '@app/api/company/domains/route';
+import { GET, POST } from '@app/api/company/domains/route';
+import { DELETE, PATCH } from '@app/api/company/domains/[id]/route';
 import { getApiCompanyService } from '@/services/company/factory';
 import { createAuthenticatedRequest } from '@/tests/utils/requestHelpers';
 


### PR DESCRIPTION
## Summary
- use `AuthContext` for company documents route handlers
- update document deletion handler signature
- import `RouteAuthContext` where missing
- correct test imports for domain routes

## Testing
- `npx vitest run --coverage` *(fails: ReferenceError indexedDB is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_68452cf501e4833190f9a91231b68fc8