### PR TITLE
Fix hooks TypeScript errors

### DIFF
--- a/src/core/user/models.ts
+++ b/src/core/user/models.ts
@@ -45,7 +45,7 @@ export interface UserProfile {
   /**
    * URL to the user's profile picture (optional)
    */
-  profilePictureUrl?: string;
+  profilePictureUrl?: string | null;
   
   /**
    * Whether the user account is active

--- a/src/hooks/user/useOrganizationSession.ts
+++ b/src/hooks/user/useOrganizationSession.ts
@@ -99,11 +99,15 @@ export function useTerminateUserSessions(orgId: string) {
     setLoading(true);
     setError(null);
     setCount(null);
-    const { data, error } = await supabase.rpc('terminate_user_sessions', { user_id: userId, organization_id: orgId });
+    const { data, error } = await supabase.rpc('terminate_user_sessions', {
+      user_id: userId,
+      organization_id: orgId
+    });
     if (error) setError(error.message);
-    setCount(data?.count || 0);
+    const terminatedCount = (data as { count?: number } | null)?.count ?? 0;
+    setCount(terminatedCount);
     setLoading(false);
-    return { count: data?.count || 0, error };
+    return { count: terminatedCount, error };
   }, [orgId]);
 
   return { terminateUserSessions, loading, error, count };

--- a/src/hooks/utils/useApiError.ts
+++ b/src/hooks/utils/useApiError.ts
@@ -1,11 +1,22 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatErrorMessage } from '@/lib/i18n/messages';
+import { ApiError } from '@/lib/api/common';
 
 interface ApiErrorShape {
   code?: string;
   message: string;
   details?: unknown;
+}
+
+export interface ParsedApiError {
+  message: string;
+  code: string;
+  status: number;
+}
+
+export function isApiError(err: unknown): err is ApiError {
+  return err instanceof ApiError;
 }
 
 /**
@@ -55,19 +66,21 @@ export function parseApiError(err: unknown): ParsedApiError {
       code: err.code,
       status: err.status,
     };
-  } else if (err instanceof Error) {
+  }
+
+  if (err instanceof Error) {
     return {
       message: err.message,
       code: 'UNKNOWN_ERROR',
       status: 500,
     };
-  } else {
-    return {
-      message: 'An unknown error occurred',
-      code: 'UNKNOWN_ERROR',
-      status: 500,
-    };
   }
+
+  return {
+    message: 'An unknown error occurred',
+    code: 'UNKNOWN_ERROR',
+    status: 500,
+  };
 }
 
 export default useApiError;


### PR DESCRIPTION
## Summary
- handle unknown data shape in `useOrganizationSession`
- update `UserProfile` type to allow null profile pictures
- add missing utilities to `useApiError`

## Testing
- `npx tsc --noEmit --pretty false src/hooks/user/useOrganizationSession.ts src/hooks/user/useUserProfile.ts src/hooks/utils/useApiError.ts` *(fails: Cannot find module '@/lib/api/common' etc.)*

------
https://chatgpt.com/codex/tasks/task_b_684c2a8092c88331a6e6b7f5a51eedf5