### PR TITLE
Fix TS errors in auth tests

### DIFF
--- a/app/api/auth/check-permission/__tests__/route.test.ts
+++ b/app/api/auth/check-permission/__tests__/route.test.ts
@@ -22,7 +22,7 @@ beforeEach(() => {
     permissionService: mockService as PermissionService,
     authService: mockAuth as AuthService,
   });
-  vi.mocked(mockService.hasPermission).mockResolvedValue(true);
+  vi.mocked(mockService.hasPermission!).mockResolvedValue(true);
 });
 
 function createRequest(body: any) {

--- a/app/api/auth/check-permissions/__tests__/route.test.ts
+++ b/app/api/auth/check-permissions/__tests__/route.test.ts
@@ -20,7 +20,7 @@ beforeEach(() => {
     permissionService: mockService as PermissionService,
     authService: mockAuth as AuthService,
   });
-  vi.mocked(mockService.hasPermission).mockResolvedValue(true);
+  vi.mocked(mockService.hasPermission!).mockResolvedValue(true);
 });
 
 function createReq(body: any) {

--- a/app/api/auth/check-role/__tests__/route.test.ts
+++ b/app/api/auth/check-role/__tests__/route.test.ts
@@ -20,7 +20,7 @@ beforeEach(() => {
     permissionService: mockService as PermissionService,
     authService: mockAuth as AuthService,
   });
-  vi.mocked(mockService.hasRole).mockResolvedValue(true);
+  vi.mocked(mockService.hasRole!).mockResolvedValue(true);
 });
 
 function makeReq(body: any) {

--- a/app/api/auth/delete-account/__tests__/route.test.ts
+++ b/app/api/auth/delete-account/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { NextRequest } from 'next/server';
 import { DELETE } from '../route';
 import { getApiAuthService } from '@/services/auth/factory';
@@ -21,7 +21,7 @@ describe('DELETE /api/auth/delete-account', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+    (getApiAuthService as unknown as Mock).mockReturnValue(mockAuthService);
     mockAuthService.deleteAccount.mockResolvedValue(undefined);
   });
 

--- a/app/api/auth/mfa/disable/__tests__/route.test.ts
+++ b/app/api/auth/mfa/disable/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { NextRequest } from 'next/server';
 import { POST } from '../route';
 import { getApiAuthService } from '@/services/auth/factory';
@@ -22,7 +22,7 @@ describe('POST /api/auth/mfa/disable', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+      (getApiAuthService as unknown as Mock).mockReturnValue(mockAuthService);
     mockAuthService.disableMFA.mockResolvedValue({ success: true });
   });
 

--- a/app/api/auth/mfa/enable/__tests__/route.test.ts
+++ b/app/api/auth/mfa/enable/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { POST } from '../route';
 import { getApiAuthService } from '@/services/auth/factory';
 import { createRateLimit } from '@/middleware/rate-limit';
@@ -17,7 +17,7 @@ describe('POST /api/auth/mfa/enable', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (getApiAuthService as unknown as vi.Mock).mockReturnValue(mockAuthService);
+      (getApiAuthService as unknown as Mock).mockReturnValue(mockAuthService);
     mockAuthService.setupMFA.mockResolvedValue({ success: true });
   });
 

--- a/app/api/auth/mfa/verify/route.ts
+++ b/app/api/auth/mfa/verify/route.ts
@@ -29,12 +29,12 @@ export const POST = createApiHandler(
       const { code, method, accessToken, rememberDevice } = data;
 
       // Verify MFA code using the AuthService
-      const verifyResult = await services.auth.verifyMfaCode({
-        code,
-        method,
-        accessToken,
-        rememberDevice: rememberDevice || false,
-      });
+        const verifyResult = await services.auth.verifyMfaCode({
+          code,
+          method: method as TwoFactorMethod,
+          accessToken,
+          rememberDevice: rememberDevice || false,
+        });
 
       // Log the MFA verification attempt
       await logUserAction({

--- a/app/api/auth/my-permissions/__tests__/route.test.ts
+++ b/app/api/auth/my-permissions/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { GET } from '../route';
 import { getApiPermissionService } from '@/services/permission/factory';
 
@@ -19,7 +19,7 @@ const mockService = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  (getApiPermissionService as unknown as vi.Mock).mockReturnValue(mockService);
+  (getApiPermissionService as unknown as Mock).mockReturnValue(mockService);
   mockService.getUserRoles.mockResolvedValue([{ roleId: 'r1' }]);
   mockService.getRoleById.mockResolvedValue({ name: 'ADMIN', permissions: ['P1'] });
 });

--- a/app/api/auth/oauth/__tests__/route.test.ts
+++ b/app/api/auth/oauth/__tests__/route.test.ts
@@ -2,7 +2,7 @@ let POST: (req: Request) => Promise<Response>;
 // import { cookies } from 'next/headers';
 // import { NextResponse } from 'next/server';
 import { OAuthProvider } from "@/types/oauth";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { getServiceContainer } from '@/lib/config/service-container';
 
 // --- Mocks ---
@@ -103,11 +103,11 @@ describe("POST /api/auth/oauth", () => {
     process.env.NEXT_PUBLIC_APPLE_REDIRECT_URI =
       "http://localhost:3000/api/auth/oauth/callback";
 
-    (getServiceContainer as vi.Mock).mockReturnValue(mockServices);
+      (getServiceContainer as Mock).mockReturnValue(mockServices);
     mockService.getOAuthAuthorizationUrl.mockReturnValue(
       'https://example.com/auth'
     );
-    POST = (await import("../route")).POST;
+      POST = (await import("../route")).POST as unknown as (req: Request) => Promise<Response>;
   });
 
   it("should return authorization URL and state for a valid provider (Google)", async () => {


### PR DESCRIPTION
## Summary
- address optional property warnings in several auth API tests
- cast mock service types correctly using `Mock` from vitest
- ensure `method` param is typed in mfa verify route
- adapt OAuth test POST import to satisfy expected signature

## Testing
- `npx vitest run --coverage` *(fails: ReferenceError: indexedDB is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68453324df80833194baebd806769af3