### PR TITLE
Fix type mismatch in address API route

### DIFF
--- a/app/api/company/addresses/route.ts
+++ b/app/api/company/addresses/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { type RouteAuthContext } from "@/middleware/auth";
+import type { AuthContext } from "@/core/config/interfaces";
 import { addressCreateSchema } from "@/core/address/models";
 import { createApiHandler } from "@/lib/api/routeHelpers";
 import { createSuccessResponse } from "@/lib/api/common";
@@ -11,7 +11,7 @@ type AddressRequest = z.infer<typeof addressCreateSchema>;
 
 async function handlePost(
   _request: NextRequest,
-  auth: RouteAuthContext,
+  auth: AuthContext,
   data: AddressRequest,
 ) {
   try {
@@ -51,7 +51,7 @@ async function handlePost(
 
 async function handleGet(
   _request: NextRequest,
-  auth: RouteAuthContext,
+  auth: AuthContext,
   _data: unknown,
 ) {
   try {


### PR DESCRIPTION
## Summary
- fix `company/addresses` route to use AuthContext

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npx vitest run --coverage` *(fails: act errors, missing env, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6845424f7a388331b9b00c4b41728451