### PR TITLE
Fix NextRequest usage in API route tests

### DIFF
--- a/app/api/auth/oauth/callback/__tests__/route.test.ts
+++ b/app/api/auth/oauth/callback/__tests__/route.test.ts
@@ -1,15 +1,15 @@
 import { POST } from '@app/api/auth/oauth/callback/route';
 import { OAuthProvider } from '@/types/oauth';
+import { NextRequest } from 'next/server';
 import { describe, it, expect } from 'vitest';
 
 describe('oauth callback route', () => {
   it('returns 400 when state is missing', async () => {
-    const req = new Request('http://localhost/api/auth/oauth/callback', {
+    const req = new NextRequest('http://localhost/api/auth/oauth/callback', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ provider: OAuthProvider.GOOGLE, code: 'code' })
     });
-    Object.defineProperty(req, 'nextUrl', { value: new URL(req.url) });
     const res = await POST(req);
     expect(res.status).toBe(400);
   });

--- a/app/api/company/domains/[id]/verify-check/__tests__/route.test.ts
+++ b/app/api/company/domains/[id]/verify-check/__tests__/route.test.ts
@@ -67,7 +67,9 @@ describe('Domain Verification Check API', () => {
       new URL(`http://localhost/api/company/domains/${mockDomainId}/verify-check`)
     );
     
-    const response = await POST(request, { params: { id: mockDomainId } });
+    const response = await POST(request, {
+      params: Promise.resolve({ id: mockDomainId })
+    });
     expect(response.status).toBe(200);
 
     const data = await response.json();
@@ -87,7 +89,9 @@ describe('Domain Verification Check API', () => {
       new URL(`http://localhost/api/company/domains/${mockDomainId}/verify-check`)
     );
     
-    const response = await POST(request, { params: { id: mockDomainId } });
+    const response = await POST(request, {
+      params: Promise.resolve({ id: mockDomainId })
+    });
     expect(response.status).toBe(401);
     
     const data = await response.json();
@@ -101,7 +105,9 @@ describe('Domain Verification Check API', () => {
       new URL(`http://localhost/api/company/domains/${mockDomainId}/verify-check`)
     );
     
-    const response = await POST(request, { params: { id: mockDomainId } });
+    const response = await POST(request, {
+      params: Promise.resolve({ id: mockDomainId })
+    });
     expect(response.status).toBe(404);
     
     const data = await response.json();
@@ -115,7 +121,9 @@ describe('Domain Verification Check API', () => {
       new URL(`http://localhost/api/company/domains/${mockDomainId}/verify-check`)
     );
     
-    const response = await POST(request, { params: { id: mockDomainId } });
+    const response = await POST(request, {
+      params: Promise.resolve({ id: mockDomainId })
+    });
     expect(response.status).toBe(400);
     
     const data = await response.json();
@@ -130,7 +138,9 @@ describe('Domain Verification Check API', () => {
       new URL(`http://localhost/api/company/domains/${mockDomainId}/verify-check`)
     );
     
-    const response = await POST(request, { params: { id: mockDomainId } });
+    const response = await POST(request, {
+      params: Promise.resolve({ id: mockDomainId })
+    });
     expect(response.status).toBe(400);
     
     const data = await response.json();
@@ -151,7 +161,9 @@ describe('Domain Verification Check API', () => {
       new URL(`http://localhost/api/company/domains/${mockDomainId}/verify-check`)
     );
     
-    const response = await POST(request, { params: { id: mockDomainId } });
+    const response = await POST(request, {
+      params: Promise.resolve({ id: mockDomainId })
+    });
     expect(response.status).toBe(400);
     
     const data = await response.json();
@@ -170,7 +182,9 @@ describe('Domain Verification Check API', () => {
       new URL(`http://localhost/api/company/domains/${mockDomainId}/verify-check`)
     );
     
-    const response = await POST(request, { params: { id: mockDomainId } });
+    const response = await POST(request, {
+      params: Promise.resolve({ id: mockDomainId })
+    });
     expect(response.status).toBe(400);
     
     const data = await response.json();
@@ -185,7 +199,9 @@ describe('Domain Verification Check API', () => {
       new URL(`http://localhost/api/company/domains/${mockDomainId}/verify-check`)
     );
     
-    const response = await POST(request, { params: { id: mockDomainId } });
+    const response = await POST(request, {
+      params: Promise.resolve({ id: mockDomainId })
+    });
     expect(response.status).toBe(500);
     
     const data = await response.json();

--- a/app/api/company/domains/[id]/verify-initiate/__tests__/route.test.ts
+++ b/app/api/company/domains/[id]/verify-initiate/__tests__/route.test.ts
@@ -56,7 +56,9 @@ describe('Domain Verification Initiate API', () => {
       new URL(`http://localhost/api/company/domains/${mockDomainId}/verify-initiate`)
     );
     
-    const response = await POST(request, { params: { id: mockDomainId } });
+    const response = await POST(request, {
+      params: Promise.resolve({ id: mockDomainId })
+    });
     expect(response.status).toBe(200);
 
     const data = await response.json();
@@ -78,7 +80,9 @@ describe('Domain Verification Initiate API', () => {
       new URL(`http://localhost/api/company/domains/${mockDomainId}/verify-initiate`)
     );
     
-    const response = await POST(request, { params: { id: mockDomainId } });
+    const response = await POST(request, {
+      params: Promise.resolve({ id: mockDomainId })
+    });
     expect(response.status).toBe(401);
     
     const data = await response.json();
@@ -92,7 +96,9 @@ describe('Domain Verification Initiate API', () => {
       new URL(`http://localhost/api/company/domains/${mockDomainId}/verify-initiate`)
     );
     
-    const response = await POST(request, { params: { id: mockDomainId } });
+    const response = await POST(request, {
+      params: Promise.resolve({ id: mockDomainId })
+    });
     expect(response.status).toBe(404);
     
     const data = await response.json();
@@ -106,7 +112,9 @@ describe('Domain Verification Initiate API', () => {
       new URL(`http://localhost/api/company/domains/${mockDomainId}/verify-initiate`)
     );
     
-    const response = await POST(request, { params: { id: mockDomainId } });
+    const response = await POST(request, {
+      params: Promise.resolve({ id: mockDomainId })
+    });
     expect(response.status).toBe(403);
     
     const data = await response.json();
@@ -120,7 +128,9 @@ describe('Domain Verification Initiate API', () => {
       new URL(`http://localhost/api/company/domains/${mockDomainId}/verify-initiate`)
     );
     
-    const response = await POST(request, { params: { id: mockDomainId } });
+    const response = await POST(request, {
+      params: Promise.resolve({ id: mockDomainId })
+    });
     expect(response.status).toBe(500);
     
     const data = await response.json();
@@ -132,7 +142,9 @@ describe('Domain Verification Initiate API', () => {
       new URL(`http://localhost/api/company/domains/${mockDomainId}/verify-initiate`)
     );
     
-    const response = await POST(request, { params: { id: mockDomainId } });
+    const response = await POST(request, {
+      params: Promise.resolve({ id: mockDomainId })
+    });
     const data = await response.json();
 
     // Token should be a string and match expected pattern

--- a/app/api/company/validate/__tests__/route.test.ts
+++ b/app/api/company/validate/__tests__/route.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { POST } from '@app/api/company/validate/route';
+import { NextRequest } from 'next/server';
 
-const mockRequest = (body: any) => new Request('http://localhost', { method: 'POST', body: JSON.stringify(body) });
+const mockRequest = (body: any) =>
+  new NextRequest('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' }
+  });
 
 describe('POST /api/company/validate', () => {
   it('returns valid: true for a valid company name', async () => {


### PR DESCRIPTION
## Summary
- ensure oauth callback test uses `NextRequest`
- update company validate test to create a `NextRequest`
- pass async params to verify route handlers

## Testing
- `npx tsc -p tsconfig.test.json --noEmit` *(fails: Property 'message' does not exist on type 'void' and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_684c704576948331ac71ac6ae8e36eef