### PR TITLE
Fix permission middleware type mismatch

### DIFF
--- a/src/core/permission/__tests__/permissions.test.ts
+++ b/src/core/permission/__tests__/permissions.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 import { withPermissionCheck } from '@/middleware/permissions';
 import { getApiAuthService } from '@/services/auth/factory';
-import { Permission } from '@/lib/rbac/roles';
+import { Permission } from '@/core/permission/models';
 import { prisma } from '@/lib/database/prisma';
 import { checkRolePermission } from '@/lib/rbac/roleService';
 

--- a/src/middleware/__tests__/permissions.test.ts
+++ b/src/middleware/__tests__/permissions.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 import { withPermissionCheck } from '@/middleware/permissions';
 import { getApiAuthService } from '@/services/auth/factory';
-import { Permission } from '@/lib/rbac/roles';
+import { Permission } from '@/core/permission/models';
 import { getApiPermissionService } from '@/services/permission/factory';
 import { prisma } from '@/lib/database/prisma'; // Prisma client for user/team data
 

--- a/src/middleware/__tests__/routeAuth.test.ts
+++ b/src/middleware/__tests__/routeAuth.test.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { withRouteAuth } from '@/middleware/auth';
 import { validateAuthToken } from '@/middleware/validateAuthToken';
 import { getApiPermissionService } from '@/services/permission/factory';
-import { Permission } from '@/lib/rbac/roles';
+import { Permission } from '@/core/permission/models';
 
 vi.mock('../validate-auth-token');
 vi.mock('@/services/permission/factory');

--- a/src/middleware/permissions.ts
+++ b/src/middleware/permissions.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getApiAuthService } from '@/services/auth/factory';
 import { getApiPermissionService } from '@/services/permission/factory';
-import type { Permission } from '@/lib/rbac/roles';
+import type { Permission } from '@/core/permission/models';
 import { isPermission } from '@/lib/rbac/roles';
 import { checkPermission, checkAnyPermission, checkAllPermissions } from '@/lib/auth/permissionCheck';
 import { createAuthApiError } from '@/middleware/authErrors';

--- a/src/middleware/withResourcePermission.ts
+++ b/src/middleware/withResourcePermission.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { withRouteAuth, type RouteAuthContext, type RouteAuthOptions } from '@/middleware/auth';
 import { createAuthApiError } from '@/middleware/authErrors';
 import { createErrorResponse } from '@/lib/api/common/responseFormatter';
-import { isPermission, type Permission } from '@/lib/rbac/roles';
+import { isPermission } from '@/lib/rbac/roles';
+import type { Permission } from '@/core/permission/models';
 
 export interface ResourcePermissionOptions<TParams = any> {
   permission: string;


### PR DESCRIPTION
## Summary
- switch middleware permission types to use core models
- update withResourcePermission and related tests

## Testing
- `npx vitest run --coverage` *(fails: Element type is invalid)*

------
https://chatgpt.com/codex/tasks/task_b_684c20a97d3c8331b601370aa736870d