### PR TITLE
Fix type errors in state stores

### DIFF
--- a/src/lib/stores/preferences.store.ts
+++ b/src/lib/stores/preferences.store.ts
@@ -94,7 +94,6 @@ export const usePreferencesStore: (() => PreferencesState) & {
   getState: () => PreferencesState;
   setState: typeof preferencesStoreBase.setState;
   subscribe: typeof preferencesStoreBase.subscribe;
-  destroy: typeof preferencesStoreBase.destroy;
 } = Object.assign(createUsePreferencesStore, {
   getState: () => {
     const state = preferencesStoreBase.getState();
@@ -107,5 +106,4 @@ export const usePreferencesStore: (() => PreferencesState) & {
   },
   setState: preferencesStoreBase.setState,
   subscribe: preferencesStoreBase.subscribe,
-  destroy: preferencesStoreBase.destroy,
 });

--- a/src/lib/stores/rbac.store.ts
+++ b/src/lib/stores/rbac.store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { api } from '@/lib/api/axios';
-import { RBACState, Role, Permission } from '@/types/rbac';
+import type { RBACState, Role, Permission } from '@/types/rbac';
 import { useAuth } from '@/lib/hooks/useAuth';
 
 type RBACInternalState = Omit<RBACState, 'hasPermission' | 'hasRole'> & {

--- a/src/services/user/__tests__/mocks/preferences.store.mock.ts
+++ b/src/services/user/__tests__/mocks/preferences.store.mock.ts
@@ -47,7 +47,6 @@ export function createMockPreferencesStore(
   usePreferencesStore.getState = store.getState;
   usePreferencesStore.setState = store.setState;
   usePreferencesStore.subscribe = vi.fn(); // no-op
-  usePreferencesStore.destroy = vi.fn(); // no-op
 
   return usePreferencesStore;
 } 

--- a/src/tests/mocks/preferences.store.mock.ts
+++ b/src/tests/mocks/preferences.store.mock.ts
@@ -47,7 +47,6 @@ export function createMockPreferencesStore(
   usePreferencesStore.getState = store.getState;
   usePreferencesStore.setState = store.setState;
   usePreferencesStore.subscribe = vi.fn(); // no-op
-  usePreferencesStore.destroy = vi.fn(); // no-op
 
   return usePreferencesStore;
 } 

--- a/src/types/rbac.ts
+++ b/src/types/rbac.ts
@@ -4,10 +4,8 @@ import {
   PermissionSchema,
   RoleValues,
   RoleSchema,
-  type Permission,
-  type Role,
-  type UserRole,
 } from '@/core/permission/models';
+import type { Permission, Role, UserRole } from '@/core/permission/models';
 
 export {
   PermissionValues,
@@ -15,7 +13,7 @@ export {
   RoleValues,
   RoleSchema,
 } from '@/core/permission/models';
-export type { Permission, Role, UserRole } from '@/core/permission/models';
+export type { Permission, Role, UserRole };
 
 // User role assignment schema
 export const userRoleSchema = z.object({


### PR DESCRIPTION
## Summary
- remove obsolete `destroy` usage from preferences store
- update rbac types exports and imports
- adjust store mocks

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: ts-errors.tsx intentionally contains errors)*

------
https://chatgpt.com/codex/tasks/task_b_684c7fbabe048331ab458328283074c1