### PR TITLE
Fix async param usage in SSO tests

### DIFF
--- a/app/api/organizations/[orgId]/__tests__/route.test.ts
+++ b/app/api/organizations/[orgId]/__tests__/route.test.ts
@@ -27,7 +27,7 @@ describe('[orgId] API', () => {
   });
 
   it('GET returns organization', async () => {
-    const res = await GET(createAuthenticatedRequest('GET', 'http://test'), { params: { orgId: 'o1' } });
+    const res = await GET(createAuthenticatedRequest('GET', 'http://test'), { params: Promise.resolve({ orgId: 'o1' }) });
     expect(res.status).toBe(200);
     expect(service.getOrganization).toHaveBeenCalledWith('o1');
   });
@@ -35,13 +35,13 @@ describe('[orgId] API', () => {
   it('PUT updates organization', async () => {
     const req = createAuthenticatedRequest('PUT', 'http://test', { name: 'New' });
     (req as any).json = async () => ({ name: 'New' });
-    const res = await PUT(req, { params: { orgId: 'o1' } });
+    const res = await PUT(req, { params: Promise.resolve({ orgId: 'o1' }) });
     expect(res.status).toBe(200);
     expect(service.updateOrganization).toHaveBeenCalled();
   });
 
   it('DELETE removes organization', async () => {
-    const res = await DELETE(createAuthenticatedRequest('DELETE', 'http://test'), { params: { orgId: 'o1' } });
+    const res = await DELETE(createAuthenticatedRequest('DELETE', 'http://test'), { params: Promise.resolve({ orgId: 'o1' }) });
     expect(res.status).toBe(200);
     expect(service.deleteOrganization).toHaveBeenCalledWith('o1');
   });

--- a/app/api/organizations/[orgId]/members/__tests__/route.test.ts
+++ b/app/api/organizations/[orgId]/members/__tests__/route.test.ts
@@ -26,7 +26,7 @@ describe('organization members API', () => {
   });
 
   it('GET returns members', async () => {
-    const res = await GET(createAuthenticatedRequest('GET', 'http://test'), { params: { orgId: 'o1' } });
+    const res = await GET(createAuthenticatedRequest('GET', 'http://test'), { params: Promise.resolve({ orgId: 'o1' }) });
     expect(res.status).toBe(200);
     expect(service.getOrganizationMembers).toHaveBeenCalledWith('o1');
   });
@@ -34,7 +34,7 @@ describe('organization members API', () => {
   it('POST adds member', async () => {
     const req = createAuthenticatedRequest('POST', 'http://test', { userId: 'u1', role: 'member' });
     (req as any).json = async () => ({ userId: 'u1', role: 'member' });
-    const res = await POST(req, { params: { orgId: 'o1' } });
+    const res = await POST(req, { params: Promise.resolve({ orgId: 'o1' }) });
     expect(res.status).toBe(201);
     expect(service.addOrganizationMember).toHaveBeenCalledWith('o1', 'u1', 'member');
   });

--- a/app/api/organizations/[orgId]/sso/[idpType]/config/__tests__/route.test.ts
+++ b/app/api/organizations/[orgId]/sso/[idpType]/config/__tests__/route.test.ts
@@ -29,7 +29,7 @@ describe('IDP Configuration API Routes', () => {
   });
 
   describe('SAML Configuration', () => {
-    const mockParams = { params: { orgId: mockOrgId, idpType: 'saml' } };
+    const mockParams = { params: Promise.resolve({ orgId: mockOrgId, idpType: 'saml' }) };
     const validSamlConfig = {
       entityId: 'https://test-idp.com/metadata',
       ssoUrl: 'https://test-idp.com/sso',
@@ -106,7 +106,7 @@ describe('IDP Configuration API Routes', () => {
   });
 
   describe('OIDC Configuration', () => {
-    const mockParams = { params: { orgId: mockOrgId, idpType: 'oidc' } };
+    const mockParams = { params: Promise.resolve({ orgId: mockOrgId, idpType: 'oidc' }) };
     const validOidcConfig = {
       clientId: 'test-client-id',
       clientSecret: 'test-client-secret',
@@ -192,7 +192,7 @@ describe('IDP Configuration API Routes', () => {
   });
 
   it('returns 404 for invalid IDP type', async () => {
-    const mockParams = { params: { orgId: mockOrgId, idpType: 'invalid' } };
+    const mockParams = { params: Promise.resolve({ orgId: mockOrgId, idpType: 'invalid' }) };
     const request = new NextRequest(
       new URL(`http://localhost/api/organizations/${mockOrgId}/sso/invalid/config`)
     );

--- a/app/api/organizations/[orgId]/sso/__tests__/route.test.ts
+++ b/app/api/organizations/[orgId]/sso/__tests__/route.test.ts
@@ -7,7 +7,7 @@ vi.mock('@/services/sso/factory', () => ({ getApiSsoService: vi.fn() }));
 
 describe('SSO API Routes', () => {
   const mockOrgId = 'test-org-123';
-  const mockParams = { params: { orgId: mockOrgId } };
+  const mockParams = { params: Promise.resolve({ orgId: mockOrgId }) };
   const store: any[] = [];
   const mockService = {
     getProviders: vi.fn(async (orgId: string) => store.filter(p => p.organizationId === orgId)),

--- a/app/api/organizations/[orgId]/sso/domains/__tests__/route.test.ts
+++ b/app/api/organizations/[orgId]/sso/domains/__tests__/route.test.ts
@@ -4,7 +4,7 @@ import { GET, POST, DELETE } from '@app/api/organizations/[orgId]/sso/domains/ro
 
 describe('Domain Verification API Routes', () => {
   const mockOrgId = 'test-org-123';
-  const mockParams = { params: { orgId: mockOrgId } };
+  const mockParams = { params: Promise.resolve({ orgId: mockOrgId }) };
   
   beforeEach(() => {
     vi.resetModules();


### PR DESCRIPTION
## Summary
- update API route tests to use asynchronous `params` context

## Testing
- `npm run test:coverage` *(fails: "Element type is invalid" etc.)*
- `npx tsc -p tsconfig.test.json --noEmit` *(fails: several TS errors)*

------
https://chatgpt.com/codex/tasks/task_b_684c706eb5388331843cb6817b8289ef