### PR TITLE
Fix NextRequest usage in API route tests

### DIFF
--- a/app/api/company/validate/__tests__/route.test.ts
+++ b/app/api/company/validate/__tests__/route.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { POST } from '@app/api/company/validate/route';
+import { NextRequest } from 'next/server';
 
-const mockRequest = (body: any) => new Request('http://localhost', { method: 'POST', body: JSON.stringify(body) });
+const mockRequest = (body: any) =>
+  new NextRequest(new URL('http://localhost'), {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
 
 describe('POST /api/company/validate', () => {
   it('returns valid: true for a valid company name', async () => {

--- a/app/api/health/__tests__/route.test.ts
+++ b/app/api/health/__tests__/route.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { GET } from '@app/api/health/route';
 import { getHealthService } from '@/services/health';
+import { NextRequest } from 'next/server';
 
 vi.mock('@/services/health', () => ({
   getHealthService: vi.fn()
@@ -13,7 +14,8 @@ describe('/api/health', () => {
     } as any;
     (getHealthService as unknown as vi.Mock).mockReturnValue(mockHealthService);
 
-    const response = await GET();
+    const request = new NextRequest(new URL('http://localhost/api/health'));
+    const response = await GET(request);
     const data = await response.json();
 
     expect(data.status).toBe('healthy');

--- a/app/api/openapi/__tests__/route.test.ts
+++ b/app/api/openapi/__tests__/route.test.ts
@@ -1,12 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { GET } from '@app/api/openapi/route';
-import { NextRequest } from 'next/server';
 
-const createRequest = () => new NextRequest('http://localhost/api/openapi');
+// GET route does not accept parameters
 
 describe('GET /api/openapi', () => {
   it('returns the openapi spec', async () => {
-    const res = await GET(createRequest());
+    const res = await GET();
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.openapi).toBe('3.0.3');

--- a/app/api/organizations/[orgId]/__tests__/route.test.ts
+++ b/app/api/organizations/[orgId]/__tests__/route.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { NextRequest } from 'next/server';
 import { GET, PUT, DELETE } from '@app/api/organizations/[orgId]/route';
 import { configureServices, resetServiceContainer } from '@/lib/config/serviceContainer';
 import { createAuthenticatedRequest } from '@/tests/utils/requestHelpers';
@@ -27,7 +26,10 @@ describe('[orgId] API', () => {
   });
 
   it('GET returns organization', async () => {
-    const res = await GET(createAuthenticatedRequest('GET', 'http://test'), { params: { orgId: 'o1' } });
+    const res = await GET(
+      createAuthenticatedRequest('GET', 'http://test'),
+      { params: Promise.resolve({ orgId: 'o1' }) }
+    );
     expect(res.status).toBe(200);
     expect(service.getOrganization).toHaveBeenCalledWith('o1');
   });
@@ -35,13 +37,16 @@ describe('[orgId] API', () => {
   it('PUT updates organization', async () => {
     const req = createAuthenticatedRequest('PUT', 'http://test', { name: 'New' });
     (req as any).json = async () => ({ name: 'New' });
-    const res = await PUT(req, { params: { orgId: 'o1' } });
+    const res = await PUT(req, { params: Promise.resolve({ orgId: 'o1' }) });
     expect(res.status).toBe(200);
     expect(service.updateOrganization).toHaveBeenCalled();
   });
 
   it('DELETE removes organization', async () => {
-    const res = await DELETE(createAuthenticatedRequest('DELETE', 'http://test'), { params: { orgId: 'o1' } });
+    const res = await DELETE(
+      createAuthenticatedRequest('DELETE', 'http://test'),
+      { params: Promise.resolve({ orgId: 'o1' }) }
+    );
     expect(res.status).toBe(200);
     expect(service.deleteOrganization).toHaveBeenCalledWith('o1');
   });

--- a/app/api/organizations/[orgId]/members/__tests__/route.test.ts
+++ b/app/api/organizations/[orgId]/members/__tests__/route.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { NextRequest } from 'next/server';
 import { GET, POST } from '@app/api/organizations/[orgId]/members/route';
 import { configureServices, resetServiceContainer } from '@/lib/config/serviceContainer';
 import { createAuthenticatedRequest } from '@/tests/utils/requestHelpers';
@@ -26,7 +25,10 @@ describe('organization members API', () => {
   });
 
   it('GET returns members', async () => {
-    const res = await GET(createAuthenticatedRequest('GET', 'http://test'), { params: { orgId: 'o1' } });
+    const res = await GET(
+      createAuthenticatedRequest('GET', 'http://test'),
+      { params: Promise.resolve({ orgId: 'o1' }) }
+    );
     expect(res.status).toBe(200);
     expect(service.getOrganizationMembers).toHaveBeenCalledWith('o1');
   });
@@ -34,7 +36,7 @@ describe('organization members API', () => {
   it('POST adds member', async () => {
     const req = createAuthenticatedRequest('POST', 'http://test', { userId: 'u1', role: 'member' });
     (req as any).json = async () => ({ userId: 'u1', role: 'member' });
-    const res = await POST(req, { params: { orgId: 'o1' } });
+    const res = await POST(req, { params: Promise.resolve({ orgId: 'o1' }) });
     expect(res.status).toBe(201);
     expect(service.addOrganizationMember).toHaveBeenCalledWith('o1', 'u1', 'member');
   });

--- a/app/api/organizations/[orgId]/sso/[idpType]/config/__tests__/route.test.ts
+++ b/app/api/organizations/[orgId]/sso/[idpType]/config/__tests__/route.test.ts
@@ -29,7 +29,6 @@ describe('IDP Configuration API Routes', () => {
   });
 
   describe('SAML Configuration', () => {
-    const mockParams = { params: { orgId: mockOrgId, idpType: 'saml' } };
     const validSamlConfig = {
       entityId: 'https://test-idp.com/metadata',
       ssoUrl: 'https://test-idp.com/sso',
@@ -42,7 +41,7 @@ describe('IDP Configuration API Routes', () => {
         new URL(`http://localhost/api/organizations/${mockOrgId}/sso/saml/config`)
       );
 
-      const response = await GET(request, mockParams);
+      const response = await GET(request);
       const data = await response.json();
 
       expect(response.status).toBe(200);
@@ -63,7 +62,7 @@ describe('IDP Configuration API Routes', () => {
         }
       );
 
-      const response = await PUT(request, mockParams);
+      const response = await PUT(request);
       const data = await response.json();
 
       expect(response.status).toBe(200);
@@ -74,7 +73,7 @@ describe('IDP Configuration API Routes', () => {
       const getRequest = new NextRequest(
         new URL(`http://localhost/api/organizations/${mockOrgId}/sso/saml/config`)
       );
-      const getResponse = await GET(getRequest, mockParams);
+      const getResponse = await GET(getRequest);
       const getdata = await getResponse.json();
 
       expect(getdata).toEqual(validSamlConfig);
@@ -96,7 +95,7 @@ describe('IDP Configuration API Routes', () => {
         }
       );
 
-      const response = await PUT(request, mockParams);
+      const response = await PUT(request);
       const data = await response.json();
 
       expect(response.status).toBe(400);
@@ -106,7 +105,6 @@ describe('IDP Configuration API Routes', () => {
   });
 
   describe('OIDC Configuration', () => {
-    const mockParams = { params: { orgId: mockOrgId, idpType: 'oidc' } };
     const validOidcConfig = {
       clientId: 'test-client-id',
       clientSecret: 'test-client-secret',
@@ -122,7 +120,7 @@ describe('IDP Configuration API Routes', () => {
         new URL(`http://localhost/api/organizations/${mockOrgId}/sso/oidc/config`)
       );
 
-      const response = await GET(request, mockParams);
+      const response = await GET(request);
       const data = await response.json();
 
       expect(response.status).toBe(200);
@@ -146,7 +144,7 @@ describe('IDP Configuration API Routes', () => {
         }
       );
 
-      const response = await PUT(request, mockParams);
+      const response = await PUT(request);
       const data = await response.json();
 
       expect(response.status).toBe(200);
@@ -157,7 +155,7 @@ describe('IDP Configuration API Routes', () => {
       const getRequest = new NextRequest(
         new URL(`http://localhost/api/organizations/${mockOrgId}/sso/oidc/config`)
       );
-      const getResponse = await GET(getRequest, mockParams);
+      const getResponse = await GET(getRequest);
       const getdata = await getResponse.json();
 
       expect(getdata).toEqual(validOidcConfig);
@@ -182,7 +180,7 @@ describe('IDP Configuration API Routes', () => {
         }
       );
 
-      const response = await PUT(request, mockParams);
+      const response = await PUT(request);
       const data = await response.json();
 
       expect(response.status).toBe(400);
@@ -192,12 +190,11 @@ describe('IDP Configuration API Routes', () => {
   });
 
   it('returns 404 for invalid IDP type', async () => {
-    const mockParams = { params: { orgId: mockOrgId, idpType: 'invalid' } };
     const request = new NextRequest(
       new URL(`http://localhost/api/organizations/${mockOrgId}/sso/invalid/config`)
     );
 
-    const response = await GET(request, mockParams);
+    const response = await GET(request);
     const data = await response.json();
 
     expect(response.status).toBe(404);


### PR DESCRIPTION
## Summary
- use `NextRequest` in company validation test
- provide `NextRequest` to health route test
- call openapi `GET` without arguments
- fix parameter objects for organization route tests
- update sso config tests to omit unused params

## Testing
- `npx tsc -p tsconfig.test.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_684c705361208331b9067cf0d8f6e887