### PR TITLE
Fix session route params and team roles middleware

### DIFF
--- a/app/api/session/[sessionId]/route.ts
+++ b/app/api/session/[sessionId]/route.ts
@@ -6,7 +6,7 @@ import { getApiSessionService } from '@/services/session/factory';
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ sessionId: string }> }) {
   const user = await getUserFromRequest(req);
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const { sessionId } = params;
+  const { sessionId } = await params;
   const service = getApiSessionService();
   try {
     await service!.revokeUserSession(user.id, sessionId);

--- a/app/api/team/roles/route.ts
+++ b/app/api/team/roles/route.ts
@@ -1,3 +1,4 @@
+import { type NextRequest } from 'next/server';
 import { createSuccessResponse } from '@/lib/api/common';
 import { getAllRoles } from '@/lib/rbac/roles';
 import {
@@ -14,6 +15,6 @@ const middleware = createMiddlewareChain([
   errorHandlingMiddleware()
 ]);
 
-export function GET() {
-  return middleware(() => handleGet())();
+export function GET(req: NextRequest) {
+  return middleware(() => handleGet())(req);
 }


### PR DESCRIPTION
## Summary
- await params when retrieving `sessionId` in session route
- pass `NextRequest` to middleware in team roles route

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684c1a081634833190370129c1c46bd7