### PR TITLE
Fix role permissions typing

### DIFF
--- a/src/lib/rbac/roles.ts
+++ b/src/lib/rbac/roles.ts
@@ -34,10 +34,16 @@ export const Permission = {
 
 export type Permission = typeof Permission[keyof typeof Permission];
 
+export interface RoleInfo {
+  name: string;
+  description: string;
+  permissions: readonly Permission[];
+}
+
 /**
  * Defines the standard roles and their associated permissions
  */
-export const RoleDefinition = {
+export const RoleDefinition: Record<string, RoleInfo> = {
   ADMIN: {
     name: 'Admin',
     description: 'Full access to all features and settings',
@@ -76,7 +82,7 @@ export const RoleDefinition = {
       Permission.VIEW_PROJECTS,
     ],
   },
-} as const;
+};
 
 export type RoleType = keyof typeof RoleDefinition;
 
@@ -102,7 +108,7 @@ export function isRole(value: string): value is RoleType {
 /**
  * Get permissions for a specific role
  */
-export function getPermissionsForRole(role: RoleType): Permission[] {
+export function getPermissionsForRole(role: RoleType): readonly Permission[] {
   return RoleDefinition[role].permissions;
 }
 


### PR DESCRIPTION
## Summary
- ensure role permissions arrays are treated as readonly
- adjust `getPermissionsForRole` return type

## Testing
- `npx tsc --noEmit -p tsconfig.json`
- `npx vitest run --coverage` *(fails: Element type is invalid; testing environment not configured for act)*

------
https://chatgpt.com/codex/tasks/task_b_684c1a47bb248331bdb83d0d5320d853