### PR TITLE
Fix deleteAccount typing

### DIFF
--- a/src/hooks/auth/__tests__/useAuth.test.tsx
+++ b/src/hooks/auth/__tests__/useAuth.test.tsx
@@ -198,7 +198,7 @@ describe("useAuth hook", () => {
   it("verifies email and deletes account", async () => {
     (mockAuthService.sendVerificationEmail as any).mockResolvedValue({ success: true });
     (mockAuthService.verifyEmail as any).mockResolvedValue(undefined);
-    (mockAuthService.deleteAccount as any).mockResolvedValue(undefined);
+    (mockAuthService.deleteAccount as any).mockResolvedValue({ success: true });
     const { result } = renderHook(() => useAuth(), { wrapper });
     await act(async () => {
       await result.current.sendVerificationEmail("a@test.com");

--- a/src/lib/stores/auth.store.ts
+++ b/src/lib/stores/auth.store.ts
@@ -94,7 +94,9 @@ export const useAuthStore = () => {
     },
 
 
-    deleteAccount: async (password?: string): Promise<void> => {
+    deleteAccount: async (
+      password?: string | { userId: string; password: string },
+    ): Promise<{ success: boolean; error?: string }> => {
       console.log('[DEPRECATED] Using auth.store deleteAccount - please migrate to useAuth');
       return auth.deleteAccount(password);
     }

--- a/src/services/auth/__tests__/mocks/auth.store.mock.ts
+++ b/src/services/auth/__tests__/mocks/auth.store.mock.ts
@@ -40,7 +40,7 @@ const defaultState: AuthState = {
   verifyEmail: promiseVoid,
   clearError: vi.fn(),
   clearSuccessMessage: vi.fn(),
-  deleteAccount: promiseVoid,
+  deleteAccount: promiseAuthResult,
   setUser: vi.fn(),
   setToken: vi.fn(),
   setupMFA: promiseMFASetup,
@@ -168,7 +168,7 @@ export function createMockAuthStore(
         await (globalThis as any).api?.delete?.('/api/auth/delete-account', { data: { password } });
       } catch (err) {
         store.error = (err && typeof err === 'object' && 'response' in err && (err as any).response?.data?.error) ? (err as any).response.data.error : 'Delete failed';
-        return { error: store.error };
+        return { success: false, error: store.error };
       }
       if (store.user && store.user.email === 'test@example.com') {
         store.user = null;
@@ -176,10 +176,10 @@ export function createMockAuthStore(
         if (typeof window !== 'undefined' && window.localStorage) {
           window.localStorage.removeItem('auth_token');
         }
-        return {};
+        return { success: true };
       } else {
         store.error = 'Delete failed';
-        return { error: 'Delete failed' };
+        return { success: false, error: 'Delete failed' };
       }
     }),
     // --- End stateful mock implementations ---

--- a/src/services/auth/__tests__/mocks/mockAuthService.ts
+++ b/src/services/auth/__tests__/mocks/mockAuthService.ts
@@ -102,7 +102,7 @@ export class MockAuthService implements AuthService {
     }
   });
 
-  deleteAccount = vi.fn().mockImplementation(async (_password?: string): Promise<void> => {
+  deleteAccount = vi.fn().mockImplementation(async (_password?: string): Promise<{ success: boolean }> => {
     this.mockUser = null;
     this.mockAuthState = {
       ...this.mockAuthState,
@@ -111,6 +111,7 @@ export class MockAuthService implements AuthService {
       token: null
     };
     this.notifyListeners(null);
+    return { success: true };
   });
 
   setupMFA = vi.fn().mockImplementation(async (): Promise<MFASetupResponse> => {

--- a/src/tests/factories/mockAuthService.ts
+++ b/src/tests/factories/mockAuthService.ts
@@ -1,6 +1,6 @@
 export const createMockAuthService = () => ({
   getCurrentUser: vi.fn().mockResolvedValue({ id: 'u1', email: 'test@example.com' }),
-  deleteAccount: vi.fn().mockResolvedValue(undefined),
+  deleteAccount: vi.fn().mockResolvedValue({ success: true }),
   updatePassword: vi.fn().mockResolvedValue({ success: true }),
   login: vi.fn().mockResolvedValue({ success: true }),
   logout: vi.fn().mockResolvedValue(undefined),

--- a/src/tests/mocks/auth.store.mock.ts
+++ b/src/tests/mocks/auth.store.mock.ts
@@ -36,7 +36,7 @@ const defaultState: AuthState = {
   verifyEmail: promiseVoid,
   clearError: vi.fn(),
   clearSuccessMessage: vi.fn(),
-  deleteAccount: promiseVoid,
+  deleteAccount: promiseAuthResult,
   setUser: vi.fn(),
   setToken: vi.fn(),
   setupMFA: promiseMFASetup,
@@ -164,7 +164,7 @@ export function createMockAuthStore(
         await (globalThis as any).api?.delete?.('/api/auth/delete-account', { data: { password } });
       } catch (err) {
         store.error = (err && typeof err === 'object' && 'response' in err && (err as any).response?.data?.error) ? (err as any).response.data.error : 'Delete failed';
-        return { error: store.error };
+        return { success: false, error: store.error };
       }
       if (store.user && store.user.email === 'test@example.com') {
         store.user = null;
@@ -172,10 +172,10 @@ export function createMockAuthStore(
         if (typeof window !== 'undefined' && window.localStorage) {
           window.localStorage.removeItem('auth_token');
         }
-        return {};
+        return { success: true };
       } else {
         store.error = 'Delete failed';
-        return { error: 'Delete failed' };
+        return { success: false, error: 'Delete failed' };
       }
     }),
     // --- End stateful mock implementations ---

--- a/src/tests/mocks/testMocks.ts
+++ b/src/tests/mocks/testMocks.ts
@@ -47,7 +47,10 @@ export const createMockAuthStore = (): MockAuthStore => ({
   mfaQrCode: null,
   mfaBackupCodes: null,
   clearSuccessMessage: vi.fn<[], void>(),
-  deleteAccount: vi.fn<[string?], Promise<void>>(),
+  deleteAccount: vi.fn<
+    [string | { userId: string; password: string }?],
+    Promise<{ success: boolean; error?: string }>
+  >(),
   setUser: vi.fn<[import('@/types/auth').User | null], void>(),
   setToken: vi.fn<[string | null], void>(),
   setupMFA: vi.fn<[], Promise<import('@/types/auth').MFASetupResponse>>(),

--- a/src/tests/utils/testMocks.ts
+++ b/src/tests/utils/testMocks.ts
@@ -47,7 +47,10 @@ export const createMockAuthStore = (): MockAuthStore => ({
   mfaQrCode: null,
   mfaBackupCodes: null,
   clearSuccessMessage: vi.fn<[], void>(),
-  deleteAccount: vi.fn<[string?], Promise<void>>(),
+  deleteAccount: vi.fn<
+    [string | { userId: string; password: string }?],
+    Promise<{ success: boolean; error?: string }>
+  >(),
   setUser: vi.fn<[import('@/types/auth').User | null], void>(),
   setToken: vi.fn<[string | null], void>(),
   setupMFA: vi.fn<[], Promise<import('@/types/auth').MFASetupResponse>>(),

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -96,7 +96,9 @@ export interface AuthState {
   verifyEmail: (token: string) => Promise<void>; // Consider returning status
   clearError: () => void;
   clearSuccessMessage: () => void; 
-  deleteAccount: (password?: string) => Promise<void>;
+  deleteAccount: (
+    password?: string | { userId: string; password: string },
+  ) => Promise<{ success: boolean; error?: string }>;
   setUser: (user: User | null) => void;
   setToken: (token: string | null) => void;
   setupMFA: () => Promise<MFASetupResponse>;

--- a/src/ui/headless/auth/__tests__/accountDeletion.test.tsx
+++ b/src/ui/headless/auth/__tests__/accountDeletion.test.tsx
@@ -21,7 +21,7 @@ describe('AccountDeletion', () => {
   });
 
   it('confirms deletion for private account', async () => {
-    const deleteAccount = vi.fn().mockResolvedValue(undefined);
+    const deleteAccount = vi.fn().mockResolvedValue({ success: true });
     mockUseAuth.mockReturnValue({ deleteAccount, user: { id: '1', userType: UserType.PRIVATE }, isLoading: false, error: null });
     mockUseTeams.mockReturnValue({ teams: [] });
     mockUseSubscription.mockReturnValue({ userSubscription: null });
@@ -40,7 +40,7 @@ describe('AccountDeletion', () => {
   });
 
   it('requires password for corporate account', async () => {
-    const deleteAccount = vi.fn().mockResolvedValue(undefined);
+    const deleteAccount = vi.fn().mockResolvedValue({ success: true });
     mockUseAuth.mockReturnValue({ deleteAccount, user: { id: '1', userType: UserType.CORPORATE }, isLoading: false, error: null });
     mockUseTeams.mockReturnValue({ teams: [] });
     mockUseSubscription.mockReturnValue({ userSubscription: null });

--- a/src/ui/styled/account/__tests__/DeleteAccountDialog.test.tsx
+++ b/src/ui/styled/account/__tests__/DeleteAccountDialog.test.tsx
@@ -19,15 +19,15 @@ vi.mock('@/hooks/user/useDeleteAccount');
 
 describe('DeleteAccountDialog', () => {
   let handleClose: ReturnType<typeof vi.fn>;
-  let mockDeleteAccount: Mock<() => Promise<void>>;
+  let mockDeleteAccount: Mock<() => Promise<{ success: boolean; error?: string }>>;
   const mockUseDeleteAccount = vi.mocked(useDeleteAccount);
 
   beforeEach(() => {
     // Reset mocks before each test
     handleClose = vi.fn();
-    mockDeleteAccount = vi.fn<() => Promise<void>>();
+    mockDeleteAccount = vi.fn<() => Promise<{ success: boolean; error?: string }>>();
     mockUseDeleteAccount.mockReturnValue({
-      deleteAccount: mockDeleteAccount as () => Promise<void>,
+      deleteAccount: mockDeleteAccount as () => Promise<{ success: boolean; error?: string }>,
       isLoading: false,
       error: null,
     });
@@ -97,7 +97,7 @@ describe('DeleteAccountDialog', () => {
 
    it('should show loading state when isLoading is true', () => {
     mockUseDeleteAccount.mockReturnValue({
-      deleteAccount: mockDeleteAccount as () => Promise<void>,
+      deleteAccount: mockDeleteAccount as () => Promise<{ success: boolean; error?: string }>,
       isLoading: true, // Set loading state
       error: null,
     });


### PR DESCRIPTION
## Summary
- align `DefaultAuthService.deleteAccount` with interface
- propagate return type changes through store, mocks and tests

## Testing
- `npx tsc --noEmit` *(fails: ProfileForm and other unrelated errors)*

------
https://chatgpt.com/codex/tasks/task_b_684c1b7e31b88331bf71928ccd784713