### PR TITLE
Fix admin search result typing

### DIFF
--- a/src/services/admin/__tests__/defaultAdmin.service.test.ts
+++ b/src/services/admin/__tests__/defaultAdmin.service.test.ts
@@ -21,7 +21,17 @@ describe('DefaultAdminService.exportUsers', () => {
     const users = [
       { id: '1', firstName: 'A', lastName: 'B', email: 'a@b.com', status: 'active', role: 'user', createdAt: '2020-01-01T00:00:00Z', lastLoginAt: null },
     ];
-    provider.searchUsers = vi.fn().mockResolvedValue({ users, pagination: { page: 1, limit: 1, totalCount: 1, totalPages: 1 } });
+    provider.searchUsers = vi.fn().mockResolvedValue({
+      users,
+      pagination: {
+        page: 1,
+        pageSize: 1,
+        totalItems: 1,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      },
+    });
     const result = await service.exportUsers({}, 'csv');
     expect(result.filename).toMatch(/\.csv$/);
     expect(result.data).toContain('ID');
@@ -31,7 +41,17 @@ describe('DefaultAdminService.exportUsers', () => {
     const users = [
       { id: '1', firstName: 'A', lastName: 'B', email: 'a@b.com', status: 'active', role: 'user', createdAt: '2020-01-01T00:00:00Z', lastLoginAt: null },
     ];
-    provider.searchUsers = vi.fn().mockResolvedValue({ users, pagination: { page: 1, limit: 1, totalCount: 1, totalPages: 1 } });
+    provider.searchUsers = vi.fn().mockResolvedValue({
+      users,
+      pagination: {
+        page: 1,
+        pageSize: 1,
+        totalItems: 1,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      },
+    });
     const result = await service.exportUsers({}, 'json');
     expect(result.filename).toMatch(/\.json$/);
     expect(result.data).toContain('"id": "1"');

--- a/src/services/admin/defaultAdmin.service.ts
+++ b/src/services/admin/defaultAdmin.service.ts
@@ -4,15 +4,12 @@ import type { IAdminDataProvider } from '@/core/admin/IAdminDataProvider';
 import { objectsToCSV } from '@/utils/export/csvExport';
 import { formatJSONForExport } from '@/utils/export/jsonExport';
 import { SearchCache } from '@/utils/cache/searchCache';
+import type { PaginationMeta } from '@/lib/api/common/responseFormatter';
+import type { UserProfile } from '@/core/user/models';
 
 interface SearchResult {
-  users: any[];
-  pagination: {
-    page: number;
-    limit: number;
-    totalCount: number;
-    totalPages: number;
-  };
+  users: UserProfile[];
+  pagination: PaginationMeta;
 }
 
 export class DefaultAdminService implements AdminService {
@@ -52,8 +49,8 @@ export class DefaultAdminService implements AdminService {
 
     const result = await this.provider.searchUsers(params);
 
-    this.searchCache.set(cacheKey, result as SearchResult);
-    return result as SearchResult;
+    this.searchCache.set(cacheKey, result);
+    return result;
   }
 
   async exportUsers(params: SearchUsersParams, format: 'csv' | 'json'): Promise<{ data: string; filename: string }> {


### PR DESCRIPTION
## Summary
- align DefaultAdminService with PaginationMeta
- update admin service tests to match new pagination shape

## Testing
- `npx vitest run src/services/admin/__tests__/defaultAdmin.service.test.ts --coverage`

------
https://chatgpt.com/codex/tasks/task_b_684c800e8ddc8331877322fa03171a11