### PR TITLE
Add mock middleware factory

### DIFF
--- a/src/tests/factories/mockMiddleware.test.ts
+++ b/src/tests/factories/mockMiddleware.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockMiddleware } from '@/tests/factories/mockMiddleware';
+
+// Basic tests to verify middleware factory behavior
+
+describe('createMockMiddleware', () => {
+  it('withSecurity returns the same handler', () => {
+    const { withSecurity } = createMockMiddleware();
+    const handler = vi.fn();
+    const wrapped = withSecurity(handler);
+    expect(wrapped).toBe(handler);
+    expect(withSecurity).toHaveBeenCalledWith(handler);
+  });
+
+  it('withAuthRateLimit returns the same handler', () => {
+    const { withAuthRateLimit } = createMockMiddleware();
+    const handler = vi.fn();
+    const req = {} as any;
+    const wrapped = withAuthRateLimit(req, handler);
+    expect(wrapped).toBe(handler);
+    expect(withAuthRateLimit).toHaveBeenCalledWith(req, handler);
+  });
+
+  it('routeAuthMiddleware injects userId', async () => {
+    const { routeAuthMiddleware } = createMockMiddleware();
+    const handler = vi.fn().mockResolvedValue('ok');
+    const middleware = routeAuthMiddleware();
+    const result = await middleware(handler)({} as any, undefined as any, { data: 1 });
+    expect(handler).toHaveBeenCalledWith({}, { userId: 'u1' }, { data: 1 });
+    expect(result).toBe('ok');
+  });
+
+  it('checkRateLimit resolves to false', async () => {
+    const { checkRateLimit } = createMockMiddleware();
+    await expect(checkRateLimit()).resolves.toBe(false);
+  });
+});

--- a/src/tests/factories/mockMiddleware.ts
+++ b/src/tests/factories/mockMiddleware.ts
@@ -1,0 +1,8 @@
+export const createMockMiddleware = () => ({
+  withSecurity: vi.fn((handler) => handler),
+  withAuthRateLimit: vi.fn((_req, handler) => handler),
+  routeAuthMiddleware: vi.fn(() => (handler) => (req, _ctx, data) =>
+    handler(req, { userId: 'u1' }, data)
+  ),
+  checkRateLimit: vi.fn().mockResolvedValue(false),
+});


### PR DESCRIPTION
## Summary
- add a mock middleware factory used in tests
- add unit tests for the factory

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_6849b2bc94dc83319f23cf3e70846924