### PR TITLE
Fix audit & access pages TS errors

### DIFF
--- a/app/admin/access-rules/ClientPage.tsx
+++ b/app/admin/access-rules/ClientPage.tsx
@@ -1,4 +1,5 @@
 'use client';
+import React from 'react';
 
 export default function AccessRulesClientPage() {
   return (

--- a/app/admin/access-rules/page.tsx
+++ b/app/admin/access-rules/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next';
+import React from 'react';
 import AccessRulesClientPage from '@app/admin/access-rules/ClientPage';
 
 export const metadata: Metadata = {

--- a/app/admin/audit-logs/page.tsx
+++ b/app/admin/audit-logs/page.tsx
@@ -1,6 +1,8 @@
 import { Metadata } from 'next';
 import { redirect } from 'next/navigation';
+import React from 'react';
 import { getSupabaseServerClient } from '@/lib/auth';
+import type { User as SupabaseUser } from '@supabase/supabase-js';
 import { hasPermission } from '@/lib/auth/hasPermission';
 import { AdminAuditLogs } from '@/ui/styled/admin/audit-logs/AdminAuditLogs';
 
@@ -13,7 +15,7 @@ export default async function AdminAuditLogsPage(): Promise<JSX.Element> {
   // Get current user and check permissions
   const supabase = getSupabaseServerClient();
   const { data, error } = await supabase.auth.getUser();
-  const user = data.user;
+  const user: SupabaseUser | null = data.user;
 
   if (error || !user) {
     redirect('/auth/login');


### PR DESCRIPTION
## Summary
- import React in server/client admin pages
- type user from Supabase in audit logs page

## Testing
- `npm run lint`
- `npm run build` *(fails: Compiled with warnings)*

------
https://chatgpt.com/codex/tasks/task_b_684c2158d1108331a8963bca24d59506