### PR TITLE
Fix auth middleware type errors

### DIFF
--- a/src/core/permission/models.ts
+++ b/src/core/permission/models.ts
@@ -111,6 +111,8 @@ export interface UserRole {
   id: string;
   userId: string;
   roleId: string;
+  /** Optional role name when joined from roles table */
+  roleName?: string;
   role?: RoleEntity;
   assignedBy: string;
   createdAt: Date;


### PR DESCRIPTION
## Summary
- fix missing `roleName` field on `UserRole`
- use `getSessionFromToken` in auth middleware
- tighten types for authenticated requests

## Testing
- `npx tsc --noEmit src/middleware/auth.ts`

------
https://chatgpt.com/codex/tasks/task_b_684c1aab789c83318cfafd0065a11452