### PR TITLE
Add mock ApiKey service factory

### DIFF
--- a/src/tests/factories/mockApiKeyService.ts
+++ b/src/tests/factories/mockApiKeyService.ts
@@ -1,0 +1,11 @@
+import { vi } from "vitest";
+export const createMockApiKeyService = () => ({
+  listApiKeys: vi.fn().mockResolvedValue([]),
+  createApiKey: vi.fn().mockResolvedValue({ 
+    success: true, 
+    key: { id: 'k1', name: 'test-key', scopes: [] }, 
+    plaintext: 'secret-key' 
+  }),
+  revokeApiKey: vi.fn().mockResolvedValue({ success: true }),
+  updateApiKey: vi.fn().mockResolvedValue({ success: true }),
+});


### PR DESCRIPTION
## Summary
- add `createMockApiKeyService` factory under `src/tests/factories`

## Testing
- `npm run test:coverage` *(fails: ReferenceError indexedDB is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6849b234826083319245c91a7a012d6f