### PR TITLE
Fix permission type inconsistencies

### DIFF
--- a/src/lib/rbac/roles.ts
+++ b/src/lib/rbac/roles.ts
@@ -1,38 +1,14 @@
 import { z } from 'zod';
+import {
+  PermissionValues,
+  RoleValues,
+  type Permission,
+  type Role,
+  DefaultRoleDefinitions,
+} from '@/core/permission/models';
 
-/**
- * Defines all available permissions in the system
- */
-export const Permission = {
-  // Team Management
-  INVITE_TEAM_MEMBER: 'INVITE_TEAM_MEMBER',
-  REMOVE_TEAM_MEMBER: 'REMOVE_TEAM_MEMBER',
-  UPDATE_MEMBER_ROLE: 'UPDATE_MEMBER_ROLE',
-  VIEW_TEAM_MEMBERS: 'VIEW_TEAM_MEMBERS',
-  
-  // Billing & Subscription
-  MANAGE_BILLING: 'MANAGE_BILLING',
-  VIEW_INVOICES: 'VIEW_INVOICES',
-  UPDATE_SUBSCRIPTION: 'UPDATE_SUBSCRIPTION',
-  
-  // Organization Settings
-  MANAGE_ORG_SETTINGS: 'MANAGE_ORG_SETTINGS',
-  CONFIGURE_SSO: 'CONFIGURE_SSO',
-  MANAGE_DOMAINS: 'MANAGE_DOMAINS',
-  
-  // Project Management
-  CREATE_PROJECT: 'CREATE_PROJECT',
-  DELETE_PROJECT: 'DELETE_PROJECT',
-  EDIT_PROJECT: 'EDIT_PROJECT',
-  VIEW_PROJECTS: 'VIEW_PROJECTS',
-  
-  // Admin Functions
-  VIEW_AUDIT_LOGS: 'VIEW_AUDIT_LOGS',
-  MANAGE_API_KEYS: 'MANAGE_API_KEYS',
-  ACCESS_ADMIN_DASHBOARD: 'ACCESS_ADMIN_DASHBOARD',
-} as const;
-
-export type Permission = typeof Permission[keyof typeof Permission];
+export { PermissionValues, RoleValues } from '@/core/permission/models';
+export type { Permission, Role } from '@/core/permission/models';
 
 export interface RoleInfo {
   name: string;
@@ -43,44 +19,47 @@ export interface RoleInfo {
 /**
  * Defines the standard roles and their associated permissions
  */
-export const RoleDefinition: Record<string, RoleInfo> = {
+export const RoleDefinition: Record<Role, RoleInfo> = {
+  SUPER_ADMIN: {
+    name: 'Super Admin',
+    description: 'System owner with all permissions',
+    permissions: DefaultRoleDefinitions.SUPER_ADMIN,
+  },
+
   ADMIN: {
     name: 'Admin',
     description: 'Full access to all features and settings',
-    permissions: Object.values(Permission),
+    permissions: DefaultRoleDefinitions.ADMIN,
   },
-  
+
+  MANAGER: {
+    name: 'Manager',
+    description: 'Manage teams and projects',
+    permissions: DefaultRoleDefinitions.MANAGER,
+  },
+
+  USER: {
+    name: 'User',
+    description: 'Standard authenticated user',
+    permissions: DefaultRoleDefinitions.USER,
+  },
+
   BILLING_MANAGER: {
     name: 'Billing Manager',
     description: 'Can manage billing, subscriptions, and view team information',
-    permissions: [
-      Permission.VIEW_TEAM_MEMBERS,
-      Permission.MANAGE_BILLING,
-      Permission.VIEW_INVOICES,
-      Permission.UPDATE_SUBSCRIPTION,
-      Permission.VIEW_PROJECTS,
-    ],
+    permissions: DefaultRoleDefinitions.BILLING_MANAGER,
   },
-  
+
   MEMBER: {
     name: 'Member',
     description: 'Standard team member with project access',
-    permissions: [
-      Permission.VIEW_TEAM_MEMBERS,
-      Permission.VIEW_INVOICES,
-      Permission.VIEW_PROJECTS,
-      Permission.EDIT_PROJECT,
-      Permission.CREATE_PROJECT,
-    ],
+    permissions: DefaultRoleDefinitions.MEMBER,
   },
-  
+
   VIEWER: {
     name: 'Viewer',
     description: 'Read-only access to projects and team information',
-    permissions: [
-      Permission.VIEW_TEAM_MEMBERS,
-      Permission.VIEW_PROJECTS,
-    ],
+    permissions: DefaultRoleDefinitions.VIEWER,
   },
 };
 
@@ -89,20 +68,20 @@ export type RoleType = keyof typeof RoleDefinition;
 /**
  * Zod schema for validating role types
  */
-export const roleSchema = z.enum(['ADMIN', 'BILLING_MANAGER', 'MEMBER', 'VIEWER']);
+export const roleSchema = z.enum(Object.values(RoleValues) as [string, ...string[]]);
 
 /**
  * Type guard to check if a string is a valid Permission
  */
 export function isPermission(value: string): value is Permission {
-  return Object.values(Permission).includes(value as Permission);
+  return Object.values(PermissionValues).includes(value as Permission);
 }
 
 /**
  * Type guard to check if a string is a valid RoleType
  */
 export function isRole(value: string): value is RoleType {
-  return Object.keys(RoleDefinition).includes(value as RoleType);
+  return Object.values(RoleValues).includes(value as Role);
 }
 
 /**

--- a/src/types/rbac.ts
+++ b/src/types/rbac.ts
@@ -1,106 +1,37 @@
 import { z } from 'zod';
+import {
+  PermissionValues,
+  PermissionSchema,
+  RoleValues,
+  RoleSchema,
+  type Permission,
+  type Role,
+  type UserRole,
+} from '@/core/permission/models';
 
-/**
- * System permissions as string literals
- */
-export const PermissionValues = {
-  ADMIN_ACCESS: 'ADMIN_ACCESS',
-  VIEW_ALL_USER_ACTION_LOGS: 'VIEW_ALL_USER_ACTION_LOGS',
-  EDIT_USER_PROFILES: 'EDIT_USER_PROFILES',
-  DELETE_USER_ACCOUNTS: 'DELETE_USER_ACCOUNTS',
-  MANAGE_ROLES: 'MANAGE_ROLES',
-  VIEW_ANALYTICS: 'VIEW_ANALYTICS',
-  EXPORT_DATA: 'EXPORT_DATA',
-  MANAGE_SETTINGS: 'MANAGE_SETTINGS',
-  MANAGE_API_KEYS: 'MANAGE_API_KEYS',
-  INVITE_USERS: 'INVITE_USERS',
-  MANAGE_TEAMS: 'MANAGE_TEAMS',
-  MANAGE_BILLING: 'MANAGE_BILLING',
-  MANAGE_SUBSCRIPTIONS: 'MANAGE_SUBSCRIPTIONS',
-  VIEW_INVOICES: 'VIEW_INVOICES',
-  UPDATE_SUBSCRIPTION: 'UPDATE_SUBSCRIPTION',
-  MANAGE_ORG_SETTINGS: 'MANAGE_ORG_SETTINGS',
-  CONFIGURE_SSO: 'CONFIGURE_SSO',
-  MANAGE_DOMAINS: 'MANAGE_DOMAINS',
-  ACCESS_ADMIN_DASHBOARD: 'ACCESS_ADMIN_DASHBOARD',
-  VIEW_ADMIN_DASHBOARD: 'VIEW_ADMIN_DASHBOARD',
-  VIEW_AUDIT_LOGS: 'VIEW_AUDIT_LOGS',
-} as const;
-
-/**
- * Zod schema for validating permissions
- */
-export const PermissionSchema = z.enum([
-  PermissionValues.ADMIN_ACCESS,
-  PermissionValues.VIEW_ALL_USER_ACTION_LOGS,
-  PermissionValues.EDIT_USER_PROFILES,
-  PermissionValues.DELETE_USER_ACCOUNTS,
-  PermissionValues.MANAGE_ROLES,
-  PermissionValues.VIEW_ANALYTICS,
-  PermissionValues.EXPORT_DATA,
-  PermissionValues.MANAGE_SETTINGS,
-  PermissionValues.MANAGE_API_KEYS,
-  PermissionValues.INVITE_USERS,
-  PermissionValues.MANAGE_TEAMS,
-  PermissionValues.MANAGE_BILLING,
-  PermissionValues.MANAGE_SUBSCRIPTIONS,
-  PermissionValues.VIEW_INVOICES,
-  PermissionValues.UPDATE_SUBSCRIPTION,
-  PermissionValues.MANAGE_ORG_SETTINGS,
-  PermissionValues.CONFIGURE_SSO,
-  PermissionValues.MANAGE_DOMAINS,
-  PermissionValues.ACCESS_ADMIN_DASHBOARD,
-  PermissionValues.VIEW_ADMIN_DASHBOARD,
-  PermissionValues.VIEW_AUDIT_LOGS,
-]);
-
-/**
- * Type representing all possible permissions
- */
-export type Permission = z.infer<typeof PermissionSchema>;
-
-/**
- * User roles in the system
- */
-export const RoleValues = {
-  SUPER_ADMIN: 'SUPER_ADMIN',
-  ADMIN: 'ADMIN',
-  MANAGER: 'MANAGER',
-  USER: 'USER',
-  VIEWER: 'VIEWER',
-  BILLING_MANAGER: 'BILLING_MANAGER',
-  MEMBER: 'MEMBER',
-} as const;
-
-/**
- * Role type
- */
-export type Role = typeof RoleValues[keyof typeof RoleValues];
-
-/**
- * Role-Permission mapping type
- */
-export type RolePermissions = {
-  [key in Role]: Permission[];
-};
-
-// Define the role schema for validation
-export const roleSchema = z.object({
-  id: z.string(),
-  name: z.enum(Object.values(RoleValues) as [string, ...string[]]),
-  description: z.string().optional(),
-  permissions: z.array(z.enum(Object.values(PermissionValues) as [string, ...string[]])),
-  createdAt: z.date().optional(),
-  updatedAt: z.date().optional(),
-});
-
-export type RoleSchema = z.infer<typeof roleSchema>;
+export {
+  PermissionValues,
+  PermissionSchema,
+  RoleValues,
+  RoleSchema,
+} from '@/core/permission/models';
 
 // User role assignment schema
 export const userRoleSchema = z.object({
   id: z.string(),
   userId: z.string(),
   roleId: z.string(),
+  roleName: z.string().optional(),
+  role: z
+    .object({
+      id: z.string(),
+      name: z.string(),
+      description: z.string(),
+      isSystemRole: z.boolean().optional(),
+      createdAt: z.date(),
+      updatedAt: z.date(),
+    })
+    .optional(),
   assignedBy: z.string(),
   createdAt: z.string().datetime(),
   expiresAt: z.string().datetime().optional(),


### PR DESCRIPTION
## Summary
- re-export role & permission types from core models
- align role definitions with default roles
- update RBAC utility types to use core models

## Testing
- `npx tsc --noEmit` *(fails: Property 'message' does not exist on type 'void', etc.)*
- `npm test` *(fails: Element type is invalid, tests cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_684c29d1a15083318c29de5f07283833