### PR TITLE
Add mock auth service factory

### DIFF
--- a/src/tests/factories/mockAuthService.ts
+++ b/src/tests/factories/mockAuthService.ts
@@ -1,0 +1,10 @@
+export const createMockAuthService = () => ({
+  getCurrentUser: vi.fn().mockResolvedValue({ id: 'u1', email: 'test@example.com' }),
+  deleteAccount: vi.fn().mockResolvedValue(undefined),
+  updatePassword: vi.fn().mockResolvedValue({ success: true }),
+  login: vi.fn().mockResolvedValue({ success: true }),
+  logout: vi.fn().mockResolvedValue(undefined),
+  refreshToken: vi.fn().mockResolvedValue({ token: 'new-token' }),
+  sendVerificationEmail: vi.fn().mockResolvedValue({ success: true }),
+  verifyEmail: vi.fn().mockResolvedValue({ success: true }),
+});


### PR DESCRIPTION
## Summary
- add `createMockAuthService` factory for tests

## Testing
- `npm run test:coverage` *(fails: ReferenceError: indexedDB is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_6849b1aeb0bc83319312b3acad5dd8b3