### PR TITLE
Fix sessionId route handler

### DIFF
--- a/app/api/session/[sessionId]/route.ts
+++ b/app/api/session/[sessionId]/route.ts
@@ -1,17 +1,29 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getUserFromRequest } from '@/lib/auth/utils';
+import { type NextRequest } from 'next/server';
+import { createApiHandler, emptySchema } from '@/lib/api/route-helpers';
+import { createSuccessResponse, createServerError } from '@/lib/api/common';
 import { getApiSessionService } from '@/services/session/factory';
 
-// DELETE /api/session/:sessionId - Revoke a specific session for the current user
-export async function DELETE(req: NextRequest, { params }: { params: { sessionId: string } }) {
-  const user = await getUserFromRequest(req);
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const { sessionId } = params;
+async function handleDelete(
+  _req: NextRequest,
+  ctx: any,
+  _data: unknown,
+  params: { sessionId: string },
+) {
   const service = getApiSessionService();
-  try {
-    await service!.revokeUserSession(user.id, sessionId);
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    return NextResponse.json({ error: 'Failed to revoke session' }, { status: 500 });
+  const result = await service!.revokeUserSession(ctx.userId!, params.sessionId);
+  if (!result.success) {
+    throw createServerError(result.error || 'Failed to revoke session');
   }
+  return createSuccessResponse({ success: true });
 }
+
+// DELETE /api/session/:sessionId - Revoke a specific session for the current user
+export const DELETE = (
+  req: NextRequest,
+  ctx: { params: { sessionId: string } },
+) =>
+  createApiHandler(
+    emptySchema,
+    (r, auth, data) => handleDelete(r, auth, data, ctx.params),
+    { requireAuth: true },
+  )(req);


### PR DESCRIPTION
## Summary
- update `/api/session/[sessionId]` to use `createApiHandler`
- improve middleware compatibility for session deletion

## Testing
- `npx vitest run --coverage` *(fails: Adapter 'user' not registered, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_684c10a2d8888331bdc82ad762ba77f8