### PR TITLE
Fix interface mismatch for deleteAccount

### DIFF
--- a/src/core/auth/interfaces.ts
+++ b/src/core/auth/interfaces.ts
@@ -215,10 +215,10 @@ export interface AuthService {
   
   /**
    * Delete the current user's account
-   * 
-   * @param passwordOrParams Either a password string or an object with userId and password
+   *
+   * @param password Current password for verification (optional)
    */
-  deleteAccount(passwordOrParams?: string | { userId: string; password: string }): Promise<{ success: boolean; error?: string }>;
+  deleteAccount(password?: string): Promise<void>;
 
   /**
    * Get account details for a user


### PR DESCRIPTION
## Summary
- fix the `deleteAccount` method definition in `AuthService`

## Testing
- `npx vitest run --coverage` *(fails: Element type is invalid: expected a string or class/function)*

------
https://chatgpt.com/codex/tasks/task_b_684c25ee4ff8833180b1b8cbfaf4ae0f