### PR TITLE
Add mock store factory utilities

### DIFF
--- a/src/tests/factories/mockStores.test.ts
+++ b/src/tests/factories/mockStores.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockProfileStore, createMockOAuthStore } from '@/tests/factories/mockStores';
+
+describe('createMockProfileStore', () => {
+  it('returns default profile store with mock functions', () => {
+    const store = createMockProfileStore();
+    expect(store.profile).toEqual({ id: 'u1', firstName: 'Test', lastName: 'User' });
+    expect(store.isLoading).toBe(false);
+    expect(store.error).toBeNull();
+    expect(vi.isMockFunction(store.updateProfile)).toBe(true);
+    expect(vi.isMockFunction(store.uploadAvatar)).toBe(true);
+    expect(vi.isMockFunction(store.setProfile)).toBe(true);
+  });
+});
+
+describe('createMockOAuthStore', () => {
+  it('returns default oauth store with mock functions', () => {
+    const store = createMockOAuthStore();
+    expect(store.isLoading).toBe(false);
+    expect(store.error).toBeNull();
+    expect(vi.isMockFunction(store.login)).toBe(true);
+    expect(vi.isMockFunction(store.clearError)).toBe(true);
+  });
+});
+

--- a/src/tests/factories/mockStores.ts
+++ b/src/tests/factories/mockStores.ts
@@ -1,0 +1,17 @@
+import { vi } from "vitest";
+export const createMockProfileStore = () => ({
+  profile: { id: 'u1', firstName: 'Test', lastName: 'User' },
+  isLoading: false,
+  error: null,
+  updateProfile: vi.fn(),
+  uploadAvatar: vi.fn(),
+  setProfile: vi.fn(),
+});
+
+export const createMockOAuthStore = () => ({
+  login: vi.fn(),
+  isLoading: false,
+  error: null,
+  clearError: vi.fn(),
+});
+


### PR DESCRIPTION
## Summary
- provide simple mock store factories for profile and OAuth stores
- add unit tests for the new factories

## Testing
- `npx vitest run --coverage` *(fails: environment limits)*

------
https://chatgpt.com/codex/tasks/task_b_6849b294b86483318f5f9fcd4fc1370e