### PR TITLE
Fix test params for org routes

### DIFF
--- a/app/api/organizations/[orgId]/__tests__/route.test.ts
+++ b/app/api/organizations/[orgId]/__tests__/route.test.ts
@@ -27,7 +27,9 @@ describe('[orgId] API', () => {
   });
 
   it('GET returns organization', async () => {
-    const res = await GET(createAuthenticatedRequest('GET', 'http://test'), { params: { orgId: 'o1' } });
+    const res = await GET(createAuthenticatedRequest('GET', 'http://test'), {
+      params: Promise.resolve({ orgId: 'o1' })
+    } as { params: Promise<{ orgId: string }> });
     expect(res.status).toBe(200);
     expect(service.getOrganization).toHaveBeenCalledWith('o1');
   });
@@ -35,13 +37,17 @@ describe('[orgId] API', () => {
   it('PUT updates organization', async () => {
     const req = createAuthenticatedRequest('PUT', 'http://test', { name: 'New' });
     (req as any).json = async () => ({ name: 'New' });
-    const res = await PUT(req, { params: { orgId: 'o1' } });
+    const res = await PUT(req, {
+      params: Promise.resolve({ orgId: 'o1' })
+    } as { params: Promise<{ orgId: string }> });
     expect(res.status).toBe(200);
     expect(service.updateOrganization).toHaveBeenCalled();
   });
 
   it('DELETE removes organization', async () => {
-    const res = await DELETE(createAuthenticatedRequest('DELETE', 'http://test'), { params: { orgId: 'o1' } });
+    const res = await DELETE(createAuthenticatedRequest('DELETE', 'http://test'), {
+      params: Promise.resolve({ orgId: 'o1' })
+    } as { params: Promise<{ orgId: string }> });
     expect(res.status).toBe(200);
     expect(service.deleteOrganization).toHaveBeenCalledWith('o1');
   });

--- a/app/api/organizations/[orgId]/members/__tests__/route.test.ts
+++ b/app/api/organizations/[orgId]/members/__tests__/route.test.ts
@@ -26,7 +26,9 @@ describe('organization members API', () => {
   });
 
   it('GET returns members', async () => {
-    const res = await GET(createAuthenticatedRequest('GET', 'http://test'), { params: { orgId: 'o1' } });
+    const res = await GET(createAuthenticatedRequest('GET', 'http://test'), {
+      params: Promise.resolve({ orgId: 'o1' })
+    } as { params: Promise<{ orgId: string }> });
     expect(res.status).toBe(200);
     expect(service.getOrganizationMembers).toHaveBeenCalledWith('o1');
   });
@@ -34,7 +36,9 @@ describe('organization members API', () => {
   it('POST adds member', async () => {
     const req = createAuthenticatedRequest('POST', 'http://test', { userId: 'u1', role: 'member' });
     (req as any).json = async () => ({ userId: 'u1', role: 'member' });
-    const res = await POST(req, { params: { orgId: 'o1' } });
+    const res = await POST(req, {
+      params: Promise.resolve({ orgId: 'o1' })
+    } as { params: Promise<{ orgId: string }> });
     expect(res.status).toBe(201);
     expect(service.addOrganizationMember).toHaveBeenCalledWith('o1', 'u1', 'member');
   });

--- a/app/api/organizations/[orgId]/sso/[idpType]/config/__tests__/route.test.ts
+++ b/app/api/organizations/[orgId]/sso/[idpType]/config/__tests__/route.test.ts
@@ -29,7 +29,9 @@ describe('IDP Configuration API Routes', () => {
   });
 
   describe('SAML Configuration', () => {
-    const mockParams = { params: { orgId: mockOrgId, idpType: 'saml' } };
+    const mockParams = {
+      params: Promise.resolve({ orgId: mockOrgId, idpType: 'saml' })
+    } as { params: Promise<{ orgId: string; idpType: string }> };
     const validSamlConfig = {
       entityId: 'https://test-idp.com/metadata',
       ssoUrl: 'https://test-idp.com/sso',
@@ -106,7 +108,9 @@ describe('IDP Configuration API Routes', () => {
   });
 
   describe('OIDC Configuration', () => {
-    const mockParams = { params: { orgId: mockOrgId, idpType: 'oidc' } };
+    const mockParams = {
+      params: Promise.resolve({ orgId: mockOrgId, idpType: 'oidc' })
+    } as { params: Promise<{ orgId: string; idpType: string }> };
     const validOidcConfig = {
       clientId: 'test-client-id',
       clientSecret: 'test-client-secret',
@@ -192,7 +196,9 @@ describe('IDP Configuration API Routes', () => {
   });
 
   it('returns 404 for invalid IDP type', async () => {
-    const mockParams = { params: { orgId: mockOrgId, idpType: 'invalid' } };
+    const mockParams = {
+      params: Promise.resolve({ orgId: mockOrgId, idpType: 'invalid' })
+    } as { params: Promise<{ orgId: string; idpType: string }> };
     const request = new NextRequest(
       new URL(`http://localhost/api/organizations/${mockOrgId}/sso/invalid/config`)
     );

--- a/app/api/organizations/[orgId]/sso/__tests__/route.test.ts
+++ b/app/api/organizations/[orgId]/sso/__tests__/route.test.ts
@@ -7,7 +7,9 @@ vi.mock('@/services/sso/factory', () => ({ getApiSsoService: vi.fn() }));
 
 describe('SSO API Routes', () => {
   const mockOrgId = 'test-org-123';
-  const mockParams = { params: { orgId: mockOrgId } };
+  const mockParams = { params: Promise.resolve({ orgId: mockOrgId }) } as {
+    params: Promise<{ orgId: string }>;
+  };
   const store: any[] = [];
   const mockService = {
     getProviders: vi.fn(async (orgId: string) => store.filter(p => p.organizationId === orgId)),

--- a/app/api/organizations/[orgId]/sso/domains/__tests__/route.test.ts
+++ b/app/api/organizations/[orgId]/sso/domains/__tests__/route.test.ts
@@ -4,7 +4,9 @@ import { GET, POST, DELETE } from '@app/api/organizations/[orgId]/sso/domains/ro
 
 describe('Domain Verification API Routes', () => {
   const mockOrgId = 'test-org-123';
-  const mockParams = { params: { orgId: mockOrgId } };
+  const mockParams = { params: Promise.resolve({ orgId: mockOrgId }) } as {
+    params: Promise<{ orgId: string }>;
+  };
   
   beforeEach(() => {
     vi.resetModules();


### PR DESCRIPTION
## Summary
- update organization API tests to pass params as promises

## Testing
- `npx tsc -p tsconfig.test.json --noEmit` *(fails: Property 'message' does not exist on type 'void')*

------
https://chatgpt.com/codex/tasks/task_b_684c7060c49883319346a8e425b53452