### PR TITLE
Fix domain API route test invocation

### DIFF
--- a/app/api/organizations/[orgId]/sso/domains/__tests__/route.test.ts
+++ b/app/api/organizations/[orgId]/sso/domains/__tests__/route.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { NextRequest } from 'next/server';
 import { GET, POST, DELETE } from '@app/api/organizations/[orgId]/sso/domains/route';
+import { callRouteWithParams } from 'tests/utils/callRoute';
 
 describe('Domain Verification API Routes', () => {
   const mockOrgId = 'test-org-123';
-  const mockParams = { params: { orgId: mockOrgId } };
   
   beforeEach(() => {
     vi.resetModules();
@@ -12,11 +11,11 @@ describe('Domain Verification API Routes', () => {
 
   describe('GET /domains', () => {
     it('returns empty domains list for new organization', async () => {
-      const request = new NextRequest(
-        new URL(`http://localhost/api/organizations/${mockOrgId}/sso/domains`)
+      const response = await callRouteWithParams(
+        GET,
+        { orgId: mockOrgId },
+        `http://localhost/api/organizations/${mockOrgId}/sso/domains`
       );
-
-      const response = await GET(request, mockParams);
       const data = await response.json();
 
       expect(response.status).toBe(200);
@@ -28,21 +27,19 @@ describe('Domain Verification API Routes', () => {
 
     it('returns list of configured domains', async () => {
       // First add a domain
-      const addRequest = new NextRequest(
-        new URL(`http://localhost/api/organizations/${mockOrgId}/sso/domains`),
-        {
-          method: 'POST',
-          body: JSON.stringify({ domain: 'example.com' }),
-        }
+      await callRouteWithParams(
+        POST,
+        { orgId: mockOrgId },
+        `http://localhost/api/organizations/${mockOrgId}/sso/domains`,
+        { method: 'POST', body: { domain: 'example.com' } }
       );
-      await POST(addRequest, mockParams);
 
       // Then get the list
-      const request = new NextRequest(
-        new URL(`http://localhost/api/organizations/${mockOrgId}/sso/domains`)
+      const response = await callRouteWithParams(
+        GET,
+        { orgId: mockOrgId },
+        `http://localhost/api/organizations/${mockOrgId}/sso/domains`
       );
-
-      const response = await GET(request, mockParams);
       const data = await response.json();
 
       expect(response.status).toBe(200);
@@ -58,15 +55,12 @@ describe('Domain Verification API Routes', () => {
 
   describe('POST /domains', () => {
     it('adds a new domain successfully', async () => {
-      const request = new NextRequest(
-        new URL(`http://localhost/api/organizations/${mockOrgId}/sso/domains`),
-        {
-          method: 'POST',
-          body: JSON.stringify({ domain: 'test.com' }),
-        }
+      const response = await callRouteWithParams(
+        POST,
+        { orgId: mockOrgId },
+        `http://localhost/api/organizations/${mockOrgId}/sso/domains`,
+        { method: 'POST', body: { domain: 'test.com' } }
       );
-
-      const response = await POST(request, mockParams);
       const data = await response.json();
 
       expect(response.status).toBe(200);
@@ -79,15 +73,12 @@ describe('Domain Verification API Routes', () => {
     });
 
     it('validates domain format', async () => {
-      const request = new NextRequest(
-        new URL(`http://localhost/api/organizations/${mockOrgId}/sso/domains`),
-        {
-          method: 'POST',
-          body: JSON.stringify({ domain: 'invalid-domain' }),
-        }
+      const response = await callRouteWithParams(
+        POST,
+        { orgId: mockOrgId },
+        `http://localhost/api/organizations/${mockOrgId}/sso/domains`,
+        { method: 'POST', body: { domain: 'invalid-domain' } }
       );
-
-      const response = await POST(request, mockParams);
       const data = await response.json();
 
       expect(response.status).toBe(400);
@@ -96,25 +87,20 @@ describe('Domain Verification API Routes', () => {
 
     it('prevents duplicate domains', async () => {
       // Add domain first time
-      const firstRequest = new NextRequest(
-        new URL(`http://localhost/api/organizations/${mockOrgId}/sso/domains`),
-        {
-          method: 'POST',
-          body: JSON.stringify({ domain: 'duplicate.com' }),
-        }
+      await callRouteWithParams(
+        POST,
+        { orgId: mockOrgId },
+        `http://localhost/api/organizations/${mockOrgId}/sso/domains`,
+        { method: 'POST', body: { domain: 'duplicate.com' } }
       );
-      await POST(firstRequest, mockParams);
 
       // Try to add same domain again
-      const secondRequest = new NextRequest(
-        new URL(`http://localhost/api/organizations/${mockOrgId}/sso/domains`),
-        {
-          method: 'POST',
-          body: JSON.stringify({ domain: 'duplicate.com' }),
-        }
+      const response = await callRouteWithParams(
+        POST,
+        { orgId: mockOrgId },
+        `http://localhost/api/organizations/${mockOrgId}/sso/domains`,
+        { method: 'POST', body: { domain: 'duplicate.com' } }
       );
-
-      const response = await POST(secondRequest, mockParams);
       const data = await response.json();
 
       expect(response.status).toBe(400);
@@ -125,47 +111,40 @@ describe('Domain Verification API Routes', () => {
   describe('DELETE /domains', () => {
     it('removes a domain successfully', async () => {
       // First add a domain
-      const addRequest = new NextRequest(
-        new URL(`http://localhost/api/organizations/${mockOrgId}/sso/domains`),
-        {
-          method: 'POST',
-          body: JSON.stringify({ domain: 'todelete.com' }),
-        }
+      await callRouteWithParams(
+        POST,
+        { orgId: mockOrgId },
+        `http://localhost/api/organizations/${mockOrgId}/sso/domains`,
+        { method: 'POST', body: { domain: 'todelete.com' } }
       );
-      await POST(addRequest, mockParams);
 
       // Then delete it
-      const deleteRequest = new NextRequest(
-        new URL(`http://localhost/api/organizations/${mockOrgId}/sso/domains`),
-        {
-          method: 'DELETE',
-          body: JSON.stringify({ domain: 'todelete.com' }),
-        }
+      const response = await callRouteWithParams(
+        DELETE,
+        { orgId: mockOrgId },
+        `http://localhost/api/organizations/${mockOrgId}/sso/domains`,
+        { method: 'DELETE', body: { domain: 'todelete.com' } }
       );
-
-      const response = await DELETE(deleteRequest, mockParams);
       expect(response.status).toBe(200);
 
       // Verify domain was removed
-      const getRequest = new NextRequest(
-        new URL(`http://localhost/api/organizations/${mockOrgId}/sso/domains`)
+      const getResponse = await callRouteWithParams(
+        GET,
+        { orgId: mockOrgId },
+        `http://localhost/api/organizations/${mockOrgId}/sso/domains`
       );
-      const getResponse = await GET(getRequest, mockParams);
       const data = await getResponse.json();
 
       expect(data.domains).toHaveLength(0);
     });
 
     it('returns 404 for non-existent domain', async () => {
-      const request = new NextRequest(
-        new URL(`http://localhost/api/organizations/${mockOrgId}/sso/domains`),
-        {
-          method: 'DELETE',
-          body: JSON.stringify({ domain: 'nonexistent.com' }),
-        }
+      const response = await callRouteWithParams(
+        DELETE,
+        { orgId: mockOrgId },
+        `http://localhost/api/organizations/${mockOrgId}/sso/domains`,
+        { method: 'DELETE', body: { domain: 'nonexistent.com' } }
       );
-
-      const response = await DELETE(request, mockParams);
       const data = await response.json();
 
       expect(response.status).toBe(404);


### PR DESCRIPTION
## Summary
- use `callRouteWithParams` helper for domain route tests

## Testing
- `npx tsc -p tsconfig.test.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c708b33c88331b7bae3cdad8949d5