### PR TITLE
Fix type errors in auth modules

### DIFF
--- a/app/admin/audit-logs/page.tsx
+++ b/app/admin/audit-logs/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 
 export default async function AdminAuditLogsPage(): Promise<JSX.Element> {
   // Get current user and check permissions
-  const supabase = getSupabaseServerClient();
+  const supabase = await getSupabaseServerClient();
   const { data, error } = await supabase.auth.getUser();
   const user: SupabaseUser | null = data.user;
 

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -16,7 +16,7 @@ export default async function AdminLayout({
   children,
 }: AdminLayoutProps): Promise<JSX.Element> {
   // Create a Supabase client tied to the server session
-  const supabase = getSupabaseServerClient();
+  const supabase = await getSupabaseServerClient();
   const { data, error } = await supabase.auth.getUser();
   const user: SupabaseUser | null = data.user;
 

--- a/app/admin/roles/page.tsx
+++ b/app/admin/roles/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 };
 
 export default async function RolesManagementPage(): Promise<JSX.Element> {
-  const supabase = getSupabaseServerClient();
+  const supabase = await getSupabaseServerClient();
   const { data, error } = await supabase.auth.getUser();
   const user: SupabaseUser | null = data.user;
 

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 };
 
 export default async function AdminUsersPage(): Promise<JSX.Element> {
-  const supabase = getSupabaseServerClient();
+  const supabase = await getSupabaseServerClient();
   const { data, error } = await supabase.auth.getUser();
   const user: SupabaseUser | null = data.user;
 

--- a/src/lib/auth/authConfig.ts
+++ b/src/lib/auth/authConfig.ts
@@ -1,5 +1,6 @@
 import { cookies } from 'next/headers';
-import { createServerClient, type Session } from '@supabase/ssr';
+import { createServerClient } from '@supabase/ssr';
+import type { Session } from '@supabase/supabase-js';
 
 /**
  * Supabase authentication configuration.
@@ -26,7 +27,7 @@ export const supabaseAuthConfig = {
  * returns the active session if one exists.
  */
 export async function auth(): Promise<Session | null> {
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
 
   const supabase = createServerClient(
     supabaseAuthConfig.url,

--- a/src/lib/auth/getUser.ts
+++ b/src/lib/auth/getUser.ts
@@ -61,8 +61,8 @@ export async function getUser(): Promise<User | null> {
       role: 'ADMIN',
       emailVerified: true,
       image: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
     };
   }
   

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -32,8 +32,8 @@ export const authOptions: Record<string, never> = {};
 /**
  * Create a Supabase client configured with the current request cookies.
  */
-export function getSupabaseServerClient(): SupabaseClient {
-  const cookieStore = cookies();
+export async function getSupabaseServerClient(): Promise<SupabaseClient> {
+  const cookieStore = await cookies();
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -50,7 +50,7 @@ export function getSupabaseServerClient(): SupabaseClient {
  * Sign the current user out of Supabase.
  */
 export async function signOut(): Promise<void> {
-  const supabase = getSupabaseServerClient();
+  const supabase = await getSupabaseServerClient();
   await supabase.auth.signOut();
 }
 

--- a/src/lib/auth/refreshTokenStore.ts
+++ b/src/lib/auth/refreshTokenStore.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import { prisma } from '@/lib/database/prisma';
+import type { Prisma } from '@prisma/client';
 
 function hashToken(token: string): string {
   return crypto.createHash('sha256').update(token).digest('hex');
@@ -28,7 +29,7 @@ export async function rotateRefreshToken(
   newToken: string,
 ): Promise<void> {
   const hashedOld = hashToken(oldToken);
-  await prisma.$transaction(async (tx) => {
+  await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.refresh_tokens.findFirst({
       where: { token: hashedOld, user_id: userId, revoked: false },
     });

--- a/src/lib/auth/supabaseAuth.config.ts
+++ b/src/lib/auth/supabaseAuth.config.ts
@@ -59,7 +59,7 @@ export const supabaseAuthConfig: SupabaseAuthConfig = {
 export function validateSupabaseAuthConfig(
   config: SupabaseAuthConfig = supabaseAuthConfig
 ): boolean {
-  const required = [
+  const required: { name: string; value: string | undefined }[] = [
     { name: 'NEXT_PUBLIC_SUPABASE_URL', value: config.url },
     { name: 'NEXT_PUBLIC_SUPABASE_ANON_KEY', value: config.anonKey },
   ];


### PR DESCRIPTION
## Summary
- update Supabase session imports
- use async `cookies()` API
- correct mock user date fields
- type Prisma transaction
- ensure config validation handles optional env vars

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property 'message' does not exist on type 'void', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_684c2ac365488331af4bbc8cb2af5986