### PR TITLE
Fix API route types

### DIFF
--- a/app/api/company/notifications/preferences/[id]/route.ts
+++ b/app/api/company/notifications/preferences/[id]/route.ts
@@ -8,13 +8,23 @@ const updateSchema = z.object({
   channel: z.enum(['email', 'in_app', 'both']).optional(),
 });
 
-async function handlePatch(_req: NextRequest, auth: AuthContext, data: z.infer<typeof updateSchema>, services: ServiceContainer, id: Promise<string>) {
+async function handlePatch(
+  _req: NextRequest,
+  auth: AuthContext,
+  data: z.infer<typeof updateSchema>,
+  services: ServiceContainer,
+  id: Promise<string>
+) {
   const resolvedId = await id;
   const updated = await services.companyNotification!.updatePreference(auth.userId!, resolvedId, data);
   return NextResponse.json(updated, { status: 200 });
 }
 
-export const PATCH = async (req: NextRequest, ctx: { params: Promise<{ id: string }> }) => {
-  const params = await ctx.params;
-  return createApiHandler(updateSchema, (r, a, d, s) => handlePatch(r, a, d, s, Promise.resolve(params.id)), { requireAuth: true })(req);
-};
+export async function PATCH(req: Request, ctx: { params: { id: string } }) {
+  const { params } = ctx;
+  return createApiHandler(
+    updateSchema,
+    (r, a, d, s) => handlePatch(r, a, d, s, Promise.resolve(params.id)),
+    { requireAuth: true }
+  )(req as NextRequest);
+}

--- a/app/api/company/notifications/recipients/[id]/route.ts
+++ b/app/api/company/notifications/recipients/[id]/route.ts
@@ -2,7 +2,13 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createApiHandler, emptySchema } from '@/lib/api/routeHelpers';
 import type { AuthContext, ServiceContainer } from '@/core/config/interfaces';
 
-async function handleDelete(_req: NextRequest, auth: AuthContext, _data: unknown, services: ServiceContainer, id: Promise<string>) {
+async function handleDelete(
+  _req: NextRequest,
+  auth: AuthContext,
+  _data: unknown,
+  services: ServiceContainer,
+  id: Promise<string>
+) {
   const resolvedId = await id;
   await services.companyNotification!.removeRecipient(auth.userId!, resolvedId);
   return NextResponse.json(
@@ -11,7 +17,11 @@ async function handleDelete(_req: NextRequest, auth: AuthContext, _data: unknown
   );
 }
 
-export const DELETE = async (req: NextRequest, ctx: { params: Promise<{ id: string }> }) => {
-  const params = await ctx.params;
-  return createApiHandler(emptySchema, (r, a, d, s) => handleDelete(r, a, d, s, Promise.resolve(params.id)), { requireAuth: true })(req);
-};
+export async function DELETE(req: Request, ctx: { params: { id: string } }) {
+  const { params } = ctx;
+  return createApiHandler(
+    emptySchema,
+    (r, a, d, s) => handleDelete(r, a, d, s, Promise.resolve(params.id)),
+    { requireAuth: true }
+  )(req as NextRequest);
+}

--- a/app/api/company/notifications/recipients/route.ts
+++ b/app/api/company/notifications/recipients/route.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { NextRequest } from 'next/server';
 import { createApiHandler } from '@/lib/api/routeHelpers';
 import type { AuthContext, ServiceContainer } from '@/core/config/interfaces';
 import { createCreatedResponse, createValidationError, createForbiddenError, createUnauthorizedError, createServerError } from '@/lib/api/common';
@@ -8,18 +9,27 @@ const recipientSchema = z.object({
   company_id: z.string().uuid('Invalid company ID format'),
   preference_id: z.string().uuid('Invalid preference ID format').optional(),
   email: z.string().email('Invalid email address'),
-  is_admin: z.boolean().optional(),
+  is_admin: z.boolean().default(false),
 });
 
 // POST /api/company/notifications/recipients - Add a new notification recipient
-async function handlePost(_req: Request, auth: AuthContext, data: z.infer<typeof recipientSchema>, services: ServiceContainer) {
+async function handlePost(
+  _req: NextRequest,
+  auth: AuthContext,
+  data: z.infer<typeof recipientSchema>,
+  services: ServiceContainer
+) {
   const result = await services.companyNotification!.addRecipient(auth.userId!, {
     companyId: data.company_id,
     preferenceId: data.preference_id ?? undefined,
     email: data.email,
-    isAdmin: data.is_admin ?? false,
+    isAdmin: data.is_admin,
   });
   return createCreatedResponse({ recipients: result.recipients, message: 'Recipient added successfully' });
 }
 
-export const POST = createApiHandler(recipientSchema, handlePost, { requireAuth: true });
+export const POST = createApiHandler(
+  recipientSchema as z.ZodType<z.infer<typeof recipientSchema>>,
+  handlePost,
+  { requireAuth: true }
+);


### PR DESCRIPTION
## Summary
- update notification preference routes to use NextRequest
- add defaults to notification schemas
- type cast schemas in `createApiHandler`

## Testing
- `npx tsc -p tsconfig.json` *(fails: Property 'message' does not exist on type 'void', etc.)*
- `npx vitest run --coverage` *(fails to execute tests)*

------
https://chatgpt.com/codex/tasks/task_b_684c29fcf8d483319204b74cad842d9d