### PR TITLE
Fix auth context types

### DIFF
--- a/app/api/company/addresses/[addressId]/route.ts
+++ b/app/api/company/addresses/[addressId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { type RouteAuthContext } from "@/middleware/auth";
+import type { AuthContext } from "@/core/config/interfaces";
 import { addressUpdateSchema } from "@/core/address/models";
 import { createApiHandler } from "@/lib/api/route-helpers";
 import { createSuccessResponse } from "@/lib/api/common";
@@ -13,7 +13,7 @@ type AddressUpdateRequest = z.infer<typeof addressUpdateSchema>;
 async function handlePut(
   _request: NextRequest,
   params: { addressId: string },
-  auth: RouteAuthContext,
+  auth: AuthContext,
   data: AddressUpdateRequest,
 ) {
   try {
@@ -59,7 +59,7 @@ async function handlePut(
 async function handleDelete(
   _request: NextRequest,
   params: { addressId: string },
-  auth: RouteAuthContext,
+  auth: AuthContext,
 ) {
   try {
     const userId = auth.userId!;

--- a/app/api/company/addresses/route.ts
+++ b/app/api/company/addresses/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { type RouteAuthContext } from "@/middleware/auth";
+import type { AuthContext } from "@/core/config/interfaces";
 import { addressCreateSchema } from "@/core/address/models";
 import { createApiHandler } from "@/lib/api/route-helpers";
 import { createSuccessResponse } from "@/lib/api/common";
@@ -11,7 +11,7 @@ type AddressRequest = z.infer<typeof addressCreateSchema>;
 
 async function handlePost(
   _request: NextRequest,
-  auth: RouteAuthContext,
+  auth: AuthContext,
   data: AddressRequest,
 ) {
   try {
@@ -51,7 +51,7 @@ async function handlePost(
 
 async function handleGet(
   _request: NextRequest,
-  auth: RouteAuthContext,
+  auth: AuthContext,
   _data: unknown,
 ) {
   try {

--- a/app/api/company/documents/[documentId]/route.ts
+++ b/app/api/company/documents/[documentId]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { getApiCompanyService } from "@/services/company/factory";
-import { type RouteAuthContext } from "@/middleware/auth";
+import type { AuthContext } from "@/core/config/interfaces";
 import { createApiHandler } from "@/lib/api/route-helpers";
 import { createSuccessResponse } from "@/lib/api/common";
 
@@ -10,7 +10,7 @@ import { createSuccessResponse } from "@/lib/api/common";
 async function handleDelete(
   _request: NextRequest,
   params: { documentId: string },
-  auth: RouteAuthContext,
+  auth: AuthContext,
 ) {
   try {
     const companyService = getApiCompanyService();

--- a/app/api/company/documents/route.ts
+++ b/app/api/company/documents/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { z } from "zod";
 import { getApiCompanyService } from "@/services/company/factory";
-import { type RouteAuthContext } from "@/middleware/auth";
+import type { AuthContext } from "@/core/config/interfaces";
 import { withSecurity } from "@/middleware/with-security";
 import { createApiHandler } from "@/lib/api/route-helpers";
 import {
@@ -40,7 +40,7 @@ const ALLOWED_MIME_TYPES = [
 // --- POST Handler for uploading company documents ---
 async function handlePost(
   _request: NextRequest,
-  auth: RouteAuthContext,
+  auth: AuthContext,
   data: DocumentUploadRequest,
 ) {
   try {
@@ -86,7 +86,7 @@ async function handlePost(
 // --- GET Handler for fetching company documents ---
 async function handleGet(
   request: NextRequest,
-  auth: RouteAuthContext,
+  auth: AuthContext,
   _data: unknown,
 ) {
   try {


### PR DESCRIPTION
## Summary
- fix auth context types for company documents and addresses API handlers

## Testing
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_6845334a10408331b6c3d47cc02ea70d