### PR TITLE
Fix config imports and Supabase client init

### DIFF
--- a/src/lib/database/migrations/20240318000000_create_audit_logs.ts
+++ b/src/lib/database/migrations/20240318000000_create_audit_logs.ts
@@ -1,5 +1,5 @@
 import { SupabaseClient } from '@supabase/supabase-js';
-import compliance from '@/config/compliance.config';
+import compliance from '../../../../config/compliance.config';
 
 export const up = async (client: SupabaseClient) => {
   await client.rpc('exec', {

--- a/src/lib/database/providers/supabase.ts
+++ b/src/lib/database/providers/supabase.ts
@@ -9,7 +9,13 @@ export class SupabaseProvider implements DatabaseProvider {
     if (!config.connectionString) {
       throw new Error('Supabase connection string is required');
     }
-    this.client = createClient(config.connectionString);
+    const key =
+      process.env.SUPABASE_SERVICE_ROLE_KEY ||
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    if (!key) {
+      throw new Error('Supabase key is required');
+    }
+    this.client = createClient(config.connectionString, key);
   }
 
   // User operations

--- a/src/lib/utils/errorTranslator.ts
+++ b/src/lib/utils/errorTranslator.ts
@@ -1,6 +1,6 @@
 import type { ApplicationError } from '@/lib/utils/errorFactory';
 import { sanitizePII } from '@/lib/utils/pii';
-import compliance from '@/config/compliance.config';
+import compliance from '../../../config/compliance.config';
 import { createError, createAuthenticationError, createNotFoundError } from '@/lib/utils/errorFactory';
 import { SERVER_ERROR_CODES } from '@/lib/api/common/errorCodes';
 import type { ErrorCode } from '@/lib/api/common/errorCodes';

--- a/src/middleware/auditLog.ts
+++ b/src/middleware/auditLog.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { supabase } from '@/lib/database/supabase';
 import { sanitizePII } from '@/lib/utils/pii';
-import compliance from '@/config/compliance.config';
+import compliance from '../../config/compliance.config';
 
 interface AuditLogOptions {
   excludePaths?: string[];


### PR DESCRIPTION
## Summary
- update compliance config imports to use relative paths
- initialize Supabase client with a URL and key

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find namespace 'vi')*

------
https://chatgpt.com/codex/tasks/task_b_684c2adf2ec08331a393214c9e969d47