### PR TITLE
Fix test typing errors

### DIFF
--- a/app/api/organizations/[orgId]/sso/domains/__tests__/route.test.ts
+++ b/app/api/organizations/[orgId]/sso/domains/__tests__/route.test.ts
@@ -4,7 +4,7 @@ import { GET, POST, DELETE } from '@app/api/organizations/[orgId]/sso/domains/ro
 
 describe('Domain Verification API Routes', () => {
   const mockOrgId = 'test-org-123';
-  const mockParams = { params: { orgId: mockOrgId } };
+  const mockParams = { params: Promise.resolve({ orgId: mockOrgId }) };
   
   beforeEach(() => {
     vi.resetModules();

--- a/app/api/permissions/__tests__/route.test.ts
+++ b/app/api/permissions/__tests__/route.test.ts
@@ -16,7 +16,9 @@ beforeEach(() => {
 
 describe('permissions root API', () => {
   it('GET returns permissions', async () => {
-    mockPermissionService.getAllPermissions!.mockResolvedValue(['READ']);
+    vi.mocked(mockPermissionService.getAllPermissions!).mockResolvedValue([
+      'READ',
+    ]);
     const res = await GET(createAuthenticatedRequest('GET', 'http://test'));
     expect(res.status).toBe(200);
     const body = await res.json();

--- a/app/api/profile/__tests__/route.test.ts
+++ b/app/api/profile/__tests__/route.test.ts
@@ -102,7 +102,9 @@ describe('/api/profile', () => {
         email: 'jane@example.com',
       } as any);
       
-      vi.mocked(mockUserService.updateUserProfile).mockResolvedValue(mockResult as any);
+      vi.mocked(mockUserService.updateUserProfile!).mockResolvedValue(
+        mockResult as any,
+      );
 
       const request = new NextRequest('http://localhost:3000/api/profile', {
         method: 'PATCH',
@@ -117,7 +119,10 @@ describe('/api/profile', () => {
       const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(mockUserService.updateUserProfile).toHaveBeenCalledWith('123', updateData);
+      expect(mockUserService.updateUserProfile!).toHaveBeenCalledWith(
+        '123',
+        updateData,
+      );
       expect(data.success).toBe(true);
       expect(data.data).toEqual(mockResult.profile);
     });
@@ -145,7 +150,7 @@ describe('/api/profile', () => {
       const response = await PATCH(request);
       
       expect(response.status).toBe(400);
-      expect(mockUserService.updateUserProfile).not.toHaveBeenCalled();
+      expect(mockUserService.updateUserProfile!).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/api/resources/[type]/[id]/permissions/__tests__/route.test.ts
+++ b/app/api/resources/[type]/[id]/permissions/__tests__/route.test.ts
@@ -25,7 +25,7 @@ beforeEach(() => {
 
 describe('resource permissions list API', () => {
   it('returns paginated permissions', async () => {
-    mockService.getPermissionsForResource.mockResolvedValue([
+    vi.mocked(mockService.getPermissionsForResource!).mockResolvedValue([
       { id: '1', userId: 'u1', permission: 'VIEW_PROJECTS', resourceType: 'project', resourceId: 'p1', createdAt: new Date() },
       { id: '2', userId: 'u2', permission: 'VIEW_PROJECTS', resourceType: 'project', resourceId: 'p1', createdAt: new Date() },
     ]);
@@ -34,6 +34,9 @@ describe('resource permissions list API', () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.data.length).toBe(2);
-    expect(mockService.getPermissionsForResource).toHaveBeenCalledWith('project', 'p1');
+    expect(mockService.getPermissionsForResource!).toHaveBeenCalledWith(
+      'project',
+      'p1',
+    );
   });
 });

--- a/app/api/resources/relationships/route.ts
+++ b/app/api/resources/relationships/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { getApiResourceRelationshipService } from "@/services/resource-relationship/factory";
 import {
@@ -23,7 +23,7 @@ const middleware = createMiddlewareChain([
   validationMiddleware(relationshipSchema),
 ]);
 
-async function handleGet(req: NextRequest) {
+async function handleGet(req: NextRequest): Promise<NextResponse> {
   const url = new URL(req.url);
   const parentType = url.searchParams.get("parentType");
   const parentId = url.searchParams.get("parentId");
@@ -31,7 +31,7 @@ async function handleGet(req: NextRequest) {
   const childId = url.searchParams.get("childId");
 
   if (!((parentType && parentId) || (childType && childId))) {
-    return Response.json(
+    return NextResponse.json(
       { error: "Must provide either parent or child resource identifiers" },
       { status: 400 },
     );

--- a/app/api/roles/[roleId]/__tests__/route.test.ts
+++ b/app/api/roles/[roleId]/__tests__/route.test.ts
@@ -25,31 +25,31 @@ beforeEach(() => {
 
 describe('roles id API', () => {
   it('GET returns role', async () => {
-    mockService.getRoleById.mockResolvedValue({ id: '1' });
+    vi.mocked(mockService.getRoleById!).mockResolvedValue({ id: '1' });
     const res = await GET(createAuthenticatedRequest('GET', 'http://test/api/roles/1'));
     expect(res.status).toBe(200);
   });
 
   it('PATCH updates role', async () => {
     const req = createAuthenticatedRequest('PATCH', 'http://test/api/roles/1', { name: 'n' });
-    mockService.updateRole.mockResolvedValue({ id: '1' });
+    vi.mocked(mockService.updateRole!).mockResolvedValue({ id: '1' });
     const res = await PATCH(req as any);
     expect(res.status).toBe(200);
-    expect(mockService.updateRole).toHaveBeenCalledWith('1', { name: 'n' }, 'u1');
+    expect(mockService.updateRole!).toHaveBeenCalledWith('1', { name: 'n' }, 'u1');
   });
 
   it('PUT updates role', async () => {
     const req = createAuthenticatedRequest('PUT', 'http://test/api/roles/1', { name: 'n' });
-    mockService.updateRole.mockResolvedValue({ id: '1' });
+    vi.mocked(mockService.updateRole!).mockResolvedValue({ id: '1' });
     const res = await PUT(req as any);
     expect(res.status).toBe(200);
-    expect(mockService.updateRole).toHaveBeenCalledWith('1', { name: 'n' }, 'u1');
+    expect(mockService.updateRole!).toHaveBeenCalledWith('1', { name: 'n' }, 'u1');
   });
 
   it('DELETE removes role', async () => {
-    mockService.deleteRole.mockResolvedValue(true);
+    vi.mocked(mockService.deleteRole!).mockResolvedValue(true);
     const res = await DELETE(createAuthenticatedRequest('DELETE', 'http://test/api/roles/1'));
     expect(res.status).toBe(204);
-    expect(mockService.deleteRole).toHaveBeenCalledWith('1', 'u1');
+    expect(mockService.deleteRole!).toHaveBeenCalledWith('1', 'u1');
   });
 });

--- a/src/core/user/models.ts
+++ b/src/core/user/models.ts
@@ -36,6 +36,36 @@ export interface UserProfile {
    * User's last name (optional)
    */
   lastName?: string;
+
+  /**
+   * Public display name (optional)
+   */
+  displayName?: string;
+
+  /**
+   * Short biography (optional)
+   */
+  bio?: string | null;
+
+  /**
+   * User location (optional)
+   */
+  location?: string | null;
+
+  /**
+   * Personal website URL (optional)
+   */
+  website?: string | null;
+
+  /**
+   * Contact phone number (optional)
+   */
+  phoneNumber?: string | null;
+
+  /**
+   * URL to the user's avatar image (optional)
+   */
+  avatarUrl?: string | null;
   
   /**
    * User's full name (optional, may be generated from first and last name)


### PR DESCRIPTION
## Summary
- fix parameter type in domain SSO route tests
- ensure permission and role service mocks typed correctly
- guard optional user profile service calls in tests
- update resource permission test mocks
- switch resource relationship GET to return NextResponse
- expand `ProfileUpdatePayload` with missing user fields

## Testing
- `npx tsc --noEmit` *(fails: other unrelated type errors)*

------
https://chatgpt.com/codex/tasks/task_b_684c70a14a6c83319a41c94f5399673d