### PR TITLE
Fix connected accounts store typings

### DIFF
--- a/src/lib/stores/connectedAccounts.store.ts
+++ b/src/lib/stores/connectedAccounts.store.ts
@@ -1,9 +1,9 @@
 import { create } from 'zustand';
 import { api } from '@/lib/api/axios';
-import { ConnectedAccountsState } from '@/types/connectedAccounts';
+import { ConnectedAccountsState, ConnectedAccount } from '@/types/connectedAccounts';
 import { OAuthProvider } from '@/types/oauth';
 
-export const useConnectedAccountsStore = create<ConnectedAccountsState>((set: (fn: (state: ConnectedAccountsState) => Partial<ConnectedAccountsState> | ConnectedAccountsState) => void) => ({
+export const useConnectedAccountsStore = create<ConnectedAccountsState>((set) => ({
   accounts: [],
   isLoading: false,
   error: null,


### PR DESCRIPTION
## Summary
- correct set function typing in connected accounts store
- import `ConnectedAccount` for local filtering

## Testing
- `npx vitest run --coverage` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_684c7f7462f88331bea8c57c7b6802a0