### PR TITLE
Add mockExternalDeps factory

### DIFF
--- a/src/tests/factories/mockExternalDeps.ts
+++ b/src/tests/factories/mockExternalDeps.ts
@@ -1,0 +1,18 @@
+import { vi } from "vitest";
+export const createMockExternalDeps = () => ({
+  // WebAuthn
+  startRegistration: vi.fn().mockResolvedValue({ credential: 'cred123' }),
+  startAuthentication: vi.fn().mockResolvedValue({ credential: 'auth123' }),
+  
+  // Next.js
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => '/',
+  
+  // Toast/UI
+  useToast: () => ({ toast: vi.fn() }),
+});


### PR DESCRIPTION
## Summary
- add a factory for mocking external dependencies used in tests

## Testing
- `vitest run --coverage` *(fails: `useConnectedAccountsStore.mockReturnValue is not a function` and other issues)*

------
https://chatgpt.com/codex/tasks/task_b_6849b2d51f548331beeae7f11e445944