### PR TITLE
Fix primitives TS errors

### DIFF
--- a/src/ui/primitives/calendar.tsx
+++ b/src/ui/primitives/calendar.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { ChevronLeftIcon, ChevronRightIcon } from '@radix-ui/react-icons';
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ChevronUpIcon,
+  ChevronDownIcon,
+} from '@radix-ui/react-icons';
 import { DayPicker } from 'react-day-picker';
 
 import { cn } from '@/lib/utils';
@@ -58,8 +63,16 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        IconLeft: () => <ChevronLeftIcon className="h-4 w-4" />,
-        IconRight: () => <ChevronRightIcon className="h-4 w-4" />,
+        Chevron: ({ orientation, className }) => {
+          const icons = {
+            left: ChevronLeftIcon,
+            right: ChevronRightIcon,
+            up: ChevronUpIcon,
+            down: ChevronDownIcon,
+          } as const;
+          const Icon = icons[orientation ?? 'right'];
+          return <Icon className={cn('h-4 w-4', className)} />;
+        },
       }}
       {...props}
     />

--- a/src/ui/primitives/formWithRecovery.tsx
+++ b/src/ui/primitives/formWithRecovery.tsx
@@ -2,7 +2,10 @@ import React, { useId, useTransition } from 'react';
 import { ErrorBoundary } from '@/ui/primitives/errorBoundary';
 import { Button } from '@/ui/primitives/button';
 
-interface FormWithRecoveryProps extends React.FormHTMLAttributes<HTMLFormElement> {
+type FormWithRecoveryProps = Omit<
+  React.FormHTMLAttributes<HTMLFormElement>,
+  'onError' | 'onSubmit'
+> & {
   /**
    * Function to call when the form is submitted successfully
    */
@@ -27,7 +30,12 @@ interface FormWithRecoveryProps extends React.FormHTMLAttributes<HTMLFormElement
    * Text to show on the recovery button
    */
   recoveryButtonText?: string;
-}
+
+  /**
+   * Children can be a React node or a render prop receiving the pending state
+   */
+  children?: React.ReactNode | ((state: { isPending: boolean }) => React.ReactNode);
+};
 
 /**
  * A form component that can recover from errors during submission

--- a/src/ui/primitives/tooltip.tsx
+++ b/src/ui/primitives/tooltip.tsx
@@ -10,9 +10,16 @@ const Tooltip: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <span className="relative inline-block">{children}</span>
 );
 
-const TooltipTrigger: React.FC<React.ComponentProps<'span'>> = ({ children, ...props }) => (
-  <span {...props}>{children}</span>
-);
+interface TooltipTriggerProps extends React.HTMLAttributes<HTMLSpanElement> {
+  asChild?: boolean;
+}
+
+const TooltipTrigger: React.FC<TooltipTriggerProps> = ({ asChild, children, ...props }) => {
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children, { ...props });
+  }
+  return <span {...props}>{children}</span>;
+};
 
 const TooltipContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, children, ...props }, ref) => (


### PR DESCRIPTION
## Summary
- update Calendar to use Chevron component instead of IconLeft/IconRight
- support `asChild` prop in TooltipTrigger
- adjust FormWithRecoveryProps to avoid conflicting DOM prop names

## Testing
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_684c20fea0788331bfb807ee506a0b88