### PR TITLE
Fix TS errors in monitoring and notifications

### DIFF
--- a/src/lib/monitoring/monitoringSystem.ts
+++ b/src/lib/monitoring/monitoringSystem.ts
@@ -2,6 +2,7 @@
 import { telemetry } from '@/lib/monitoring/errorSystem';
 import { AlertManager, AlertRule } from '@/lib/telemetry/alertManager';
 import { ApplicationError } from '@/core/common/errors';
+import type { TelemetryAlert } from '@/lib/monitoring/telemetry';
 
 let initialized = false;
 export const alertManager = new AlertManager();
@@ -20,12 +21,14 @@ export function initializeMonitoringSystem(config: MonitoringConfig = {}): void 
     }
   }
 
-  telemetry.addAlertNotifier(alert => {
-    const error = new ApplicationError(
-      alert.errorType as any,
-      alert.message,
-      alert.severity === 'critical' ? 500 : 400,
-    );
-    alertManager.registerError(error);
+  telemetry.addAlertNotifier({
+    notify(alert: TelemetryAlert) {
+      const error = new ApplicationError(
+        alert.errorType as any,
+        alert.message,
+        alert.severity === 'critical' ? 500 : 400,
+      );
+      alertManager.registerError(error);
+    },
   });
 }


### PR DESCRIPTION
## Summary
- handle telemetry alerts via notifier object
- type company notification Supabase results
- update monitoring tests for notifier object

## Testing
- `npx vitest run --coverage src/lib/monitoring/__tests__/monitoringSystem.test.ts` *(fails: Failed Tests 1)*

------
https://chatgpt.com/codex/tasks/task_b_684c2af43aa0833190873eacdb5a13cb