### PR TITLE
Fix TS errors in admin routes and type exports

### DIFF
--- a/app/api/admin/saved-searches/[id]/route.ts
+++ b/app/api/admin/saved-searches/[id]/route.ts
@@ -13,7 +13,7 @@ import {
 import type { RouteAuthContext } from "@/middleware/auth";
 import { withSecurity } from "@/middleware/withSecurity";
 import { getApiSavedSearchService } from "@/services/saved-search/factory";
-import { Permission } from "@/lib/rbac/roles";
+import { PermissionValues } from "@/lib/rbac/roles";
 
 const updateSavedSearchSchema = z.object({
   name: z.string().min(1).optional(),
@@ -79,12 +79,12 @@ async function deleteSavedSearch(
 
 const baseMiddleware = createMiddlewareChain([
   errorHandlingMiddleware(),
-  routeAuthMiddleware({ requiredPermissions: [Permission.ACCESS_ADMIN_DASHBOARD] }),
+  routeAuthMiddleware({ requiredPermissions: [PermissionValues.ACCESS_ADMIN_DASHBOARD] }),
 ]);
 
 const patchMiddleware = createMiddlewareChain([
   errorHandlingMiddleware(),
-  routeAuthMiddleware({ requiredPermissions: [Permission.ACCESS_ADMIN_DASHBOARD] }),
+  routeAuthMiddleware({ requiredPermissions: [PermissionValues.ACCESS_ADMIN_DASHBOARD] }),
   validationMiddleware(updateSavedSearchSchema),
 ]);
 

--- a/app/api/admin/saved-searches/route.ts
+++ b/app/api/admin/saved-searches/route.ts
@@ -10,7 +10,7 @@ import {
 import type { RouteAuthContext } from "@/middleware/auth";
 import { withSecurity } from "@/middleware/withSecurity";
 import { getApiSavedSearchService } from "@/services/saved-search/factory";
-import { Permission } from "@/lib/rbac/roles";
+import { PermissionValues } from "@/lib/rbac/roles";
 
 const savedSearchParamsSchema = z.object({
   query: z.string().optional(),
@@ -64,12 +64,12 @@ async function createSavedSearch(
 
 const getMiddleware = createMiddlewareChain([
   errorHandlingMiddleware(),
-  routeAuthMiddleware({ requiredPermissions: [Permission.ACCESS_ADMIN_DASHBOARD] }),
+  routeAuthMiddleware({ requiredPermissions: [PermissionValues.ACCESS_ADMIN_DASHBOARD] }),
 ]);
 
 const postMiddleware = createMiddlewareChain([
   errorHandlingMiddleware(),
-  routeAuthMiddleware({ requiredPermissions: [Permission.ACCESS_ADMIN_DASHBOARD] }),
+  routeAuthMiddleware({ requiredPermissions: [PermissionValues.ACCESS_ADMIN_DASHBOARD] }),
   validationMiddleware(createSavedSearchSchema),
 ]);
 

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -8,7 +8,7 @@ import {
 } from "@/middleware/createMiddlewareChain";
 import { z } from "zod";
 import { getApiAdminService } from "@/services/admin/factory";
-import { Permission } from "@/lib/rbac/roles";
+import { PermissionValues } from "@/lib/rbac/roles";
 
 const querySchema = z.object({
   page: z.coerce.number().int().positive().default(1),
@@ -59,7 +59,7 @@ async function handleGet(
 
 const getMiddleware = createMiddlewareChain([
   errorHandlingMiddleware(),
-  routeAuthMiddleware({ requiredPermissions: [Permission.ACCESS_ADMIN_DASHBOARD] }),
+  routeAuthMiddleware({ requiredPermissions: [PermissionValues.ACCESS_ADMIN_DASHBOARD] }),
   validationMiddleware(querySchema),
 ]);
 

--- a/app/api/company/notifications/preferences/[id]/route.ts
+++ b/app/api/company/notifications/preferences/[id]/route.ts
@@ -13,18 +13,23 @@ async function handlePatch(
   auth: AuthContext,
   data: z.infer<typeof updateSchema>,
   services: ServiceContainer,
-  id: Promise<string>
+  params: Promise<{ id: string }>
 ) {
-  const resolvedId = await id;
-  const updated = await services.companyNotification!.updatePreference(auth.userId!, resolvedId, data);
+  const { id } = await params;
+  const updated = await services.companyNotification!.updatePreference(
+    auth.userId!,
+    id,
+    data,
+  );
   return NextResponse.json(updated, { status: 200 });
 }
 
-export async function PATCH(req: Request, ctx: { params: { id: string } }) {
-  const { params } = ctx;
-  return createApiHandler(
+export const PATCH = async (
+  req: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) =>
+  createApiHandler(
     updateSchema,
-    (r, a, d, s) => handlePatch(r, a, d, s, Promise.resolve(params.id)),
-    { requireAuth: true }
-  )(req as NextRequest);
-}
+    (r, a, d, s) => handlePatch(r, a, d, s, ctx.params),
+    { requireAuth: true },
+  )(req);

--- a/app/api/company/notifications/recipients/[id]/route.ts
+++ b/app/api/company/notifications/recipients/[id]/route.ts
@@ -7,21 +7,22 @@ async function handleDelete(
   auth: AuthContext,
   _data: unknown,
   services: ServiceContainer,
-  id: Promise<string>
+  params: Promise<{ id: string }>
 ) {
-  const resolvedId = await id;
-  await services.companyNotification!.removeRecipient(auth.userId!, resolvedId);
+  const { id } = await params;
+  await services.companyNotification!.removeRecipient(auth.userId!, id);
   return NextResponse.json(
     { success: true, message: 'Recipient removed successfully' },
     { status: 200 }
   );
 }
 
-export async function DELETE(req: Request, ctx: { params: { id: string } }) {
-  const { params } = ctx;
-  return createApiHandler(
+export const DELETE = async (
+  req: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) =>
+  createApiHandler(
     emptySchema,
-    (r, a, d, s) => handleDelete(r, a, d, s, Promise.resolve(params.id)),
-    { requireAuth: true }
-  )(req as NextRequest);
-}
+    (r, a, d, s) => handleDelete(r, a, d, s, ctx.params),
+    { requireAuth: true },
+  )(req);

--- a/src/types/rbac.ts
+++ b/src/types/rbac.ts
@@ -15,6 +15,7 @@ export {
   RoleValues,
   RoleSchema,
 } from '@/core/permission/models';
+export type { Permission, Role, UserRole } from '@/core/permission/models';
 
 // User role assignment schema
 export const userRoleSchema = z.object({


### PR DESCRIPTION
## Summary
- export Permission, Role and UserRole types from rbac util
- update admin notification routes to use PermissionValues
- adjust company notification param handlers
- fix admin users middleware import

## Testing
- `npm run test:coverage` *(fails: The current testing environment is not configured to support act(...), etc.)*

------
https://chatgpt.com/codex/tasks/task_b_684c702779c483319815573488f8d4d9